### PR TITLE
Keep sitemap empty while public launch is contained

### DIFF
--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -5,6 +5,12 @@ import { buildPublicSitemapUrls, fetchAllPublishedVendorRouteRows, fetchAllTaxon
 export const dynamic = 'force-dynamic';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // While launch is intentionally contained, no unfinished public routes
+  // should be advertised to search engines.
+  if (process.env.NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED !== 'true') {
+    return [];
+  }
+
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!


### PR DESCRIPTION
The live holding page redirected unfinished public routes, but sitemap.xml still advertised directory and vendor URLs. This one-file correction returns no sitemap entries unless public launch is explicitly enabled. Verified with web lint, Cloudflare production build, and the secret scan. No data, permissions, or public routes are changed.