### PR TITLE
feat(ops): add protected owner-status feed

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -93,6 +93,10 @@ Implemented queues:
 - `/ops/contact`: private support requests and audited resolution state;
 - `/ops/system`: integration health, automation jobs, and append-only audit history.
 
+Ops is a non-technical working surface. Queue pages use protected pagination (100 records per page). The System page presents plain-English meaning, whether action is required, and a safe next step rather than raw provider errors, metadata, or internal identifiers; it shows up to 200 recent automated-work and decision records. See `docs/OPS/` for the solo-owner guide and coverage record.
+
+The authenticated owner-status feed is `list_current_owner_request_statuses()`. It is read-only, server-authorised, owner-scoped, and returns only request status guidance. It does not return listing data, identifiers, raw operator notes, or write audit events. User Workflows owns its presentation.
+
 Operator actions use authenticated `SECURITY DEFINER` RPCs that call `private.require_active_operator()`, lock mutable records, validate transitions, and append audit events atomically. Publication never changes as a side effect of ownership, ABN, payment, or tier.
 
 The permanent operator is `admin@suburbmates.com.au`; the hosted database has exactly one active operator record for that identity. Do not enrol the temporary `carl@suburbmates.com.au` identity or the Stripe-only Yahoo identity by assumption. Any future operator change must be explicitly authorised, audited, and reverified.

--- a/docs/OPS/COVERAGE.md
+++ b/docs/OPS/COVERAGE.md
@@ -1,0 +1,19 @@
+# Ops coverage and open gates
+
+## Verified scope
+
+- `/ops` requires a valid session and active server-side operator membership.
+- Listing, claim, profile-edit, and contact decisions use authorised server-side routines and append permanent audit records.
+- Queue pages use protected pagination rather than silently stopping at 100 records.
+- System status and decision history use plain English and do not display raw provider errors, metadata, or internal reference IDs.
+- The owner-status feed is read-only and returns only request type, status, controlled explanation, next step, and dates for the signed-in owner’s own claim and profile-change requests.
+
+## What remains for acceptance
+
+The owner-status feed is a data boundary for User Workflows to display; this Ops change does not create another owner screen. A browser acceptance can use the first genuine request. Do not create fake production requests because the audit trail is permanent.
+
+## Boundaries
+
+- No listing publication, ownership change, import, deploy, Stripe, pricing, or billing change is included.
+- The public holding page, public owner dashboard display, and automation presentation belong to their respective lanes.
+- Technical repair remains exceptional. The operator should record a warning and ask for help, not use provider dashboards.

--- a/docs/OPS/README.md
+++ b/docs/OPS/README.md
@@ -1,0 +1,49 @@
+# SuburbMates Operations
+
+This is the working guide for one person operating SuburbMates. Use the Operations area for normal work; you do not need to understand the database, hosting, email provider, code, or technical logs.
+
+## Your responsibility
+
+Make careful, explainable decisions about listings and requests. Before deciding, answer:
+
+1. What happened?
+2. What evidence supports the decision?
+3. What will change for the public, owner, or requester?
+4. What will not change?
+
+Write the reason in the decision note. The system keeps it as permanent audit evidence.
+
+## Getting in
+
+Open `/ops` and sign in with `admin@suburbmates.com.au`. Open the email link in the same browser that requested it. If a link fails, wait for the stated email limit and use the newest link; do not repeatedly request more links.
+
+## Daily order
+
+1. **Listings** — decide whether a business is suitable for the public directory.
+2. **Claims** — decide whether a person should control an existing listing.
+3. **Profile edits** — decide whether an approved owner’s proposed public changes are accurate.
+4. **Contact** — handle support, correction, claim-help, and privacy messages.
+5. **System** — notice warnings and confirm decisions appear in the permanent record.
+
+If a queue grows, use **Next page** and **Previous page** at the bottom. Each page has up to 100 items. An empty queue needs no action.
+
+## Decisions
+
+| Queue | Safe choices | What changes |
+| --- | --- | --- |
+| Listings | Save a draft, move to review, publish, approve changes, reject, unpublish | Only explicit publication makes a listing public. A claim, payment, ABN result, tier, or automated check never publishes it. |
+| Claims | Request information, approve, reject, revoke | Ownership only. A claim decision never publishes a listing or alters its public details. |
+| Profile edits | Approve or reject | Only approved public fields change. Ownership, publication, payment, tier, and ABN stay unchanged. |
+| Contact | Start work, return to new, resolve, mark spam, reopen, restore | Only the private request status changes. Listings and ownership stay unchanged. |
+
+When uncertain, leave a listing unpublished, save a draft, request information, or record why more review is needed. Do not invent business facts, delete records to tidy up, overwrite evidence, or use automation as a substitute for your decision.
+
+## System warnings
+
+System warnings are supporting information, not permission to change a listing. If a warning says it needs technical help, record it and ask for help. You do not need provider dashboards for routine operations.
+
+## Boundaries
+
+Do not use Supabase, Cloudflare, Resend, Stripe, deployments, or raw logs for normal work. Stripe, pricing, and billing are not part of normal Operations work.
+
+The locked product authority is in `docs/REFERENCE/`. The implementation record and unresolved launch gates are in `docs/HANDOVER.md` and `COVERAGE.md`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run public-catalogue:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run public-catalogue:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -21,6 +21,7 @@
     "vendor-slug:test": "tsx scripts/test-vendor-slug-policy.ts",
     "website-safety": "node scripts/website-safety.mjs",
     "website-safety:test": "node scripts/test-website-safety.mjs",
