### PR TITLE
Clarify Ops dates in Melbourne time

### DIFF
--- a/web/src/app/ops/claims/[claimId]/page.tsx
+++ b/web/src/app/ops/claims/[claimId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { formatOpsDateTime } from "@/lib/ops/date";
 import { reviewClaimAction } from "../actions";
 
 type OpsClaim = {
@@ -75,7 +76,7 @@ export default async function OpsClaimDetailPage({
       <div className="grid gap-6 lg:grid-cols-2">
         <InfoCard title="Claimant">
           <InfoRow label="Email" value={claim.claimant_email} />
-          <InfoRow label="Submitted" value={new Date(claim.created_at).toLocaleString("en-AU")} />
+          <InfoRow label="Submitted" value={formatOpsDateTime(claim.created_at)} />
           <InfoRow label="Claimant note" value={claim.claimant_note ?? "None provided"} />
         </InfoCard>
         <InfoCard title="Listing">

--- a/web/src/app/ops/claims/page.tsx
+++ b/web/src/app/ops/claims/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { formatOpsDate } from "@/lib/ops/date";
 
 const statuses = ["pending", "needs_information", "approved", "rejected", "revoked"] as const;
 type ClaimStatus = (typeof statuses)[number];
@@ -85,7 +86,7 @@ export default async function OpsClaimsPage({
                     </td>
                     <td className="px-5 py-4">{claim.claimant_email}</td>
                     <td className="px-5 py-4">{claim.evidence?.email_match ? "Email match" : "Manual review"}</td>
-                    <td className="px-5 py-4">{new Date(claim.created_at).toLocaleDateString("en-AU")}</td>
+                    <td className="px-5 py-4">{formatOpsDate(claim.created_at)}</td>
                     <td className="px-5 py-4 text-right">
                       <Link className="font-bold underline underline-offset-4" href={`/ops/claims/${claim.claim_request_id}`}>Review</Link>
                     </td>

--- a/web/src/app/ops/contact/[requestId]/page.tsx
+++ b/web/src/app/ops/contact/[requestId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { formatOpsDateTime } from "@/lib/ops/date";
 import { reviewContactAction } from "../actions";
 
 type ContactRequest = {
@@ -48,7 +49,7 @@ export default async function OpsContactDetailPage({
     <div className="space-y-7">
       <Link href={`/ops/contact?status=${request.contact_status}`} className="text-sm font-bold underline underline-offset-4">← Back to contact queue</Link>
       <div className="flex flex-wrap items-start justify-between gap-4">
-        <div><p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">{formatStatus(request.topic)}</p><h2 className="mt-2 text-4xl font-black tracking-tight">{request.requester_name}</h2><p className="mt-2 text-slate-600">Received {new Date(request.created_at).toLocaleString("en-AU")}</p></div>
+        <div><p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">{formatStatus(request.topic)}</p><h2 className="mt-2 text-4xl font-black tracking-tight">{request.requester_name}</h2><p className="mt-2 text-slate-600">Received {formatOpsDateTime(request.created_at)}</p></div>
         <span className="rounded-full bg-slate-950 px-4 py-2 text-sm font-bold text-white">{formatStatus(request.contact_status)}</span>
       </div>
 
@@ -57,7 +58,7 @@ export default async function OpsContactDetailPage({
 
       <div className="grid gap-6 lg:grid-cols-2">
         <InfoCard title="Contact details"><InfoRow label="Reply email" value={request.requester_email} /><InfoRow label="Business" value={request.business_name ?? "Not provided"} /></InfoCard>
-        <InfoCard title="Request state"><InfoRow label="Topic" value={formatStatus(request.topic)} /><InfoRow label="Status" value={formatStatus(request.contact_status)} /><InfoRow label="Last decision" value={request.decided_at ? new Date(request.decided_at).toLocaleString("en-AU") : "Not reviewed"} /></InfoCard>
+        <InfoCard title="Request state"><InfoRow label="Topic" value={formatStatus(request.topic)} /><InfoRow label="Status" value={formatStatus(request.contact_status)} /><InfoRow label="Last decision" value={request.decided_at ? formatOpsDateTime(request.decided_at) : "Not reviewed"} /></InfoCard>
       </div>
 
       <InfoCard title="Message"><p className="whitespace-pre-wrap break-words text-sm leading-7">{request.message}</p></InfoCard>

--- a/web/src/app/ops/contact/page.tsx
+++ b/web/src/app/ops/contact/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { formatOpsDate } from "@/lib/ops/date";
 
 const statuses = ["new", "in_progress", "resolved", "spam"] as const;
 type ContactStatus = (typeof statuses)[number];
@@ -70,7 +71,7 @@ export default async function OpsContactPage({
                     <td className="px-5 py-4"><p className="font-bold">{request.requester_name}</p><p className="mt-1 text-xs text-slate-500">{request.business_name ?? request.requester_email}</p></td>
                     <td className="px-5 py-4">{formatStatus(request.topic)}</td>
                     <td className="max-w-md truncate px-5 py-4">{request.message}</td>
-                    <td className="px-5 py-4">{new Date(request.created_at).toLocaleDateString("en-AU")}</td>
+                    <td className="px-5 py-4">{formatOpsDate(request.created_at)}</td>
                     <td className="px-5 py-4 text-right"><Link className="font-bold underline underline-offset-4" href={`/ops/contact/${request.contact_request_id}`}>Review</Link></td>
                   </tr>
                 ))}

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { formatOpsDateTime } from "@/lib/ops/date";
 import { decideListingAction, saveListingDraftAction } from "../actions";
 
 type Listing = {
@@ -154,7 +155,7 @@ function EvidenceCard({ evidence }: { evidence: ListingEvidence }) {
       {evidence.summary && <p className="mt-3 text-sm text-slate-700">{evidence.summary}</p>}
       {evidence.source_url && <p className="mt-2 break-all text-sm text-slate-600">Source: {evidence.source_url}</p>}
       {fields.length > 0 && <dl className="mt-4 grid gap-2 text-sm sm:grid-cols-2">{fields.map(([key, fieldValue]) => <div key={key} className="rounded-lg bg-slate-50 p-3"><dt className="font-semibold text-slate-500">{statusLabel(key)}</dt><dd className="mt-1 break-words">{typeof fieldValue === "object" ? JSON.stringify(fieldValue) : String(fieldValue)}</dd></div>)}</dl>}
-      <p className="mt-3 text-xs text-slate-500">Recorded {new Date(evidence.created_at).toLocaleString("en-AU")}{evidence.checked_at ? ` · Checked ${new Date(evidence.checked_at).toLocaleString("en-AU")}` : ""}</p>
+      <p className="mt-3 text-xs text-slate-500">Recorded {formatOpsDateTime(evidence.created_at)}{evidence.checked_at ? ` · Checked ${formatOpsDateTime(evidence.checked_at)}` : ""}</p>
     </article>
   );
 }

--- a/web/src/app/ops/profile-edits/page.tsx
+++ b/web/src/app/ops/profile-edits/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { formatOpsDate } from "@/lib/ops/date";
 
 const statuses = ["pending", "approved", "rejected"] as const;
 type Status = (typeof statuses)[number];
@@ -67,7 +68,7 @@ export default async function OpsProfileEditsPage({ searchParams }: { searchPara
                     <p className="mt-2 text-sm text-slate-600">Changed: {changedFields.map(formatStatus).join(", ")}</p>
                   </div>
                   <div className="text-right">
-                    <p className="text-xs text-slate-500">{new Date(request.created_at).toLocaleDateString("en-AU")}</p>
+                    <p className="text-xs text-slate-500">{formatOpsDate(request.created_at)}</p>
                     <Link href={`/ops/profile-edits/${request.change_request_id}`} className="mt-2 inline-block font-bold underline underline-offset-4">Review</Link>
                   </div>
                 </div>

--- a/web/src/app/ops/system/page.tsx
+++ b/web/src/app/ops/system/page.tsx
@@ -1,4 +1,5 @@
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { formatOpsDateTime } from "@/lib/ops/date";
 
 type Health = {
   integration_name: string;
@@ -74,5 +75,5 @@ function jobMessage(status: string, attempt: number, maxAttempts: number) {
   if (status === "running" || status === "queued") return `Still being handled automatically (attempt ${attempt} of ${maxAttempts}). No listing has changed automatically.`;
   return "This task has an updated status. No listing has changed automatically.";
 }
-function date(value: string) { return new Date(value).toLocaleString("en-AU"); }
+function date(value: string) { return formatOpsDateTime(value); }
 function label(value: string) { return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase()); }

--- a/web/src/lib/ops/date.ts
+++ b/web/src/lib/ops/date.ts
@@ -1,0 +1,24 @@
+const melbourneDate = new Intl.DateTimeFormat("en-AU", {
+  timeZone: "Australia/Melbourne",
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+});
+
+const melbourneDateTime = new Intl.DateTimeFormat("en-AU", {
+  timeZone: "Australia/Melbourne",
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  timeZoneName: "short",
+});
+
+export function formatOpsDate(value: string) {
+  return melbourneDate.format(new Date(value));
+}
+
+export function formatOpsDateTime(value: string) {
+  return melbourneDateTime.format(new Date(value));
+}


### PR DESCRIPTION
Makes every Ops timestamp explicitly use Australia/Melbourne time, including AEST/AEDT where a time is shown. This fixes the live System screen ambiguity found during browser acceptance; it does not change any business, listing, or automation state.