### PR TITLE
Keep public directory ranking commercially neutral

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run public-catalogue:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -17,6 +17,7 @@
     "catalogue:merge:test": "tsx --env-file-if-exists=.env.local scripts/test-merge-vendor-catalogues.ts",
     "catalogue:report": "tsx scripts/report-catalogue-coverage.ts",
     "public-catalogue:test": "tsx scripts/test-public-catalogue-pagination.ts",
+    "directory-ranking:test": "tsx scripts/test-directory-ranking-policy.ts",
     "edge-functions:test": "tsx scripts/test-disabled-edge-functions.ts",
     "vendor-slug:test": "tsx scripts/test-vendor-slug-policy.ts",
     "website-safety": "node scripts/website-safety.mjs",

--- a/scripts/test-directory-ranking-policy.ts
+++ b/scripts/test-directory-ranking-policy.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const publicDirectoryRoutes = [
+  "web/src/app/(directory)/businesses/page.tsx",
+  "web/src/app/(directory)/[suburb]/[service]/page.tsx",
+];
+
+async function run() {
+  for (const route of publicDirectoryRoutes) {
+    const source = await readFile(route, "utf8");
+    assert.doesNotMatch(source, /\.order\(["']tier["']/, `${route} must not rank public results by commercial tier`);
+    assert.match(source, /\.order\(["']business_name["']/, `${route} must have a deterministic non-commercial ordering`);
+  }
+
+  console.log("Public directory ranking policy tests passed.");
+}
+
+await run();

--- a/web/src/app/(directory)/[suburb]/[service]/page.tsx
+++ b/web/src/app/(directory)/[suburb]/[service]/page.tsx
@@ -58,7 +58,7 @@ export default async function Page({ params }: PageProps) {
       .select("id, slug, business_name, description, contact_email, phone, website, tier, is_claimed, street_address")
       .eq("suburb_slug", suburbSlug)
       .eq("category_slug", serviceSlug)
-      .order("tier", { ascending: false }) // premium/claimed first
+      .order("business_name", { ascending: true })
   ]);
 
   // If the category or suburb does not exist, return a 404

--- a/web/src/app/(directory)/businesses/page.tsx
+++ b/web/src/app/(directory)/businesses/page.tsx
@@ -60,7 +60,7 @@ export default async function BusinessesPage({
   if (suburb) query = query.eq('suburb_slug', suburb);
   if (category) query = query.eq('category_slug', category);
 
-  query = query.order('tier', { ascending: false }).order('business_name', { ascending: true });
+  query = query.order('business_name', { ascending: true });
   
   const from = (page - 1) * pageSize;
   const to = from + pageSize - 1;


### PR DESCRIPTION
## Summary
- Remove tier-based ordering from both public directory result paths.
- Order deterministically by business name instead.
- Add a regression check to the repository verification suite.

## Verification
- `npm run check`
- `npm --prefix web run lint`
- `npm --prefix web run build -- --webpack`

No database or public-release changes.