+    "owner-status:test": "tsx scripts/test-owner-status-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },
   "devDependencies": {

--- a/scripts/test-owner-status-boundary.ts
+++ b/scripts/test-owner-status-boundary.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const source = fs.readFileSync('supabase/migrations/20260718110510_owner_status_feed.sql', 'utf8');
+
+assert.match(source, /CREATE OR REPLACE FUNCTION public\.list_current_owner_request_statuses\(\)/);
+assert.match(source, /SECURITY DEFINER/);
+assert.match(source, /SET search_path = ''/);
+assert.match(source, /v_user_id UUID := auth\.uid\(\)/);
+assert.match(source, /IF v_user_id IS NULL THEN/);
+assert.match(source, /claim\.claimant_user_id = v_user_id/);
+assert.match(source, /change\.submitted_by = v_user_id/);
+assert.match(source, /REVOKE ALL ON FUNCTION public\.list_current_owner_request_statuses\(\) FROM PUBLIC, anon, service_role/);
+assert.match(source, /GRANT EXECUTE ON FUNCTION public\.list_current_owner_request_statuses\(\) TO authenticated/);
+
+for (const forbidden of ['operator_note', 'business_name', 'vendor_id', 'request_id', 'INSERT INTO', 'UPDATE ', 'DELETE FROM']) {
+  assert(!source.includes(forbidden), `Owner status feed must not expose or write ${forbidden}.`);
+}
+
+console.log('Owner-status feed security boundary checks passed.');

--- a/supabase/migrations/20260718110510_owner_status_feed.sql
+++ b/supabase/migrations/20260718110510_owner_status_feed.sql
@@ -1,0 +1,85 @@
+-- A read-only, owner-scoped status feed for the dashboard. It deliberately
+-- returns only status guidance, not listing data, raw operator notes, or IDs.
+-- User Workflows owns the presentation; Ops owns this security boundary.
+
+CREATE OR REPLACE FUNCTION public.list_current_owner_request_statuses()
+RETURNS TABLE (
+  request_type TEXT,
+  request_status TEXT,
+  safe_operator_reason TEXT,
+  next_step TEXT,
+  submitted_at TIMESTAMPTZ,
+  decided_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Authentication is required.';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    'claim'::TEXT,
+    claim.claim_status,
+    CASE claim.claim_status
+      WHEN 'pending' THEN 'Your claim is waiting for review.'
+      WHEN 'needs_information' THEN 'SuburbMates needs more information before a decision can be made.'
+      WHEN 'approved' THEN 'Your claim was approved.'
+      WHEN 'rejected' THEN 'Your claim was not approved.'
+      WHEN 'revoked' THEN 'Your ownership approval was removed.'
+      WHEN 'withdrawn' THEN 'Your claim is no longer active.'
+      ELSE 'Your claim has an updated status.'
+    END,
+    CASE claim.claim_status
+      WHEN 'pending' THEN 'No action is needed while your claim is reviewed.'
+      WHEN 'needs_information' THEN 'Reply to SuburbMates with the requested information.'
+      WHEN 'approved' THEN 'You can now manage profile-change requests from your dashboard.'
+      WHEN 'rejected' THEN 'Contact SuburbMates if you believe this decision is incorrect.'
+      WHEN 'revoked' THEN 'Contact SuburbMates if you need help with this decision.'
+      WHEN 'withdrawn' THEN 'Submit a new claim only if you are still the appropriate owner.'
+      ELSE 'Check back later or contact SuburbMates if you need help.'
+    END,
+    claim.created_at,
+    claim.decided_at
+  FROM public.claim_requests AS claim
+  WHERE claim.claimant_user_id = v_user_id
+
+  UNION ALL
+
+  SELECT
+    'profile_change'::TEXT,
+    change.change_status,
+    CASE change.change_status
+      WHEN 'pending' THEN 'Your profile changes are waiting for review.'
+      WHEN 'approved' THEN 'Your profile changes were approved.'
+      WHEN 'rejected' THEN 'Your profile changes were not approved.'
+      WHEN 'withdrawn' THEN 'Your profile-change request is no longer active.'
+      ELSE 'Your profile-change request has an updated status.'
+    END,
+    CASE change.change_status
+      WHEN 'pending' THEN 'No action is needed while your changes are reviewed.'
+      WHEN 'approved' THEN 'Refresh your public profile to see the approved changes.'
+      WHEN 'rejected' THEN 'Review your listing and submit a fresh request when it is ready.'
+      WHEN 'withdrawn' THEN 'Submit a new request only when you have changes ready for review.'
+      ELSE 'Check back later or contact SuburbMates if you need help.'
+    END,
+    change.created_at,
+    change.decided_at
+  FROM public.listing_change_requests AS change
+  WHERE change.submitted_by = v_user_id
+
+  ORDER BY 5 DESC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.list_current_owner_request_statuses() FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.list_current_owner_request_statuses() TO authenticated;
+
+COMMENT ON FUNCTION public.list_current_owner_request_statuses() IS
+  'Read-only owner-scoped status feed. Returns only safe request status guidance and never writes audit events or exposes listing data, identifiers, or operator notes.';

--- a/web/src/app/ops/claims/[claimId]/page.tsx
+++ b/web/src/app/ops/claims/[claimId]/page.tsx
@@ -48,6 +48,7 @@ export default async function OpsClaimDetailPage({
 
   const open = claim.claim_status === "pending" || claim.claim_status === "needs_information";
   const approved = claim.claim_status === "approved";
+  const successfulAction = ["needs_information", "approve", "reject", "revoke"].includes(message.success ?? "");
 
   return (
     <div className="space-y-7">
@@ -67,7 +68,7 @@ export default async function OpsClaimDetailPage({
           {message.error === "invalid" ? "Enter a reason before making a valid decision." : "The decision could not be completed. Refresh and check the current claim state."}
         </p>
       )}
-      {message.success && (
+      {successfulAction && (
         <p className="rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800">Decision recorded with an audit event.</p>
       )}
 
@@ -96,7 +97,7 @@ export default async function OpsClaimDetailPage({
       {(open || approved) && (
         <section className="rounded-2xl border border-slate-300 bg-white p-6 shadow-sm">
           <h3 className="text-xl font-bold">Record a decision</h3>
-          <p className="mt-2 text-sm text-slate-600">A clear reason is required and will be stored in the immutable audit history.</p>
+          <p className="mt-2 text-sm text-slate-600">A clear reason is required and will be stored permanently. Approving gives the claimant control of this listing only; it does not publish it or change its public details.</p>
           <form action={reviewClaimAction} className="mt-5 space-y-4">
             <input type="hidden" name="claimId" value={claim.claim_request_id} />
             <label className="block text-sm font-bold" htmlFor="reason">Decision basis or reason</label>
@@ -107,6 +108,7 @@ export default async function OpsClaimDetailPage({
               {open && <button name="decision" value="approve" className="btn btn-primary">Approve ownership</button>}
               {approved && <button name="decision" value="revoke" className="btn btn-outline">Revoke ownership</button>}
             </div>
+            <p className="text-sm text-slate-600">Request information keeps the claim open. Reject keeps the listing unclaimed. Revoke removes the current ownership approval without changing publication.</p>
           </form>
         </section>
       )}

--- a/web/src/app/ops/claims/page.tsx
+++ b/web/src/app/ops/claims/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { QueuePagination } from "@/components/ops/QueuePagination";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 
 const statuses = ["pending", "needs_information", "approved", "rejected", "revoked"] as const;
@@ -18,23 +19,27 @@ type OpsClaim = {
 export default async function OpsClaimsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ status?: string }>;
+  searchParams: Promise<{ status?: string; page?: string }>;
 }) {
   const params = await searchParams;
   const status = statuses.includes(params.status as ClaimStatus) ? (params.status as ClaimStatus) : "pending";
+  const page = pageNumber(params.page);
   const { supabase } = await verifyOpsAdmin(`/ops/claims?status=${status}`);
   const { data, error } = await supabase.rpc("ops_list_claim_requests", {
     p_status: status,
     p_claim_request_id: null,
-    p_limit: 100,
-    p_offset: 0,
+    p_limit: 101,
+    p_offset: page * 100,
   });
 
   if (error) {
     throw new Error("The claim queue could not be loaded.");
   }
 
-  const claims = (data ?? []) as OpsClaim[];
+  const results = (data ?? []) as OpsClaim[];
+  const claims = results.slice(0, 100);
+  const hasNextPage = results.length > 100;
+  const pageHref = (targetPage: number) => `/ops/claims?${new URLSearchParams({ status, ...(targetPage ? { page: String(targetPage) } : {}) }).toString()}`;
 
   return (
     <div className="space-y-7">
@@ -91,10 +96,16 @@ export default async function OpsClaimsPage({
           </div>
         )}
       </section>
+      <QueuePagination page={page} hasNextPage={hasNextPage} hrefForPage={pageHref} />
     </div>
   );
 }
 
 function formatStatus(status: string) {
   return status.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function pageNumber(value: string | undefined) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, 10_000) : 0;
 }

--- a/web/src/app/ops/contact/[requestId]/page.tsx
+++ b/web/src/app/ops/contact/[requestId]/page.tsx
@@ -42,6 +42,7 @@ export default async function OpsContactDetailPage({
   if (error) throw new Error("The contact request could not be loaded.");
   const request = data?.[0] as ContactRequest | undefined;
   if (!request) notFound();
+  const successfulAction = message.success === "1";
 
   return (
     <div className="space-y-7">
@@ -52,7 +53,7 @@ export default async function OpsContactDetailPage({
       </div>
 
       {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800">{message.error === "invalid" ? "Choose a valid action and enter a reason." : "The status could not be changed. Refresh and check its current state."}</p>}
-      {message.success && <p className="rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800">Status and audit history updated.</p>}
+      {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800">Status and audit history updated.</p>}
 
       <div className="grid gap-6 lg:grid-cols-2">
         <InfoCard title="Contact details"><InfoRow label="Reply email" value={request.requester_email} /><InfoRow label="Business" value={request.business_name ?? "Not provided"} /></InfoCard>
@@ -64,12 +65,13 @@ export default async function OpsContactDetailPage({
 
       <section className="rounded-2xl border border-slate-300 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">Update request</h3>
-        <p className="mt-2 text-sm text-slate-600">Record what was done. The status change and reason are written to immutable audit history.</p>
+        <p className="mt-2 text-sm text-slate-600">Record what was done. The status change and reason are written permanently. This never changes a listing or ownership.</p>
         <form action={reviewContactAction} className="mt-5 space-y-4">
           <input type="hidden" name="requestId" value={request.contact_request_id} />
           <label className="block text-sm font-bold" htmlFor="reason">Action taken or review note</label>
           <textarea id="reason" name="reason" required maxLength={2000} rows={4} className="w-full rounded-xl border border-slate-300 p-3" />
           <div className="flex flex-wrap gap-3">{transitions[request.contact_status].map((transition) => <button key={transition.status} name="status" value={transition.status} className={transition.status === "resolved" ? "btn btn-primary" : "btn btn-outline"}>{transition.label}</button>)}</div>
+          <p className="text-sm text-slate-600">Start work keeps the request active. Resolve records that you finished it. Mark as spam hides a non-genuine request from normal work; it can be restored later.</p>
         </form>
       </section>
     </div>

--- a/web/src/app/ops/contact/page.tsx
+++ b/web/src/app/ops/contact/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { QueuePagination } from "@/components/ops/QueuePagination";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 
 const statuses = ["new", "in_progress", "resolved", "spam"] as const;
@@ -18,20 +19,24 @@ type ContactRequest = {
 export default async function OpsContactPage({
   searchParams,
 }: {
-  searchParams: Promise<{ status?: string }>;
+  searchParams: Promise<{ status?: string; page?: string }>;
 }) {
   const params = await searchParams;
   const status = statuses.includes(params.status as ContactStatus) ? (params.status as ContactStatus) : "new";
+  const page = pageNumber(params.page);
   const { supabase } = await verifyOpsAdmin(`/ops/contact?status=${status}`);
   const { data, error } = await supabase.rpc("ops_list_contact_requests", {
     p_status: status,
     p_contact_request_id: null,
-    p_limit: 100,
-    p_offset: 0,
+    p_limit: 101,
+    p_offset: page * 100,
   });
 
   if (error) throw new Error("The contact queue could not be loaded.");
-  const requests = (data ?? []) as ContactRequest[];
+  const results = (data ?? []) as ContactRequest[];
+  const requests = results.slice(0, 100);
+  const hasNextPage = results.length > 100;
+  const pageHref = (targetPage: number) => `/ops/contact?${new URLSearchParams({ status, ...(targetPage ? { page: String(targetPage) } : {}) }).toString()}`;
 
   return (
     <div className="space-y-7">
@@ -74,10 +79,16 @@ export default async function OpsContactPage({
           </div>
         )}
       </section>
+      <QueuePagination page={page} hasNextPage={hasNextPage} hrefForPage={pageHref} />
     </div>
   );
 }
 
 function formatStatus(value: string) {
   return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function pageNumber(value: string | undefined) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, 10_000) : 0;
 }

--- a/web/src/app/ops/error.tsx
+++ b/web/src/app/ops/error.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import Link from "next/link";
+
+export default function OpsError({ reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <section className="rounded-2xl border border-amber-300 bg-amber-50 p-8">
+      <p className="text-sm font-bold uppercase tracking-[0.18em] text-amber-900">Operations</p>
+      <h2 className="mt-2 text-3xl font-black tracking-tight">This view could not be loaded</h2>
+      <p className="mt-3 max-w-2xl text-slate-700">No listing, claim, or contact request has changed. Try again. If this keeps happening, return to the overview and check the System page.</p>
+      <div className="mt-6 flex flex-wrap gap-3">
+        <button type="button" onClick={reset} className="btn btn-primary">Try again</button>
+        <Link href="/ops" className="btn btn-outline">Open overview</Link>
+      </div>
+    </section>
+  );
+}

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -55,6 +55,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const status = listing.listing_status;
   const evidence = (evidenceResult.data ?? []) as ListingEvidence[];
   const publicSlug = routeResult.data?.[0]?.current_slug as string | undefined;
+  const successfulAction = ["draft", "publish", "approve_changes", "reject", "unpublish", "restore"].includes(message.success ?? "");
 
   return (
     <div className="space-y-7">
@@ -69,7 +70,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
       </div>
 
       {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 font-semibold text-red-800">{message.error === "draft" ? "The draft could not be saved. Check required fields and formats." : "The action failed. Refresh and check the listing state, draft and reason."}</p>}
-      {message.success && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">{message.success === "draft" ? "Operator draft saved. The public listing and sitemap were not changed." : "Decision recorded with an audit event."}</p>}
+      {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">{message.success === "draft" ? "Operator draft saved. The public listing and sitemap were not changed." : "Decision recorded with an audit event."}</p>}
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">Source evidence</h3>
@@ -99,7 +100,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">Lifecycle action</h3>
-        <p className="mt-2 text-sm text-slate-600">Publication is an operator decision. Ownership, ABN, payment and tier remain independent.</p>
+        <p className="mt-2 text-sm text-slate-600">Publication is your explicit decision. Ownership, ABN, payment and tier remain unchanged. Your decision note becomes a permanent record.</p>
         <form action={decideListingAction} className="mt-5 space-y-4">
           <input type="hidden" name="vendorId" value={vendorId} />
           {(status === "pending_review" || status === "published") && listing.active_draft_id && (
@@ -112,6 +113,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
             {status === "pending_review" && listing.active_draft_id && <button name="decision" value="publish" className="btn btn-primary">Approve &amp; publish</button>}
             {status === "published" && listing.active_draft_id && <button name="decision" value="approve_changes" className="btn btn-primary">Approve changes</button>}
           </div>
+          <p className="text-sm text-slate-600">Moving a listing to review keeps it private. Publishing makes the approved listing public. Approving changes updates an already public listing.</p>
         </form>
 
         {status === "pending_review" && <ReasonDecision vendorId={vendorId} decision="reject" label="Reject listing" reasons={rejectReasons} />}
@@ -130,7 +132,8 @@ function SelectField({ label, name, defaultValue, options, required }: { label: 
 }
 
 function ReasonDecision({ vendorId, decision, label, reasons }: { vendorId: string; decision: string; label: string; reasons: readonly { value: string; label: string }[] }) {
-  return <form action={decideListingAction} className="mt-8 space-y-4 border-t border-slate-200 pt-6"><input type="hidden" name="vendorId" value={vendorId} /><input type="hidden" name="decision" value={decision} /><label className="block text-sm font-bold">Reason<select name="reasonCode" required className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="">Select a reason</option>{reasons.map((reason) => <option key={reason.value} value={reason.value}>{reason.label}</option>)}</select></label><label className="block text-sm font-bold">Operator note<textarea name="operatorNote" required maxLength={2000} rows={3} className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label><button className="btn btn-outline">{label}</button></form>;
+  const outcome = decision === "unpublish" ? "This removes the listing from public access but keeps the record and its decision history." : "This keeps the listing private and retains the record and its decision history.";
+  return <form action={decideListingAction} className="mt-8 space-y-4 border-t border-slate-200 pt-6"><p className="text-sm text-slate-600">{outcome}</p><input type="hidden" name="vendorId" value={vendorId} /><input type="hidden" name="decision" value={decision} /><label className="block text-sm font-bold">Reason<select name="reasonCode" required className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="">Select a reason</option>{reasons.map((reason) => <option key={reason.value} value={reason.value}>{reason.label}</option>)}</select></label><label className="block text-sm font-bold">Operator note<textarea name="operatorNote" required maxLength={2000} rows={3} className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label><button className="btn btn-outline">{label}</button></form>;
 }
 
 function value(source: Listing | Record<string, string | null>, key: string) {

--- a/web/src/app/ops/listings/page.tsx
+++ b/web/src/app/ops/listings/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { QueuePagination } from "@/components/ops/QueuePagination";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 
 const statuses = ["review", "unclassified", "draft", "pending_review", "published", "rejected", "unpublished"] as const;
@@ -17,20 +18,24 @@ type OpsListing = {
   active_draft_id: string | null;
 };
 
-export default async function OpsListingsPage({ searchParams }: { searchParams: Promise<{ status?: string; q?: string }> }) {
+export default async function OpsListingsPage({ searchParams }: { searchParams: Promise<{ status?: string; q?: string; page?: string }> }) {
   const params = await searchParams;
   const status = statuses.includes(params.status as Status) ? (params.status as Status) : "review";
   const q = typeof params.q === "string" ? params.q.slice(0, 200) : "";
+  const page = pageNumber(params.page);
   const { supabase } = await verifyOpsAdmin(`/ops/listings?status=${status}`);
   const { data, error } = await supabase.rpc("ops_list_listings", {
     p_status: status,
     p_query: q || null,
     p_vendor_id: null,
-    p_limit: 100,
-    p_offset: 0,
+    p_limit: 101,
+    p_offset: page * 100,
   });
   if (error) throw new Error("The listing review queue could not be loaded.");
-  const listings = (data ?? []) as OpsListing[];
+  const results = (data ?? []) as OpsListing[];
+  const listings = results.slice(0, 100);
+  const hasNextPage = results.length > 100;
+  const pageHref = (targetPage: number) => `/ops/listings?${new URLSearchParams({ status, ...(q ? { q } : {}), ...(targetPage ? { page: String(targetPage) } : {}) }).toString()}`;
 
   return (
     <div className="space-y-7">
@@ -75,6 +80,7 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
           </div>
         )}
       </section>
+      <QueuePagination page={page} hasNextPage={hasNextPage} hrefForPage={pageHref} />
     </div>
   );
 }
@@ -87,4 +93,9 @@ function statusLabel(value: string) {
   if (value === "review") return "Attention";
   if (value === "unclassified") return "Needs classification";
   return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function pageNumber(value: string | undefined) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, 10_000) : 0;
 }

--- a/web/src/app/ops/profile-edits/[requestId]/page.tsx
+++ b/web/src/app/ops/profile-edits/[requestId]/page.tsx
@@ -54,6 +54,7 @@ export default async function OpsProfileEditDetailPage({
   const isStale = Object.keys(fieldLabels).some(
     (field) => request.current_values[field] !== request.base_values[field],
   );
+  const successfulAction = ["approve", "reject"].includes(message.success ?? "");
 
   return (
     <div className="space-y-7">
@@ -66,7 +67,7 @@ export default async function OpsProfileEditDetailPage({
 
       {isStale && <p className="rounded-xl border border-amber-300 bg-amber-50 p-4 font-semibold text-amber-900">The public listing changed after this request was submitted. Approval is blocked; reject it so the owner can submit a fresh request.</p>}
       {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 font-semibold text-red-800">{message.error === "invalid" ? "Enter a decision reason." : "The decision failed. Check whether the request is stale or already decided."}</p>}
-      {message.success && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">Decision recorded with an audit event.</p>}
+      {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">Decision recorded with an audit event.</p>}
 
       <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
         <div className="grid grid-cols-[10rem_1fr_1fr] gap-4 bg-slate-100 px-5 py-4 text-xs font-bold uppercase tracking-wide text-slate-600">
@@ -86,7 +87,7 @@ export default async function OpsProfileEditDetailPage({
 
       {request.change_status === "pending" && (
         <section className="rounded-2xl border border-slate-300 bg-white p-6 shadow-sm">
-          <p className="text-sm text-slate-600">Approval updates only these public fields. Publication, ownership, tier, ABN and payment state remain unchanged.</p>
+          <p className="text-sm text-slate-600">Approval updates only these public fields. Rejection makes no public change. Publication, ownership, tier, ABN and payment state remain unchanged. Your reason is recorded permanently.</p>
           <form action={reviewProfileChangeAction} className="mt-5 space-y-4">
             <input type="hidden" name="requestId" value={request.change_request_id} />
             <label htmlFor="reason" className="block text-sm font-bold">Decision basis or reason</label>

--- a/web/src/app/ops/profile-edits/page.tsx
+++ b/web/src/app/ops/profile-edits/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { QueuePagination } from "@/components/ops/QueuePagination";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 
 const statuses = ["pending", "approved", "rejected"] as const;
@@ -15,19 +16,23 @@ type ProfileChange = {
   created_at: string;
 };
 
-export default async function OpsProfileEditsPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+export default async function OpsProfileEditsPage({ searchParams }: { searchParams: Promise<{ status?: string; page?: string }> }) {
   const params = await searchParams;
   const status = statuses.includes(params.status as Status) ? (params.status as Status) : "pending";
+  const page = pageNumber(params.page);
   const { supabase } = await verifyOpsAdmin(`/ops/profile-edits?status=${status}`);
   const { data, error } = await supabase.rpc("ops_list_profile_changes", {
     p_status: status,
     p_change_request_id: null,
-    p_limit: 100,
-    p_offset: 0,
+    p_limit: 101,
+    p_offset: page * 100,
   });
 
   if (error) throw new Error("The profile edit queue could not be loaded.");
-  const requests = (data ?? []) as ProfileChange[];
+  const results = (data ?? []) as ProfileChange[];
+  const requests = results.slice(0, 100);
+  const hasNextPage = results.length > 100;
+  const pageHref = (targetPage: number) => `/ops/profile-edits?${new URLSearchParams({ status, ...(targetPage ? { page: String(targetPage) } : {}) }).toString()}`;
 
   return (
     <div className="space-y-7">
@@ -71,10 +76,16 @@ export default async function OpsProfileEditsPage({ searchParams }: { searchPara
           </div>
         )}
       </section>
+      <QueuePagination page={page} hasNextPage={hasNextPage} hrefForPage={pageHref} />
     </div>
   );
 }
 
 function formatStatus(value: string) {
   return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function pageNumber(value: string | undefined) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? Math.min(parsed, 10_000) : 0;
 }

--- a/web/src/app/ops/system/page.tsx
+++ b/web/src/app/ops/system/page.tsx
@@ -4,21 +4,18 @@ type Health = {
   integration_name: string;
   status: string;
   last_success_at: string | null;
-  last_failure_at: string | null;
   next_expected_sync_at: string | null;
-  last_error: string | null;
-  metadata: Record<string, unknown>;
   updated_at: string;
 };
-type Job = { job_id: string; job_type: string; status: string; attempt_count: number; max_attempts: number; error_message: string | null; created_at: string };
-type Audit = { event_id: string; actor_type: string; action: string; entity_type: string; entity_id: string | null; reason: string | null; correlation_id: string; created_at: string };
+type Job = { job_id: string; job_type: string; status: string; attempt_count: number; max_attempts: number; created_at: string };
+type Audit = { event_id: string; actor_type: string; action: string; entity_type: string; reason: string | null; created_at: string };
 
 export default async function OpsSystemPage() {
   const { supabase } = await verifyOpsAdmin("/ops/system");
   const [healthResult, jobsResult, auditResult] = await Promise.all([
     supabase.rpc("ops_list_integration_health"),
-    supabase.rpc("ops_list_automation_jobs", { p_limit: 50 }),
-    supabase.rpc("ops_list_audit_events", { p_limit: 50 }),
+    supabase.rpc("ops_list_automation_jobs", { p_limit: 200 }),
+    supabase.rpc("ops_list_audit_events", { p_limit: 200 }),
   ]);
   if (healthResult.error || jobsResult.error || auditResult.error) throw new Error("System health could not be loaded.");
   const health = (healthResult.data ?? []) as Health[];
@@ -27,30 +24,55 @@ export default async function OpsSystemPage() {
 
   return (
     <div className="space-y-9">
-      <div><p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">System</p><h2 className="mt-2 text-4xl font-black tracking-tight">Health and audit</h2><p className="mt-3 max-w-3xl text-slate-600">Exception-led status only. Unknown means no automated provider check is connected yet; it does not mean healthy.</p></div>
+      <div>
+        <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">System</p>
+        <h2 className="mt-2 text-4xl font-black tracking-tight">Health and decision record</h2>
+        <p className="mt-3 max-w-3xl text-slate-600">Use this page to notice a problem and confirm that your decisions were recorded. A warning never changes a listing, claim, or contact request by itself.</p>
+      </div>
 
       <section>
-        <h3 className="text-xl font-bold">Integrations and internal monitors</h3>
-        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {health.map((item) => <article key={item.integration_name} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"><div className="flex items-center justify-between gap-3"><h4 className="font-bold">{label(item.integration_name)}</h4><Status value={item.status} /></div><p className="mt-3 text-xs text-slate-500">Updated {new Date(item.updated_at).toLocaleString("en-AU")}</p>{item.last_error && <p className="mt-3 text-sm font-semibold text-red-700">{item.last_error}</p>}<dl className="mt-4 space-y-2 text-xs text-slate-600">{Object.entries(item.metadata ?? {}).map(([key, value]) => <div key={key} className="flex justify-between gap-4"><dt>{label(key)}</dt><dd className="text-right font-semibold">{String(value)}</dd></div>)}</dl></article>)}
-        </div>
+        <h3 className="text-xl font-bold">Service checks</h3>
+        {health.length === 0 ? <p className="mt-4 rounded-2xl border border-slate-200 bg-white p-6 text-slate-600">No automated checks have reported yet. This is not an action request.</p> : (
+          <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {health.map((item) => <article key={item.integration_name} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+              <div className="flex items-center justify-between gap-3"><h4 className="font-bold">{label(item.integration_name)}</h4><Status value={item.status} /></div>
+              <p className="mt-3 text-sm text-slate-700">{healthMessage(item.status)}</p>
+              <p className="mt-3 text-xs text-slate-500">Last checked {date(item.updated_at)}</p>
+              {item.last_success_at && <p className="mt-1 text-xs text-slate-500">Last successful check {date(item.last_success_at)}</p>}
+              {item.next_expected_sync_at && <p className="mt-1 text-xs text-slate-500">Next check expected {date(item.next_expected_sync_at)}</p>}
+            </article>)}
+          </div>
+        )}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
-        <div className="border-b border-slate-200 p-5"><h3 className="text-xl font-bold">Automation jobs</h3></div>
-        {jobs.length === 0 ? <p className="p-8 text-slate-600">No queued or completed automation jobs yet.</p> : <div className="divide-y divide-slate-200">{jobs.map((job) => <div key={job.job_id} className="flex flex-wrap items-center justify-between gap-4 p-5 text-sm"><div><p className="font-bold">{label(job.job_type)}</p><p className="mt-1 text-xs text-slate-500">Attempt {job.attempt_count} of {job.max_attempts} · {new Date(job.created_at).toLocaleString("en-AU")}</p></div><Status value={job.status} />{job.error_message && <p className="w-full text-red-700">{job.error_message}</p>}</div>)}</div>}
+        <div className="border-b border-slate-200 p-5"><h3 className="text-xl font-bold">Automated work</h3><p className="mt-1 text-sm text-slate-600">These checks prepare information only. They do not publish listings or change ownership.</p></div>
+        {jobs.length === 0 ? <p className="p-8 text-slate-600">No automated work has run yet. Nothing needs your attention.</p> : <div className="divide-y divide-slate-200">{jobs.map((job) => <div key={job.job_id} className="flex flex-wrap items-center justify-between gap-4 p-5 text-sm"><div><p className="font-bold">{label(job.job_type)}</p><p className="mt-1 text-slate-600">{jobMessage(job.status, job.attempt_count, job.max_attempts)}</p><p className="mt-1 text-xs text-slate-500">Started {date(job.created_at)}</p></div><Status value={job.status} /></div>)}</div>}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white shadow-sm">
-        <div className="border-b border-slate-200 p-5"><h3 className="text-xl font-bold">Recent audit events</h3></div>
-        <div className="divide-y divide-slate-200">{events.map((event) => <div key={event.event_id} className="grid gap-2 p-5 text-sm md:grid-cols-[1fr_12rem]"><div><p className="font-bold">{label(event.action)}</p><p className="mt-1 text-slate-600">{event.reason ?? `${label(event.entity_type)} ${event.entity_id ?? ""}`}</p><p className="mt-1 text-xs text-slate-500">Actor: {label(event.actor_type)} · Correlation: {event.correlation_id}</p></div><time className="text-xs text-slate-500 md:text-right">{new Date(event.created_at).toLocaleString("en-AU")}</time></div>)}</div>
+        <div className="border-b border-slate-200 p-5"><h3 className="text-xl font-bold">Decision record</h3><p className="mt-1 text-sm text-slate-600">This is the permanent record of recent operator and system actions.</p></div>
+        {events.length === 0 ? <p className="p-8 text-slate-600">No decisions have been recorded yet.</p> : <div className="divide-y divide-slate-200">{events.map((event) => <article key={event.event_id} className="grid gap-2 p-5 text-sm md:grid-cols-[1fr_12rem]"><div><p className="font-bold">{label(event.action)}</p><p className="mt-1 text-slate-600">{event.reason ?? `Recorded against ${label(event.entity_type)}.`}</p><p className="mt-1 text-xs text-slate-500">Recorded permanently by {label(event.actor_type)}.</p></div><time className="text-xs text-slate-500 md:text-right">{date(event.created_at)}</time></article>)}</div>}
       </section>
     </div>
   );
 }
 
 function Status({ value }: { value: string }) {
-  const colour = value === "healthy" || value === "succeeded" ? "bg-green-100 text-green-800" : value === "failed" ? "bg-red-100 text-red-800" : value === "degraded" ? "bg-amber-100 text-amber-900" : "bg-slate-100 text-slate-700";
+  const colour = value === "healthy" || value === "succeeded" ? "bg-green-100 text-green-800" : value === "failed" ? "bg-red-100 text-red-800" : value === "degraded" || value === "stale" ? "bg-amber-100 text-amber-900" : "bg-slate-100 text-slate-700";
   return <span className={`rounded-full px-2.5 py-1 text-xs font-bold ${colour}`}>{label(value)}</span>;
 }
+function healthMessage(status: string) {
+  if (status === "healthy") return "This check is working normally. No action is needed.";
+  if (status === "degraded" || status === "stale") return "This information may be out of date. Record the issue and ask for technical help if it persists.";
+  if (status === "failed") return "The latest check did not finish. No listing or request has changed automatically. Record the issue and ask for technical help.";
+  return "No current automatic check is available. This does not mean there is a problem.";
+}
+function jobMessage(status: string, attempt: number, maxAttempts: number) {
+  if (status === "succeeded") return "Completed successfully. No action is needed.";
+  if (status === "failed") return `Did not complete after ${attempt} of ${maxAttempts} attempts. Record the issue and ask for technical help.`;
+  if (status === "running" || status === "queued") return `Still being handled automatically (attempt ${attempt} of ${maxAttempts}). No listing has changed automatically.`;
+  return "This task has an updated status. No listing has changed automatically.";
+}
+function date(value: string) { return new Date(value).toLocaleString("en-AU"); }
 function label(value: string) { return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase()); }

--- a/web/src/components/ops/QueuePagination.tsx
+++ b/web/src/components/ops/QueuePagination.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export function QueuePagination({ page, hasNextPage, hrefForPage }: { page: number; hasNextPage: boolean; hrefForPage: (page: number) => string }) {
+  if (page === 0 && !hasNextPage) return null;
+
+  return (
+    <nav className="flex items-center justify-between gap-4" aria-label="Queue pages">
+      {page > 0 ? <Link className="font-bold underline underline-offset-4" href={hrefForPage(page - 1)}>Previous page</Link> : <span />}
+      <p className="text-sm text-slate-600">Page {page + 1}. Each page shows up to 100 items.</p>
+      {hasNextPage ? <Link className="font-bold underline underline-offset-4" href={hrefForPage(page + 1)}>Next page</Link> : <span />}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Scope
- Plain-English Ops guides, recovery surface, queue paging, and decision wording
- System screen removes raw provider errors, metadata, and internal IDs
- Read-only, owner-scoped status feed for claim and profile-change outcomes
- Focused boundary test; no User Workflows display changes

## Verification
- npm run check
- npm --prefix web run lint
- npm --prefix web run cf:build
- supabase db lint --linked --fail-on error reports one pre-existing Communications migration error outside this PR

No deploy, publication, ownership change, import, Stripe, pricing, or billing change.