### PR TITLE
Correct dormant communications lint migration syntax

### DIFF
--- a/supabase/migrations/20260719100000_fix_transactional_communications_lint.sql
+++ b/supabase/migrations/20260719100000_fix_transactional_communications_lint.sql
@@ -2,7 +2,7 @@
 -- and remove its PL/pgSQL column-name ambiguity. This does not enable or send
 -- transactional email.
 
-+CREATE OR REPLACE FUNCTION public.prepare_contact_communications(p_contact_request_id UUID)
+CREATE OR REPLACE FUNCTION public.prepare_contact_communications(p_contact_request_id UUID)
 RETURNS TABLE (
   communication_delivery_id UUID,
   contact_request_id UUID,


### PR DESCRIPTION
The first migration application safely applied the Ops owner-status feed, then stopped before executing this separate Communications correction because one leading plus sign made the SQL invalid. This one-character source correction restores valid SQL. It does not enable or send email.