### PR TITLE
Define SuburbMates target-state governance

### DIFF
--- a/docs/AUTOMATION/README.md
+++ b/docs/AUTOMATION/README.md
@@ -2,7 +2,7 @@
 
 This folder is the canonical operational map for SuburbMates automation. It explains what the implemented automations do, what triggers them, which services they use, and their current operating status.
 
-It does not override the locked product and Ops authorities in `docs/REFERENCE/` or the current-state record in `docs/HANDOVER.md`. It records implementation evidence as at 18 July 2026.
+It does not override the locked product and Ops authorities in `docs/REFERENCE/` or the current-state record in `docs/HANDOVER.md`. It records implementation evidence as at 19 July 2026. A pending target-state decision must be reconciled with the locked authorities before it changes production behaviour.
 
 ## Read first
 
@@ -21,16 +21,16 @@ Database health updates and contact retention are narrow, audited **Ops** proces
 
 - The internal Supabase health monitor and contact-retention job are active as Ops processes outside this lane.
 - GitHub has four active workflows on `main`: Verify, Catalogue candidate discovery, Website safety evidence, and Production smoke.
-- One controlled run of each scheduled workflow was completed on 17 July. Catalogue discovery and Production smoke exposed safe implementation defects; their isolated fix is commit `92eef2f` on `codex/preflight-recovery`, awaiting Main review and promotion. Website safety completed evidence collection and raised one operator review issue.
+- Catalogue discovery and Production smoke fixes were merged in pull requests #4 and #5. Controlled manual runs then succeeded on `main`. Website safety completed evidence collection and raised one operator review issue.
 - Stripe billing, bulk ABR/ABN checks, AI publication, media/logo processing, and the legacy inactivity pruner are disabled.
-- Candidate-artifact import into an `/ops` queue is deliberately deferred. The current discovery workflow is complete as evidence-only GitHub artefacts and does not require a database handoff.
+- Candidate artifacts remain evidence-only GitHub artefacts today. A future candidate-to-Ops handoff is required by the target product direction, but it has not yet been implemented or authorised to change production data.
 - The database health monitor does not ingest GitHub workflow runs or artefacts. Its green automation-queue status means only that the local job table has no failed or overdue rows; it is not evidence that GitHub checks ran.
 
 ## Verified current gaps
 
-1. **Promote and rerun the two isolated workflow fixes.** Commit `92eef2f` makes CI's local env file optional for catalogue discovery and makes Production smoke validate the approved holding page before directory-only checks. It has not reached `main`, so neither repaired workflow has a successful controlled run yet.
-2. **Review website-safety evidence.** The controlled run checked 588 websites and flagged 86. The report is retained for 30 days in GitHub Actions and [issue #3](https://github.com/carlsuburbmates/suburbmates/issues/3) is the single review entry. No listing was changed.
-3. **Keep GitHub evidence distinct from the database health badge.** GitHub workflow-result ingestion is not implemented. Candidate-to-Ops import is deliberately deferred while discovery remains an evidence-only workflow. Neither omission is a reason to treat a database health row as proof of GitHub freshness.
+1. **Review website-safety evidence.** The controlled run checked 588 websites and flagged 86. The report is retained for 30 days in GitHub Actions and [issue #3](https://github.com/carlsuburbmates/suburbmates/issues/3) is the single review entry. No listing was changed.
+2. **Keep GitHub evidence distinct from the database health badge.** GitHub workflow-result ingestion is not implemented. Candidate-to-Ops import is not yet implemented. Neither omission is a reason to treat a database health row as proof of GitHub freshness.
+3. **Harden external acquisition.** The current robustness work adds bounded provider requests, response validation, fallback evidence and date-boundary tests. It remains an unmerged candidate until CI and review evidence are attached.
 4. **Cloudflare preview-build guard is enabled.** On 18 July, Cloudflare Workers Builds was verified with production branch `main` and non-production branch builds disabled. This prevents PR branches from producing automatic preview deployments.
 
 ## Documentation rule

--- a/docs/AUTOMATION/WORKFLOWS.md
+++ b/docs/AUTOMATION/WORKFLOWS.md
@@ -9,7 +9,7 @@ The map does not imply that a configured workflow has run successfully, or that 
 ## End-to-end map
 
 ```text
-GitHub catalogue discovery (active on main; repaired run pending)
+GitHub catalogue discovery (active on main; controlled run succeeded after the environment fix)
   -> OpenStreetMap / Overpass public data
   -> candidate CSV
   -> data-hygiene audit
@@ -25,7 +25,7 @@ GitHub website-safety evidence (active on main)
   -> GitHub issue only when review is needed
   -> no database write; no listing change
 
-GitHub production smoke (active on main; repaired run pending)
+GitHub production smoke (active on main; controlled holding-posture run succeeded)
   -> public site + Supabase safe projections
   -> route, sitemap, access-control, and catalogue consistency checks
   -> GitHub issue only on failure
@@ -43,9 +43,9 @@ Supabase internal health monitor (active Ops process; outside Automation lane)
 | Workflow | Trigger | Verified steps | Services / infrastructure | Output | Current status | State-changing boundary |
 | --- | --- | --- | --- | --- | --- | --- |
 | Repository verification | GitHub pull request; push to `main` or `codex/**` | Check out code; install Node 22 dependencies; run root checks; lint, build, and Cloudflare build for `web/` | GitHub Actions, Node.js, npm, Next.js, OpenNext/Cloudflare build tooling | Pass/fail GitHub check | **Active** | No hosted data write or deployment command |
-| Catalogue candidate discovery | Monday schedule at `18:17` UTC; manual dispatch | Acquire City of Darebin commercial candidates from Overpass; audit; merge with curated candidates; audit again; print coverage report; upload OSM and merged CSVs | GitHub Actions, Node.js, npm, OpenStreetMap/Overpass, repository CSV files, GitHub artifacts | Two CSV artifacts retained 30 days | **Active on `main`; repair pending promotion** — controlled run failed only because CI had no `.env.local` | No seed command, Supabase write, or publication command |
+| Catalogue candidate discovery | Monday schedule at `18:17` UTC; manual dispatch | Acquire City of Darebin commercial candidates from Overpass; audit; merge with curated candidates; audit again; print coverage report; upload OSM and merged CSVs | GitHub Actions, Node.js, npm, OpenStreetMap/Overpass, repository CSV files, GitHub artifacts | Two CSV artifacts retained 30 days | **Active on `main`; controlled run succeeded after the environment fix**. External-request hardening remains under review. | No seed command, Supabase write, or publication command |
 | Website-safety evidence | Monday schedule at `08:41` UTC; manual dispatch | Read `published_vendors`; validate public DNS; make DNS-pinned HTTPS `HEAD` requests; follow at most three HTTPS redirects; write JSON report; fail when review is required; open/update one GitHub issue on failure | GitHub Actions, Supabase public projection, DNS, HTTPS, GitHub artifacts/issues | JSON report retained 30 days; one review issue if flagged | **Active on `main`; evidence run completed** — 588 checked, 86 flagged for review | No listing write; no automatic contact or publication decision |
-| Production smoke | Daily schedule at `19:23` Australia/Melbourne; manual dispatch | Check public routes; require unauthenticated Ops redirects; verify canonical redirects and invalid vendor 404; paginate safe Supabase projections; reconstruct and compare sitemap; sample a public vendor page; open/update one GitHub issue on failure | GitHub Actions, production Cloudflare site, Supabase public projections, GitHub issues | Pass/fail run; one failure issue if needed | **Active on `main`; repair pending promotion** — controlled run used directory checks against the intentional holding page | No Supabase write; no deployment; no listing change |
+| Production smoke | Daily schedule at `19:23` Australia/Melbourne; manual dispatch | Check public routes; require unauthenticated Ops redirects; verify canonical redirects and invalid vendor 404; paginate safe Supabase projections; reconstruct and compare sitemap; sample a public vendor page; open/update one GitHub issue on failure | GitHub Actions, production Cloudflare site, Supabase public projections, GitHub issues | Pass/fail run; one failure issue if needed | **Active on `main`; controlled holding-posture run succeeded after the route-expectation fix** | No Supabase write; no deployment; no listing change |
 | Internal operations health | Supabase `pg_cron`, hourly at minute 5 | Count failed and overdue automation jobs; count listings needing review, pending claims, and pending profile changes; update integration-health rows; expose them through authenticated Ops RPCs | Supabase PostgreSQL, `pg_cron`, `automation_jobs`, operator workflow tables, `/ops/system` | `integration_health` status and queue counts | **Active Ops process; outside Automation lane** | Writes health records only; never changes listings, ownership, claims, payments, publication, billing, or tier |
 | Contact retention | Supabase `pg_cron`, daily at `03:17` UTC | Delete spam requests unchanged for 30 days and resolved requests unchanged for 12 months; append a retention audit event if content was deleted; update retention health | Supabase PostgreSQL, `pg_cron`, `contact_requests`, `audit_events`, `integration_health` | Retention health, deletion count, immutable audit evidence | **Active Ops process; outside Automation lane** | Deletes only eligible private contact-request content; never touches listings, ownership, claims, payments, or publication |
 | On-demand path revalidation | Authenticated `POST /api/webhook/revalidate` | Require bearer token; require a path/tag; call `revalidatePath`; return response | Next.js, Cloudflare runtime secret `REVALIDATION_TOKEN` | Cache revalidation response | **Available on demand** — no scheduled caller is evidenced | Does not write listing data; changes only rendered-path cache state |
@@ -75,7 +75,7 @@ Verified sequence:
 7. Print coverage information in the workflow log.
 8. Upload the OSM and merged CSVs as 30-day GitHub artifacts.
 
-The workflow deliberately does not run `seed`, does not call Supabase, and does not publish a listing. Its first controlled run failed before acquisition because CI had no `.env.local`. Commit `92eef2f` makes that file optional and awaits Main promotion. Import of these artifacts into an authenticated `/ops` candidate review queue is deliberately deferred: it is not a requirement of the current evidence-only workflow.
+The workflow deliberately does not run `seed`, does not call Supabase, and does not publish a listing. The environment fix is merged and a controlled run succeeded on `main`. The current hardening work bounds external requests, validates provider responses and records fallback failures before review. Import of these artifacts into an authenticated `/ops` candidate review queue is not yet implemented; it remains evidence-only until a reviewed handoff exists.
 
 ### 3. Website-safety evidence
 
@@ -87,7 +87,7 @@ For every published listing with a website, it retrieves only the safe `publishe
 
 Sources: `.github/workflows/production-smoke.yml` and `scripts/production-smoke.mjs`.
 
-It checks the public site and public database projections together: public routes, unauthenticated Ops redirects, canonical redirects, an invalid vendor route, public catalogue pagination, taxonomy eligibility, exact sitemap membership, category links, and one vendor page. A failure creates or updates one GitHub issue. It never writes to Supabase. The first controlled run failed because it expected the unfinished public contact route while the approved holding page was live. Commit `92eef2f` adds a holding-page check and awaits Main promotion.
+It checks the public site and public database projections together: public routes, unauthenticated Ops redirects, canonical redirects, an invalid vendor route, public catalogue pagination, taxonomy eligibility, exact sitemap membership, category links, and one vendor page. A failure creates or updates one GitHub issue. It never writes to Supabase. Its holding-page expectation is merged and a controlled run succeeded on `main`.
 
 ### 5. Internal health and Ops display
 
@@ -105,7 +105,7 @@ This is intentionally narrower than general data pruning. It deletes only privat
 
 | Area | Actual implementation state | Consequence |
 | --- | --- | --- |
-| Candidate artifact to Ops review queue | Deliberately deferred | Candidate CSVs remain GitHub artifacts by design. No operator queue entry, persisted provenance, job, or audit event is created by the current evidence-only workflow |
+| Candidate artifact to Ops review queue | Not yet implemented | Candidate CSVs remain GitHub artifacts today. The target product requires a reviewed, auditable handoff with persisted provenance and exception handling; it must not create an unreviewed production data path. |
 | Job execution and retry | No job producer or retry action implemented | `automation_jobs` can be displayed but does not currently receive GitHub workflow results or support a retry |
 | Stripe billing | Webhook returns `501` | No payment or subscription automation exists |
 | Bulk ABR/ABN lookup | Disabled | No ABN automation exists |

--- a/docs/OPS/README.md
+++ b/docs/OPS/README.md
@@ -25,6 +25,8 @@ Open `/ops` and sign in with `admin@suburbmates.com.au`. Open the email link in 
 4. **Contact** — handle support, correction, claim-help, and privacy messages.
 5. **System** — notice warnings and confirm decisions appear in the permanent record.
 
+Routine exact-email claims are intended to be low-friction. Claims requiring a challenge, recovery, revocation, conflict resolution or sensitive-change review belong in the protected Claims queue. A claim never publishes a listing or changes unrelated trust/commercial state.
+
 If a queue grows, use **Next page** and **Previous page** at the bottom. Each page has up to 100 items. An empty queue needs no action.
 
 ## Decisions

--- a/docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md
+++ b/docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md
@@ -1,0 +1,55 @@
+# SuburbMates — Communications and Account-Access Specification
+
+## Purpose
+
+This is the approved design contract for account access and staged transactional communication. It prevents a broad email system from appearing by accident while still giving people clear outcomes.
+
+## Operating rule
+
+The product status screen is the source of a person's request outcome. A message is an approved supplement, never the only evidence of a claim, submission, report or privacy decision.
+
+## Current holding posture
+
+| Capability | Status |
+| --- | --- |
+| Passwordless sign-in from `auth@suburbmates.com.au` | Active for authorised access. |
+| Expired/superseded-link recovery | Active through the login page's newest-link and rate-limit guidance. |
+| Public contact/support form | Implemented but not publicly reachable while holding is active. |
+| Contact dispatcher / general notification sender | Dormant; not enabled. |
+| Marketing, newsletters, public support inbox, bulk messages, automatic retries | Prohibited. |
+
+## Staged post-release message catalogue
+
+No row below becomes enabled until its associated user journey and Ops workflow are accepted. `auth@suburbmates.com.au` remains the only active sender. A separate sender for a future catalogue row must be explicitly approved in that implementation issue; none is approved by this contract. Each enabled message contains no private evidence beyond the necessary status and has an in-product fallback.
+
+| Stage | Message | Trigger | Recipient | In-product fallback | Ops evidence |
+| --- | --- | --- | --- | --- | --- |
+| Active | Magic-link sign-in | Person requests authorised sign-in. | Requesting email. | Login page/retry guidance. | Auth provider result; no application message ledger required. |
+| 1 | Claim status | Claim needs information, is approved, rejected or revoked. | Authenticated claimant's approved address. | Owner request-status feed. | Claim ID, status, template/version, delivery result. |
+| 1 | Profile-change status | Proposed change is approved or rejected. | Authenticated owner. | Owner request-status feed. | Change-request ID, status, template/version, delivery result. |
+| 2 | Missing-business outcome | Candidate is accepted, needs information or declined. | Submitter only when they supplied a valid contact basis. | Submitted reference/status path where offered. | Candidate ID, outcome, consent/contact basis, delivery result. |
+| 2 | Report/correction/privacy outcome | Operator closes a request and a reply is appropriate. | Requester only when contact basis permits it. | Private request reference/status path where offered. | Request ID, outcome, delivery result and operator reason. |
+
+## Contact/help/privacy intake
+
+The public form must classify the request before it reaches Ops: correction, claim help, privacy, technical problem or another allowed topic. It applies validation, rate limiting, Turnstile and consent. It saves a private request and displays an honest on-screen receipt; it must not promise an email or change a listing automatically.
+
+## Delivery and failure rules
+
+- Store only the minimum message metadata: type, linked entity, recipient reference, template/version, provider result, timestamps and correlation ID. Do not store email bodies in the ledger.
+- A failed delivery creates an observable Ops state; it is not retried automatically.
+- A sender, recipient or template may be used only for an approved catalogue row.
+- A message never grants ownership, publishes/unpublishes a listing, changes trust/commercial state or exposes private evidence.
+- Retention follows the associated private request/claim policy; delivery metadata remains private and auditable.
+
+## `SUB-15` delivery boundary
+
+`SUB-15` verifies this specification against the current Auth, contact and dormant delivery-ledger implementation, identifies the minimum migration/API/UI changes, and splits `SUB-13` into one implementation issue per enabled message stage. It does not enable an additional sender, dispatcher or outbound message.
+
+## Evidence required before review
+
+- authenticated magic-link and expired-link recovery check;
+- contact input validation/abuse-control and private-queue boundary check;
+- review of delivery-ledger access, audit and retention boundaries;
+- explicit confirmation that no dormant dispatcher became active; and
+- a proposed `SUB-13` child-issue list, one per enabled message path.

--- a/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
+++ b/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
@@ -127,7 +127,9 @@ The site should retain only the minimum useful operational evidence: anonymous a
 
 ### Claim-policy decision gate
 
-The current repository includes a self-service email-match claim design. Older Operations material describes a reviewed claim queue. The finished public claim policy is not yet approved: `SUB-7` must choose and document the evidence, review, conflict, recovery and revocation rules before this journey is released. This map does not silently select either model.
+**Approved owner decision:** an exact match to the listing's recorded contact email is the normal low-friction claim path. It must be paired with a protected exception, challenge, recovery and revocation path for conflicts, sensitive changes and non-matching evidence. A successful claim changes ownership only; it does not publish a listing or confer unrelated trust/commercial status.
+
+The current repository's direct email-match implementation is not, by itself, proof that the full exception and revocation path exists. That work remains governed by the owner journey and Ops issues.
 
 ### Media and logo changes
 

--- a/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
+++ b/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
@@ -35,11 +35,13 @@ mindmap
       Find business
         Claim listing
           Sign in by email link
-          Provide ownership evidence
-          Track request
-            Approved
+          Follow approved claim policy
+            Track request or claim outcome
               Manage profile changes
-            More evidence needed or declined
+      Communications and account access
+        Magic-link sign in and recovery
+        Approved status messages only
+        Contact help and privacy intake
     Business not listed
       Add a business
         Protected submission
@@ -110,9 +112,9 @@ The site should retain only the minimum useful operational evidence: anonymous a
 1. The owner enters through **Find or claim your business** or finds their listing through search.
 2. They open the existing unclaimed profile and select **Claim this business**.
 3. They sign in through the approved passwordless email path.
-4. They provide the evidence required by the eventual claim policy and can see what happens next.
-5. The system shows a clear request state: received, more information needed, under review, approved, declined or withdrawn.
-6. An authorised operator reviews the evidence and makes the ownership decision.
+4. They follow the claim method approved for public release and can see what happens next.
+5. The system shows a clear, explainable outcome or request state.
+6. If the approved policy requires review, an authorised operator reviews the evidence and makes the ownership decision.
 7. If approved, the owner can propose profile changes; those changes follow the moderation rule appropriate to the field. If not approved, the listing remains independently valid or invalid according to its publication state.
 8. The journey is complete when the owner sees a final, explained claim result and any accepted profile change is reflected.
 
@@ -123,15 +125,50 @@ The site should retain only the minimum useful operational evidence: anonymous a
 - Approval changes ownership only. It never creates publication, an ABN signal, payment status or a general "verified" badge by itself.
 - Necessary transactional messages may confirm sign-in, request receipt, requests for more information and final outcomes. No uncontrolled marketing or automatic retries are implied.
 
+### Claim-policy decision gate
+
+The current repository includes a self-service email-match claim design. Older Operations material describes a reviewed claim queue. The finished public claim policy is not yet approved: `SUB-7` must choose and document the evidence, review, conflict, recovery and revocation rules before this journey is released. This map does not silently select either model.
+
+### Media and logo changes
+
+An owner may eventually propose a logo or other listing media through the moderated profile-change journey. The flow must identify the source or permission basis, apply safe file/storage handling, show a pending state, and give Ops an approve, reject or remove decision. Media is never accepted merely because a user is authenticated.
+
 ### What Ops needs to retain
 
 - claimant account reference, listing reference and request timestamps;
 - submitted ownership evidence, redaction/access rules and conflict flags;
 - claim status, decision, reason, reviewer and audit trail;
 - proposed profile changes, before/after values, source/evidence and moderation outcome; and
-- message-delivery outcome only where a necessary transactional message was sent.
+- message-delivery outcome only where an approved transactional message was sent; and
+- media source/permission evidence and moderation outcome when media is proposed.
 
-## 4. New-business journey: add a business that is not yet listed
+## 4. Communications and account-access journey
+
+This is a first-class service journey, not a background detail of claims or forms. It has two intentionally separate states.
+
+### Current holding posture
+
+The only approved outbound email is the passwordless sign-in link from `auth@suburbmates.com.au`. It supports the authorised operator's sign-in and recovery path. There is no public support inbox, contact dispatcher, marketing mail, bulk notification system or automatic retry loop.
+
+### Finished public posture
+
+Before any new message is enabled, `SUB-15` must approve a message catalogue. Each message must name its trigger, recipient, sender, content boundary, contact/consent basis, data retained, delivery failure state, retention rule and Ops action. A person must still be able to see their request status if a message cannot be delivered.
+
+The possible public intents are:
+
+1. **Account access:** request a magic link, use it in the same browser, recover safely from an expired or superseded link, and reach only the authorised private area.
+2. **Claim or profile request status:** see the status in the authenticated product; any email is an approved supplement, never the only record.
+3. **Contact, help and privacy request:** select a plain-language request type, submit a private request, receive an honest on-screen outcome and, only where approved and permitted, a transactional reply.
+4. **Submission or report outcome:** receive a status through the approved channel only when a contact basis exists and the message catalogue permits it.
+
+### What Ops needs to retain
+
+- message/request type, trigger, recipient reference and correlation identifier;
+- the approved template/version or on-screen outcome, delivery result and failure reason where delivery occurs;
+- contact permission, retention state and the private request/claim/report link; and
+- the operator action and audit record for a material response, privacy request or delivery exception.
+
+## 5. New-business journey: add a business that is not yet listed
 
 1. A person selects **Add a business** from Home or a directory empty state.
 2. They provide the minimum useful details and a way to support the business's existence and local relevance.
@@ -155,7 +192,7 @@ The site should retain only the minimum useful operational evidence: anonymous a
 - review queue state, decision reason, reviewer and audit history; and
 - a link to the final listing only after a deliberate lifecycle decision.
 
-## 5. Community-reporter journey: correct or flag a concern
+## 6. Community-reporter journey: correct or flag a concern
 
 1. A visitor selects **Report a problem** from a business profile or the contact path.
 2. They choose a plain-language reason such as wrong details, duplicate, closed business, unsafe destination or another concern.
@@ -164,6 +201,10 @@ The site should retain only the minimum useful operational evidence: anonymous a
 5. An operator checks evidence and corrects, withholds, merges, rejects or escalates the concern.
 6. The journey is complete when the public record is safely resolved and, if a reply is appropriate and permitted, the reporter receives a factual outcome.
 
+### Reconsideration, removal and privacy
+
+A reporter, business owner or affected person must be able to understand the safe next step when they disagree with an outcome, need a factual correction, request removal/withholding, or make a privacy request. The request is private, explained and audit-recorded; it never silently deletes a listing or audit history. The exact public policy and eligibility rules are an approval item in `SUB-7`.
+
 ### What Ops needs to retain
 
 - report type, listing reference, evidence and timestamps;
@@ -171,7 +212,7 @@ The site should retain only the minimum useful operational evidence: anonymous a
 - moderation status, decision, reason, reviewer and linked audit event; and
 - any resulting listing-state or public-fact change, with before/after evidence.
 
-## 6. Operator journey: run the directory safely
+## 7. Operator journey: run the directory safely
 
 1. The authorised operator signs in and reaches protected **Ops**.
 2. The overview identifies work needing attention: listing exceptions, candidate reviews, claims, profile changes, reports, contacts and system health.
@@ -194,7 +235,7 @@ The site should retain only the minimum useful operational evidence: anonymous a
 - queue state, retry/recovery information and links to relevant system/job evidence; and
 - immutable audit history for material lifecycle, claim, correction and security-sensitive actions.
 
-## 7. Automation journey: evidence, not unchecked authority
+## 8. Automation journey: evidence, not unchecked authority
 
 1. A scheduled or manually initiated workflow starts with a visible run identity.
 2. It acquires data from approved sources, applies bounded requests and validates the returned data.
@@ -214,7 +255,7 @@ The site should retain only the minimum useful operational evidence: anonymous a
 - retry/fallback/error evidence and operator-visible exception state; and
 - proof that no prohibited state-changing action was performed.
 
-## 8. Search-engine journey: public discovery after release
+## 9. Search-engine journey: public discovery after release
 
 1. Once the public launch gate is deliberately enabled, a crawler reaches only public, indexable routes.
 2. It receives canonical URLs, permitted metadata and a sitemap containing only eligible public pages.
@@ -240,9 +281,10 @@ The site should retain only the minimum useful operational evidence: anonymous a
 
 1. Approve this map and reconcile it with the Target State, Operations Specification and current implementation.
 2. Build the public directory discovery and profile journey with safe holding/release controls.
-3. Build claims, owner status and moderated profile changes.
-4. Build protected missing-business and concern-report journeys with Ops queues.
-5. Build the audited candidate-to-Ops qualification handoff currently parked in Linear as `SUB-6`.
-6. Verify each journey end-to-end: browser behaviour, database records, authorisation, background evidence and Ops observability.
+3. Approve the Communications and account-access journey in `SUB-15`; do not activate expanded delivery before this gate.
+4. Build claims, owner status and moderated profile changes.
+5. Build protected missing-business and concern-report journeys with Ops queues.
+6. Build the audited candidate-to-Ops qualification handoff currently parked in Linear as `SUB-6`.
+7. Verify each journey end-to-end: browser behaviour, database records, authorisation, background evidence and Ops observability.
 
 Monetisation is intentionally absent from this sequence until a separate paid offer is approved.

--- a/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
+++ b/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
@@ -1,0 +1,248 @@
+# SuburbMates — Complete User Journey Map
+
+## Purpose and status
+
+This is the owner-readable map of the finished SuburbMates experience. It starts with a person arriving at the home page and follows each person or system until its intent is complete. It covers the visible journey, the private work behind it, the background processes and the evidence Ops needs to safely operate the service.
+
+It is the product-flow companion to the Target State and Operating Authority. It does not replace the detailed Operations Specification or the [Automation workflow map](../AUTOMATION/WORKFLOWS.md). Where this map describes a target flow that is not yet live, it is a build commitment, not a claim that the current holding site already provides it.
+
+## The people and systems served
+
+| Actor | What they are trying to achieve | Finished when |
+| --- | --- | --- |
+| Resident / visitor | Find a useful Darebin business and contact or visit it. | They reach accurate contact, website, directions or other stated next step. |
+| Existing business owner | Find their existing listing, establish ownership and keep it accurate. | Their claim or requested update has a clear status and, when accepted, their change is reflected. |
+| Business not yet listed | Tell SuburbMates about a real local business. | They submit a protected candidate and understand that review, not instant publication, follows. |
+| Community reporter | Flag a wrong, unsafe, closed or duplicate listing. | The concern is recorded, triaged and resolved or explained. |
+| Authorised operator | Keep the directory safe, useful and truthful without living in provider dashboards. | The relevant decision, exception or system problem is resolved and audit-recorded. |
+| Scheduled automation | Gather and check evidence without making discretionary business decisions. | It creates a reviewable result, or a visible exception when it cannot. |
+| Search engine | Discover public pages once public release is enabled. | It receives only the deliberate public routes, canonical URLs and sitemap entries. |
+
+## Experience mind map
+
+```mermaid
+mindmap
+  root((SuburbMates home))
+    Resident
+      Browse or search
+        Directory results
+          Business profile
+            Contact business
+            Open website
+            Get directions
+            Report a problem
+    Existing business owner
+      Find business
+        Claim listing
+          Sign in by email link
+          Provide ownership evidence
+          Track request
+            Approved
+              Manage profile changes
+            More evidence needed or declined
+    Business not listed
+      Add a business
+        Protected submission
+          Private candidate
+            Qualification and duplicate check
+              Published unclaimed or exception review
+    Community reporter
+      Report incorrect or unsafe information
+        Moderated review
+          Corrected, withheld or explained
+    Operator
+      Protected Ops
+        Listings and exceptions
+        Claims and profile changes
+        Reports and contact requests
+        Health and audit history
+    Automation
+      Scheduled evidence collection
+        Validate, deduplicate and retain provenance
+          Candidate or exception record
+    Search engine
+      Public routes after release
+        Sitemap and canonical URLs
+```
+
+## 1. Home page: the common beginning
+
+### What a visitor can do
+
+The home page makes the product promise clear: find local Darebin businesses. Its primary actions are:
+
+- **Browse businesses** — opens the directory or a category/suburb starting point.
+- **Search** — takes a person to matching directory results.
+- **Find or claim your business** — helps an owner look for an existing listing before asking them to create anything new.
+- **Add a business** — starts a protected missing-business submission, not an instant public listing.
+- **Report incorrect information / contact SuburbMates** — starts a safe concern or help path.
+
+While the holding posture is active, these actions may correctly lead to a clear holding explanation rather than an unfinished journey. Once public release is authorised, every primary action must complete one of the journeys below.
+
+### Shared information retained
+
+The site should retain only the minimum useful operational evidence: anonymous abuse/rate-limit signals, consent where needed, submitted form content, status, timestamps, and a correlation identifier. Do not turn ordinary browsing into a CRM record or expose private submissions publicly.
+
+## 2. Resident journey: find and use a business
+
+1. The resident opens **Home** and chooses Browse or Search.
+2. They see results that explain location/category context and distinguish trustworthy facts from owner-claimed or other supported signals.
+3. They open a business profile.
+4. They choose an intent: call, visit the business website, get directions, or use another stated contact method.
+5. The journey is complete when they have reached the business's own next step; SuburbMates does not need to capture or sell the lead.
+
+### Behind the page
+
+- The public result and profile use only listing facts eligible for public display.
+- Publication, ownership, ABN evidence and future commercial status remain separate.
+- Canonical URLs, redirects and indexability are applied only after public release is enabled.
+- A broken destination, missing fact or unsafe website can be reported without changing the listing automatically.
+
+### What Ops needs to retain
+
+- listing identity, displayed fields and public lifecycle status;
+- source/provenance and last-check information for public facts;
+- report identifier, reason, evidence and outcome when someone flags a problem; and
+- an audit event for material correction, withholding or restoration decisions.
+
+## 3. Existing-owner journey: claim and improve an existing listing
+
+1. The owner enters through **Find or claim your business** or finds their listing through search.
+2. They open the existing unclaimed profile and select **Claim this business**.
+3. They sign in through the approved passwordless email path.
+4. They provide the evidence required by the eventual claim policy and can see what happens next.
+5. The system shows a clear request state: received, more information needed, under review, approved, declined or withdrawn.
+6. An authorised operator reviews the evidence and makes the ownership decision.
+7. If approved, the owner can propose profile changes; those changes follow the moderation rule appropriate to the field. If not approved, the listing remains independently valid or invalid according to its publication state.
+8. The journey is complete when the owner sees a final, explained claim result and any accepted profile change is reflected.
+
+### Behind the page
+
+- Authentication establishes who is signed in; it does not prove that they control a business.
+- Claim evidence, conflict checks, decision reason and reviewer identity are private.
+- Approval changes ownership only. It never creates publication, an ABN signal, payment status or a general "verified" badge by itself.
+- Necessary transactional messages may confirm sign-in, request receipt, requests for more information and final outcomes. No uncontrolled marketing or automatic retries are implied.
+
+### What Ops needs to retain
+
+- claimant account reference, listing reference and request timestamps;
+- submitted ownership evidence, redaction/access rules and conflict flags;
+- claim status, decision, reason, reviewer and audit trail;
+- proposed profile changes, before/after values, source/evidence and moderation outcome; and
+- message-delivery outcome only where a necessary transactional message was sent.
+
+## 4. New-business journey: add a business that is not yet listed
+
+1. A person selects **Add a business** from Home or a directory empty state.
+2. They provide the minimum useful details and a way to support the business's existence and local relevance.
+3. Validation and abuse controls reject obvious spam, malformed input and duplicates before anything becomes public.
+4. The system creates a **private candidate**, explains that the information will be reviewed, and gives the person a reference or authenticated status path when appropriate.
+5. Background and operator checks compare it with approved sources, scope, duplicate records and safety concerns.
+6. A qualifying candidate follows the approved directory-first lifecycle; an uncertain one becomes an Ops exception rather than a silent public listing.
+7. The journey is complete when the submitter can understand the outcome where contact is appropriate, and the candidate has an auditable decision.
+
+### Behind the page
+
+- A submission is not a self-service profile creator and cannot overwrite an existing listing.
+- Source, contact permission, evidence, anti-abuse signals and duplicate matches stay private.
+- Automation may assist evidence gathering and matching, but cannot invent public facts or make discretionary publication/ownership decisions.
+
+### What Ops needs to retain
+
+- original submission, submission source, consent/contact preference and timestamps;
+- validation/abuse outcome and any safe rate-limit or challenge result;
+- candidate identity, duplicate candidates, provenance and qualification reasons;
+- review queue state, decision reason, reviewer and audit history; and
+- a link to the final listing only after a deliberate lifecycle decision.
+
+## 5. Community-reporter journey: correct or flag a concern
+
+1. A visitor selects **Report a problem** from a business profile or the contact path.
+2. They choose a plain-language reason such as wrong details, duplicate, closed business, unsafe destination or another concern.
+3. They provide enough detail for review; the site acknowledges receipt without promising an automatic change.
+4. Abuse controls and moderation place the report in the appropriate private queue.
+5. An operator checks evidence and corrects, withholds, merges, rejects or escalates the concern.
+6. The journey is complete when the public record is safely resolved and, if a reply is appropriate and permitted, the reporter receives a factual outcome.
+
+### What Ops needs to retain
+
+- report type, listing reference, evidence and timestamps;
+- reporter contact/consent only when supplied and necessary;
+- moderation status, decision, reason, reviewer and linked audit event; and
+- any resulting listing-state or public-fact change, with before/after evidence.
+
+## 6. Operator journey: run the directory safely
+
+1. The authorised operator signs in and reaches protected **Ops**.
+2. The overview identifies work needing attention: listing exceptions, candidate reviews, claims, profile changes, reports, contacts and system health.
+3. The operator opens one queue item, sees the evidence and makes one constrained decision.
+4. The system validates authorisation, applies the permitted transition, preserves the reason and writes an audit event.
+5. Ops shows the result immediately and makes a recovery/review path available where appropriate.
+6. The journey is complete when the queue item has a reasoned, auditable state—not merely when a button has been pressed.
+
+### Important operator boundaries
+
+- Ops is not a replacement for Supabase, Stripe, Cloudflare or GitHub dashboards.
+- Actions must not collapse publication, ownership, verification and commercial state into one control.
+- A disabled integration must be shown as disabled, not simulated as working.
+- Sensitive evidence is visible only to authorised operators and follows retention rules.
+
+### What Ops needs to retain
+
+- actor, authorisation result, action, timestamp and correlation identifier;
+- prior state, new state, reason and supporting evidence;
+- queue state, retry/recovery information and links to relevant system/job evidence; and
+- immutable audit history for material lifecycle, claim, correction and security-sensitive actions.
+
+## 7. Automation journey: evidence, not unchecked authority
+
+1. A scheduled or manually initiated workflow starts with a visible run identity.
+2. It acquires data from approved sources, applies bounded requests and validates the returned data.
+3. It normalises, deduplicates and records provenance, check time, qualification signals and exceptions.
+4. A healthy result produces a reviewable artifact or controlled candidate handoff. A failed or ambiguous result produces a visible exception with enough evidence to investigate.
+5. It never publishes a raw record, grants ownership, resolves a claim, invents a public fact or changes commercial status.
+6. The journey is complete when the result or failure is observable to the appropriate operator and linked to its run evidence.
+
+### Technical companion
+
+`docs/AUTOMATION/WORKFLOWS.md` is the implementation inventory for schedules, triggers, systems, artifacts and current operational status. This map defines why each automation exists and what it must not decide.
+
+### What Ops needs to retain
+
+- run identifier, trigger, version/correlation reference, timestamps and result;
+- source endpoint, artifact reference, provenance, validation and duplicate outcomes;
+- retry/fallback/error evidence and operator-visible exception state; and
+- proof that no prohibited state-changing action was performed.
+
+## 8. Search-engine journey: public discovery after release
+
+1. Once the public launch gate is deliberately enabled, a crawler reaches only public, indexable routes.
+2. It receives canonical URLs, permitted metadata and a sitemap containing only eligible public pages.
+3. Redirects and removed/withheld records lead to the intended safe outcome.
+4. The journey is complete when search engines have an accurate, maintainable representation of the public directory—not when a page is merely present in the database.
+
+### Behind the page and for Ops
+
+- The holding posture remains no-index with an empty sitemap until release.
+- Indexability is independent of whether a record exists, is claimed or has an ABN.
+- Ops needs route/sitemap checks, canonical/redirect evidence, release timestamp and any search visibility warnings without claiming control over search-engine indexing.
+
+## Completion rules shared by every journey
+
+- A journey completes on the person's real outcome, not when they enter a form.
+- The UI always gives a clear next state: success, pending review, more information needed, unavailable, or safe recovery.
+- Public facts are evidence-backed; private submissions and internal evidence never leak into public pages.
+- Every meaningful decision is attributable, timestamped and reviewable.
+- Automation failures become visible work, not silent data loss or automatic state changes.
+- Holding posture, disabled features and release gates are stated honestly until they change through an authorised, verified release.
+
+## Build sequencing implied by this map
+
+1. Approve this map and reconcile it with the Target State, Operations Specification and current implementation.
+2. Build the public directory discovery and profile journey with safe holding/release controls.
+3. Build claims, owner status and moderated profile changes.
+4. Build protected missing-business and concern-report journeys with Ops queues.
+5. Build the audited candidate-to-Ops qualification handoff currently parked in Linear as `SUB-6`.
+6. Verify each journey end-to-end: browser behaviour, database records, authorisation, background evidence and Ops observability.
+
+Monetisation is intentionally absent from this sequence until a separate paid offer is approved.

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -61,6 +61,14 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Guardrail:** No automatic merge, reset, deployment, production data change or policy change follows from that refresh. Unmerged lane work is candidate work, not accepted truth.
 - **Evidence to close:** Relevant CI evidence, persisted run and exception evidence, tests, review and live verification where a public or production behaviour changes.
 
+### D-006 — Communications and account access
+
+- **Date:** 19 July 2026
+- **Decision:** Communications is a first-class user journey. During the holding posture, passwordless sign-in from `auth@suburbmates.com.au` is the only approved outbound email. A public contact dispatcher, support inbox, marketing mail, bulk notification system and uncontrolled retries remain disabled.
+- **Decision required before expansion:** `SUB-15` must approve the exact post-release message catalogue: trigger, recipient, sender, content boundary, contact/consent basis, retained evidence, failure state, retention and Ops action.
+- **Guardrail:** A user must retain an in-product status/recovery path if a message cannot be delivered. A message never changes publication, ownership, trust, commercial or claim state.
+- **Evidence to close:** Approved journey/map, message catalogue, authorised implementation and end-to-end delivery/failure evidence for each enabled message.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -69,6 +69,17 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Guardrail:** A user must retain an in-product status/recovery path if a message cannot be delivered. A message never changes publication, ownership, trust, commercial or claim state.
 - **Evidence to close:** Approved journey/map, message catalogue, authorised implementation and end-to-end delivery/failure evidence for each enabled message.
 
+### D-007 — SUB-7 owner decisions: directory, claims, communications and release
+
+- **Date:** 19 July 2026
+- **Claim policy:** An exact match to the listing's recorded contact email is the normal claim path. Conflicts, sensitive changes, challenges, recovery, revocation and non-matching evidence enter a protected, auditable exception path. Claims change ownership only.
+- **Missing-business policy:** A submission is private first. Deterministically qualified, approved-source, in-scope, identifiable and deduplicated candidates may become unclaimed listings; uncertain or risky candidates enter Ops exception review. Direct self-service public profile creation is not allowed.
+- **Communications policy:** Keep the current sign-in email. After public release, introduce only explicitly approved transactional status messages in stages, with an in-product status/recovery path and no marketing, general support inbox, bulk notifications or uncontrolled retries. `SUB-15` defines the exact catalogue before `SUB-13` implements any message.
+- **Release policy:** Lift holding only after thin end-to-end acceptance proves the resident, owner, submission/report, Ops, automation and public-route journeys. Records existing in the database are not sufficient.
+- **Correction/privacy policy:** Use a private tracked request with operator decision reason and audit history. Never silently delete a listing or audit history, and never automatically remove public information solely from an unreviewed request.
+- **First launch:** The initial public launch is complete when the minimum end-to-end journeys above are proven. Stripe, broad email, bulk ABN checks, AI publication and optional polish are not launch prerequisites.
+- **Evidence to close:** Update authority/issue descriptions; build the ready foundation work; then verify each public journey and release gate.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -1,0 +1,72 @@
+# SuburbMates — Decision Log
+
+## Purpose
+
+This log records owner-approved product decisions and material departures from the current implementation or older documents. It prevents a branch, a lane report, or an outdated specification from silently becoming product policy.
+
+It is a durable repository record. Linear mirrors the active decision and implementation work; GitHub records reviewed technical changes; live production remains the factual release baseline.
+
+## Decision protocol
+
+For every material decision or deviation:
+
+1. record the owner decision, source and date here;
+2. link the Linear issue(s) that will align implementation, tests and documentation;
+3. identify whether the current production behaviour differs;
+4. preserve the discrepancy until it is deliberately resolved through review; and
+5. close the record only with repository, database and live-verification evidence where applicable.
+
+No branch, pull request, automation run or lane handover changes product policy by itself.
+
+## Active decisions
+
+### D-001 — Target-state authority and change control
+
+- **Date:** 19 July 2026
+- **Decision:** The Target State and Operating Authority is the concise owner-approved operating direction. Where it conflicts with older planning language, the intended direction is authoritative, but implementation must be aligned through explicit work rather than silently changed.
+- **Current state:** Older documents and the live application still contain manual-publication and holding-posture assumptions.
+- **Required alignment:** Reconcile the Master Architecture, Operations Specification, handover and lane documents; then implement and verify the target state through reviewed issues.
+- **Evidence to close:** Updated authority documents, linked issue evidence and a release decision.
+
+### D-002 — Directory-first default unclaimed publication
+
+- **Date:** 19 July 2026
+- **Decision:** A business that deterministically qualifies from an approved source is intended to appear in the directory by default as an unclaimed listing. A business does not need to register, claim, provide an ABN or pay before it appears.
+- **Guardrail:** "Found" means an approved, in-scope, identifiable, deduplicated candidate without known material safety or legitimacy concerns. Provenance and the qualifying evidence must be retained. Exceptions remain visible to an operator and audit-recorded.
+- **Current state:** The application requires an explicit operator publication decision and public release remains contained behind the holding posture.
+- **Required alignment:** Build and prove the qualification, evidence, duplicate, exception and lifecycle controls. Do not enable automated production publication or lift the holding posture until that work and public-route acceptance are complete.
+- **Evidence to close:** Policy implementation, tests, controlled data-path verification, operator exception evidence and authorised public release verification.
+
+### D-003 — Owner participation and public input
+
+- **Date:** 19 July 2026
+- **Decision:** Claiming establishes ownership; it does not decide whether an otherwise legitimate listing is published. Owners may propose profile corrections and supporting information through moderated workflows. A public missing-business submission creates a private candidate and cannot publish raw input directly.
+- **Current state:** The finished owner and public-input workflows are build commitments, not accepted completion.
+- **Required alignment:** Implement claim, request-status, profile-change, submission, validation, abuse-control, moderation and necessary transactional communication flows.
+- **Evidence to close:** End-to-end user and operator acceptance evidence, including failed and abuse-resistant paths.
+
+### D-004 — Capability scope
+
+- **Date:** 19 July 2026
+- **Decision:** Monetisation is the only explicitly deferred product capability. It remains disabled until a real paid offer and its price, benefits, entitlement lifecycle, cancellation/failure behaviour and reconciliation model are approved.
+- **Decision:** Core directory, acquisition, trust, owner, moderation, communications, media, accessibility, SEO and operational capabilities are build commitments, subject to their safety controls.
+- **Guardrail:** Payment never determines publication, ownership, legitimacy or ranking.
+- **Evidence to close:** A separate owner-approved commercial model and fully verified billing implementation, if and when monetisation is activated.
+
+### D-005 — Automation and release evidence
+
+- **Date:** 19 July 2026
+- **Decision:** Automation may acquire, normalise, deduplicate and record evidence. It must be idempotent, observable and safe to retry; it must surface exceptions rather than invent facts. AI may not invent public facts or make discretionary publication, claim or ownership decisions.
+- **Decision:** Before every material audit, implementation or release phase, refresh `origin/main`, inspect the shared worktree/branch state and use the remote main branch as the audit and release baseline. Refresh again before reporting a phase complete.
+- **Guardrail:** No automatic merge, reset, deployment, production data change or policy change follows from that refresh. Unmerged lane work is candidate work, not accepted truth.
+- **Evidence to close:** Relevant CI evidence, persisted run and exception evidence, tests, review and live verification where a public or production behaviour changes.
+
+## Open deviations to track
+
+| Deviation | Current truth | Required resolution |
+| --- | --- | --- |
+| Publication policy | Manual publication in implementation; default qualified unclaimed publication is the target direction. | Authority reconciliation, deterministic qualification controls and controlled release work. |
+| Public product | Holding page, redirects and empty sitemap remain live. | Complete public-product workflows and deliberate public-route acceptance. |
+| Owner and public input | Claim, status, profile correction and missing-business submission journeys are incomplete or not accepted as a finished set. | Build, harden and verify both user and Ops paths. |
+| Monetisation | Stripe is disabled. | Leave disabled until separately approved commercial scope exists. |
+| Automation record | Automation safety controls exist but documentation and issue records need current-state reconciliation. | Maintain evidence, exception handling and current documentation as workflows are hardened. |

--- a/docs/REFERENCE/SuburbMates — Execution Governance and Readiness Protocol.md
+++ b/docs/REFERENCE/SuburbMates — Execution Governance and Readiness Protocol.md
@@ -1,0 +1,133 @@
+# SuburbMates — Execution Governance and Readiness Protocol
+
+## Purpose
+
+This is the lightweight control system for executing SuburbMates work. It prevents a local branch, an old document, a passing test or an AI suggestion from quietly changing product policy, production data or release posture.
+
+It is designed for one owner. Linear is the work board; the repository is the durable authority; GitHub is the technical review record; live production is the factual release result.
+
+## 1. Authority and facts are different
+
+### Product authority order
+
+1. Explicit owner decisions recorded in the Decision Log.
+2. Target State and Operating Authority.
+3. Complete User Journey Map.
+4. Detailed Master Architecture and Operations Specification, only where consistent with the first three.
+5. An approved Linear issue, which may implement authority but may not silently rewrite it.
+6. Lane documents, handovers and reports, only as implementation guidance.
+
+### Current-state evidence order
+
+1. Live production and remote database state.
+2. `origin/main` and its merged pull-request/CI record.
+3. Remote migration list and hosted workflow evidence.
+4. Isolated branch/worktree evidence.
+5. Local assumptions or chat summaries.
+
+An authority document defines what should happen. Current-state evidence defines what is happening. A difference is a **deviation** to record and resolve—not permission to change either one silently.
+
+## 2. Roles and boundaries
+
+| Actor | May do | Must not do |
+| --- | --- | --- |
+| Owner | Approve product decisions, scope, public release and final acceptance. | Be presumed to have approved an unstated product or commercial choice. |
+| Linear | Hold project lane, issue scope, blockers, status and evidence links. | Become the sole source of permanent product authority. |
+| Codex | Audit, implement an approved issue, test, document evidence and report deviations. | Make discretionary production decisions, broaden scope, merge, deploy or alter live data without authority. |
+| GitHub | Hold branches, pull requests, CI and merged technical history. | Prove that production behaviour or acceptance criteria are correct by itself. |
+| Ops | Make the constrained, server-authorised decisions defined by the product. | Bypass audit, authorisation or independent listing/ownership/trust/commercial states. |
+| Automation | Gather, validate, normalise and report evidence. | Invent facts or make discretionary publication, ownership, claim or commercial decisions. |
+
+## 3. Issue readiness gate
+
+An issue may move from **Backlog** to **Todo** only when all of these are true:
+
+- its governing authority source is linked;
+- its outcome, scope and out-of-scope boundary are explicit;
+- acceptance criteria are observable and testable;
+- required data, security, automation, Ops, UI and communications effects are named;
+- blockers and owning lane are correct;
+- a release/holding-posture impact is stated; and
+- any product decision still needed is explicitly marked as a blocker.
+
+If any item is missing, improve the issue or return it to Backlog. Do not begin implementation merely because the title sounds useful.
+
+## 4. Execution protocol
+
+### Before a material phase
+
+1. Refresh `origin/main` and inspect the shared worktree/branch state.
+2. Read the issue, its dependencies, the governing authority and the current factual baseline.
+3. Record a material contradiction or scope expansion in the Decision Log and Linear before editing code.
+4. Work in an isolated `codex/` branch or worktree. Do not treat unmerged lane work as accepted truth.
+
+### While implementing
+
+- Change only what the issue authorises.
+- Keep public holding, data and security boundaries active unless the issue explicitly and validly changes them.
+- Use the smallest useful verification after each meaningful change.
+- Keep data migrations, user-facing flows, background work and Ops evidence aligned; do not ship only one layer of a journey.
+- Stop and escalate when evidence contradicts the issue, a migration/data effect is uncertain, a security boundary changes, or another lane has changed the same area.
+
+### Before review
+
+1. Refresh the remote baseline and inspect concurrent work again.
+2. Run the issue's relevant tests, build and any required database/browser/hosted-workflow checks.
+3. Push the isolated branch and capture CI evidence.
+4. Update the Linear issue with files changed, commands/checks, results, data/deployment impact and remaining uncertainty.
+5. Move it to **In Review** only when every acceptance criterion has evidence. Otherwise leave it In Progress.
+
+### Review, merge and release
+
+- Review checks scope, authority alignment, dependency state, test evidence and unintended changes.
+- A merge requires a current-baseline comparison; a merge is not a deployment or final acceptance.
+- A public release requires the relevant journey, data, Ops and automation evidence plus explicit owner release authority.
+- **Done** requires the issue's evidence, not a commit, pull request or optimistic status update.
+
+## 5. Required evidence by change type
+
+| Change | Minimum evidence before In Review |
+| --- | --- |
+| UI or user journey | Relevant browser flow on mobile/desktop, error/recovery state and accessibility check. |
+| Database or lifecycle | Migration/reconciliation result, authorised-transition tests, preserved audit evidence and rollback/recovery impact. |
+| Automation | Unit/integration check, hosted run/artifact, failure/exception behaviour and proof of no prohibited state change. |
+| Ops | Authorisation check, constrained action result, queue state and audit event evidence. |
+| Communications | Approved catalogue entry, sender/recipient/content boundary, delivery/failure state, retained evidence and user fallback. |
+| Public release/SEO | Production route, sitemap/canonical/redirect evidence, public-data eligibility and owner release decision. |
+
+## 6. Deviation and stop rules
+
+| Finding | Required action |
+| --- | --- |
+| Authority conflict | Stop implementation; log the conflict; route to `SUB-7` or a dedicated decision issue. |
+| Security, privacy, audit or live-data risk | Stop the affected path; preserve evidence; do not experiment in production. |
+| A new user journey, provider, sender or paid offer | Create/propose a scoped issue and obtain owner approval before implementation. |
+| Stale documentation or incorrect status | Correct it through reviewed documentation work; do not use it as authority in the meantime. |
+| External provider failure | Preserve the failure/attempt evidence, use the approved fallback if available and surface an exception. |
+| Overlapping lane change | Refresh branches, compare the shared surface and agree the dependency/owner before merging. |
+
+## 7. Cross-lane rule
+
+Each issue belongs to the lane that owns its primary outcome. It may depend on work in other lanes but must not duplicate their implementation.
+
+- Main Platform owns shared states, public routes, security foundations and release gates.
+- User Workflows owns the resident, owner, submitter and reporter experience.
+- Operations owns protected queues, decisions and audit visibility.
+- Automation owns evidence acquisition, background runs, retries and exceptions.
+- Communications owns approved account access and transactional delivery.
+- Monetisation remains deferred until separately approved.
+
+## 8. Current controlled entry point
+
+`SUB-16` establishes this protocol. `SUB-7` is the first product decision gate: it reconciles claim policy, Communications scope, authority conflicts and journey acceptance before feature issues move to Todo.
+
+`SUB-5` remains in review as a bounded automation hardening change. `SUB-6` remains parked. The holding posture, public containment and disabled billing posture remain unchanged.
+
+## 9. Working cadence
+
+- **Before each material phase:** remote refresh, worktree inspection and issue/authority read.
+- **At each meaningful discovery:** Decision Log plus Linear update when it changes scope, policy, risk or dependency.
+- **Before every review or merge:** refresh baseline again and attach evidence.
+- **After every merge or release:** verify the factual result, record any deviation and update the relevant issue/project status.
+
+This cadence is mandatory control, not bureaucracy: it replaces repeated re-audits and prevents the project from drifting.

--- a/docs/REFERENCE/SuburbMates — Listing Lifecycle and Release-State Contract.md
+++ b/docs/REFERENCE/SuburbMates — Listing Lifecycle and Release-State Contract.md
@@ -1,0 +1,61 @@
+# SuburbMates — Listing Lifecycle and Release-State Contract
+
+## Purpose
+
+This contract turns the owner-approved directory policy into a buildable model. It deliberately keeps publication, site release, ownership, trust evidence, commercial presentation, provenance and SEO eligibility separate.
+
+## State model
+
+| Dimension | Meaning | Must not be changed by |
+| --- | --- | --- |
+| Listing lifecycle | `draft`, `pending_review`, `published`, `rejected`, `unpublished`. A listing's own directory eligibility. | Claim, ABN result, payment, tier or AI output alone. |
+| Public release | The site-wide holding/release gate that controls whether otherwise published records are publicly browseable and indexable. | A database record being published. |
+| Ownership | `unclaimed`, `claim_pending`, `claimed`, `owner_verified` where implemented. | Publication, ranking or SEO eligibility. |
+| Trust evidence | Evidence records such as source, website and optional ABN checks. | A universal "verified" badge or publication automatically. |
+| Commercial state | Free now; future paid entitlement only after a separate approved offer. | Publication, ownership, legitimacy, claim outcome or ranking. |
+| Provenance | Source, source key/URL, checked time, qualification evidence and duplicate relationship. | Public display without the lifecycle decision. |
+| SEO eligibility | Whether a public route/taxonomy page can be indexed. | Ownership, payment or mere database existence. |
+
+## Current implementation inventory
+
+- `vendors.listing_status` and `vendors.is_published` already implement the listing lifecycle and consistency check.
+- `vendors.ownership_status`, `owner_id` and `is_claimed` are separate from publication.
+- `listing_evidence`, source fields and audit events hold supporting provenance and decision history.
+- `published_vendors` is a narrow public projection; it does not expose source, owner, moderation or internal lifecycle data.
+- `taxonomy_page_eligibility` computes indexable taxonomy routes from published, evidence-backed listings. It is an SEO rule, not a new listing state.
+- Protected Ops lifecycle functions require an operator, reason and audit event.
+
+## Required corrections and boundaries
+
+1. **Commercial neutrality:** public directory ranking must not order by `tier` or another commercial field. Commercial presentation belongs to its own future approved model.
+2. **Qualified default publication:** the approved target is deterministic publication of qualifying approved-source candidates as unclaimed listings. The current importer keeps new records in `pending_review`; changing that path belongs to `SUB-6` after its auditable candidate handoff is designed and proven.
+3. **Holding remains separate:** a `published` listing stays non-public while the global holding gate is active. Releasing public routes is governed by `SUB-14`, not an import or claim.
+4. **Claims remain independent:** the approved normal exact-email path and its future exception/revocation flow never publish a listing or change commercial/SEO state.
+5. **Evidence remains precise:** an ABN or website result is stored as supporting evidence. It is not a universal entry requirement.
+
+## Allowed lifecycle transitions
+
+```mermaid
+stateDiagram-v2
+  [*] --> draft
+  draft --> pending_review: candidate or operator prepares record
+  pending_review --> published: approved current control / future qualified policy
+  pending_review --> rejected: insufficient, duplicate, unsafe or out of scope
+  published --> unpublished: reasoned safety, accuracy, privacy or closure decision
+  unpublished --> pending_review: restore for review
+  rejected --> pending_review: new evidence or correction
+```
+
+Every transition requires the permitted actor, reason, timestamp and audit evidence. The current operator-only transition path is retained until `SUB-6` delivers an approved deterministic qualification handoff.
+
+## `SUB-8` delivery boundary
+
+`SUB-8` verifies and corrects the shared model: state separation, operator transition protection, public projection and non-commercial ranking. It does not enable automatic candidate publication, lift holding mode, implement claim exceptions, or activate billing.
+
+## Evidence required before review
+
+- source-level tests for valid and prohibited transitions;
+- a public-directory result proving neutral, non-commercial ordering;
+- confirmation that public projection and holding gate remain unchanged;
+- review of migration/RLS/audit impact; and
+- no remote data mutation during verification unless a separately approved migration is ready.

--- a/docs/REFERENCE/SuburbMates — SUB-7 Owner Decision Sheet.md
+++ b/docs/REFERENCE/SuburbMates — SUB-7 Owner Decision Sheet.md
@@ -1,0 +1,108 @@
+# SuburbMates — SUB-7 Owner Decision Sheet
+
+## How to use this sheet
+
+These are the few decisions that affect many future issues. Choose the recommended position, select another option, or write a short variation. No choice in this document changes the live site by itself.
+
+Current fact remains: the site is in holding mode; the directory is not publicly browsable; the only approved outbound email is the operator magic-link sign-in path; Stripe is disabled.
+
+## 1. How an existing business owner claims a listing
+
+### Current implementation
+
+An owner can sign in with the email already recorded on an unclaimed listing and claim it automatically. Older Ops material instead describes evidence review by an operator.
+
+### Options
+
+| Option | What happens | Trade-off |
+| --- | --- | --- |
+| A. Automatic email-match | A matching contact email gives ownership immediately. | Fastest, but a stale/shared email may give the wrong person control. |
+| B. Review every claim | Every claimant supplies evidence and waits for an operator decision. | Strongest control, but adds friction and workload. |
+| C. **Recommended: email-match with an exception path** | A matching email gives the normal claim result; conflicts, later challenge, sensitive changes or non-matching evidence enter the protected Ops review path. | Keeps claiming easy while retaining a practical correction/revocation route. |
+
+**Decision:** A / B / C / variation: ______
+
+## 2. What happens when a person submits a missing business
+
+### Proposed target
+
+A submission is always private first. It must not create a self-service public profile or overwrite an existing business.
+
+### Options
+
+| Option | What happens | Trade-off |
+| --- | --- | --- |
+| A. Operator-review only | Every candidate waits for manual review. | Maximum control; slowest catalogue growth. |
+| B. **Recommended: deterministic qualification with exception review** | Approved-source, in-scope, identifiable, deduplicated candidates that pass the policy become unclaimed listings; uncertain or risky candidates enter Ops review. | Scales the directory while preserving evidence and exceptions. |
+| C. Direct self-service profile | The submitter creates a live business profile. | Not recommended: easy to abuse and conflicts with the directory-first model. |
+
+**Decision:** A / B / C / variation: ______
+
+## 3. Communications after public release
+
+### Current fact
+
+While holding, only passwordless sign-in from `auth@suburbmates.com.au` is enabled. There is no public support inbox, contact dispatcher, marketing mail or general notification system.
+
+### Options
+
+| Option | What happens | Trade-off |
+| --- | --- | --- |
+| A. Keep email to sign-in only | Users see statuses only inside the product; contact is handled in Ops. | Simplest, but people may miss outcomes. |
+| B. **Recommended: staged transactional messages** | Keep sign-in email; add only approved final-status messages one at a time for claims, submissions or reports, with an in-product fallback. | Useful without creating a general messaging platform. |
+| C. Broad notification system | Add automatic receipts, reminders, support inboxes and marketing. | Not recommended now: high maintenance and unnecessary scope. |
+
+**Decision:** A / B / C / variation: ______
+
+If B: approve only the message types that are genuinely needed:
+
+- claim accepted / declined / more information needed;
+- profile change accepted / declined;
+- submission or report outcome;
+- privacy-request outcome.
+
+## 4. Public directory release standard
+
+### Current fact
+
+Holding mode stays active: no-index page, empty sitemap and no public directory routes.
+
+### Options
+
+| Option | What happens | Trade-off |
+| --- | --- | --- |
+| A. Release as soon as records are available | Lift holding when listings exist. | Fast, but risks exposing incomplete journeys. |
+| B. **Recommended: release after thin end-to-end acceptance** | Release only after resident discovery, owner claim, submission/report, Ops decisions, lifecycle controls and public SEO routes have each been proven once. | A focused, practical launch gate. |
+| C. Wait for every future feature | Hold until every optional refinement is complete. | Safest but delays useful launch unnecessarily. |
+
+**Decision:** A / B / C / variation: ______
+
+## 5. Correction, removal, privacy and challenge requests
+
+### Proposed target
+
+People can report wrong/unsafe information or submit a privacy/removal request. It becomes a private, audit-recorded Ops item; it never silently deletes a listing or audit history.
+
+### Options
+
+| Option | What happens | Trade-off |
+| --- | --- | --- |
+| A. Manual email-only handling | Requests are handled outside the product. | Low build cost; weak tracking and inconsistent outcomes. |
+| B. **Recommended: private tracked request flow** | A simple form creates a protected Ops request with status, decision reason and safe outcome. | Clear accountability without building a support CRM. |
+| C. Automatic removal | A request immediately hides/deletes public information. | Not recommended: vulnerable to abuse and destroys review evidence. |
+
+**Decision:** A / B / C / variation: ______
+
+## 6. What counts as a complete first public launch
+
+### Recommended definition
+
+The first launch is complete when a resident can find and use a listing; an owner can claim or obtain a clear claim outcome; a person can submit a missing business or report a concern; Ops can make and audit the necessary decisions; automation surfaces evidence and failures; and the public routes/sitemap reflect only eligible records.
+
+It does **not** require Stripe, a broad email platform, bulk ABN checks, AI publication, or every visual refinement.
+
+**Decision:** approve / change: ______
+
+## Decision record
+
+When the owner approves these choices, record each final answer in the Decision Log, update `SUB-7`, then move only the newly ready dependent issues to Todo. The current holding posture remains until the separate public-release acceptance issue is complete.

--- a/docs/REFERENCE/SuburbMates — SUB-7 Owner Decision Sheet.md
+++ b/docs/REFERENCE/SuburbMates — SUB-7 Owner Decision Sheet.md
@@ -4,6 +4,10 @@
 
 These are the few decisions that affect many future issues. Choose the recommended position, select another option, or write a short variation. No choice in this document changes the live site by itself.
 
+## Approved owner decisions — 19 July 2026
+
+The owner approved the recommended position for every decision: **1C, 2B, 3B, 4B, 5B**, and the recommended first-launch definition in decision 6. The Decision Log is the durable policy record; this sheet remains the concise explanation of the choices.
+
 Current fact remains: the site is in holding mode; the directory is not publicly browsable; the only approved outbound email is the operator magic-link sign-in path; Stripe is disabled.
 
 ## 1. How an existing business owner claims a listing

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -14,6 +14,8 @@ All execution follows [SuburbMates — Execution Governance and Readiness Protoc
 
 The unresolved owner choices that gate implementation are collected in [SUB-7 — Owner Decision Sheet](./SuburbMates%20%E2%80%94%20SUB-7%20Owner%20Decision%20Sheet.md).
 
+The implementation contracts for the ready foundation work are [Listing Lifecycle and Release-State Contract](./SuburbMates%20%E2%80%94%20Listing%20Lifecycle%20and%20Release-State%20Contract.md) and [Communications and Account-Access Specification](./SuburbMates%20%E2%80%94%20Communications%20and%20Account-Access%20Specification.md).
+
 ## Product outcome
 
 SuburbMates is a directory-first service for discovering local Darebin businesses and contacting them directly. It is not a lead-selling marketplace, quote funnel, merchant of record, or a platform that invents business facts.

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -12,6 +12,8 @@ The complete non-technical experience is defined in [SuburbMates — Complete Us
 
 All execution follows [SuburbMates — Execution Governance and Readiness Protocol](./SuburbMates%20%E2%80%94%20Execution%20Governance%20and%20Readiness%20Protocol.md).
 
+The unresolved owner choices that gate implementation are collected in [SUB-7 — Owner Decision Sheet](./SuburbMates%20%E2%80%94%20SUB-7%20Owner%20Decision%20Sheet.md).
+
 ## Product outcome
 
 SuburbMates is a directory-first service for discovering local Darebin businesses and contacting them directly. It is not a lead-selling marketplace, quote funnel, merchant of record, or a platform that invents business facts.

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -10,6 +10,8 @@ Owner decisions and material implementation deviations are recorded in [SuburbMa
 
 The complete non-technical experience is defined in [SuburbMates — Complete User Journey Map](./SuburbMates%20%E2%80%94%20Complete%20User%20Journey%20Map.md). Its technical automation companion is `docs/AUTOMATION/WORKFLOWS.md`.
 
+All execution follows [SuburbMates — Execution Governance and Readiness Protocol](./SuburbMates%20%E2%80%94%20Execution%20Governance%20and%20Readiness%20Protocol.md).
+
 ## Product outcome
 
 SuburbMates is a directory-first service for discovering local Darebin businesses and contacting them directly. It is not a lead-selling marketplace, quote funnel, merchant of record, or a platform that invents business facts.

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -8,6 +8,8 @@ Where this document makes an explicit owner decision that differs from an older 
 
 Owner decisions and material implementation deviations are recorded in [SuburbMates — Decision Log](./SuburbMates%20%E2%80%94%20Decision%20Log.md). Linear holds the linked work and verification record; this repository holds the durable product authority.
 
+The complete non-technical experience is defined in [SuburbMates — Complete User Journey Map](./SuburbMates%20%E2%80%94%20Complete%20User%20Journey%20Map.md). Its technical automation companion is `docs/AUTOMATION/WORKFLOWS.md`.
+
 ## Product outcome
 
 SuburbMates is a directory-first service for discovering local Darebin businesses and contacting them directly. It is not a lead-selling marketplace, quote funnel, merchant of record, or a platform that invents business facts.

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -1,0 +1,131 @@
+# SuburbMates — Target State and Operating Authority
+
+## Status and purpose
+
+This is the owner-approved, concise definition of the expected SuburbMates product and its operating authority. It gives Linear, Codex, GitHub and future contributors a shared control-room view without replacing the detailed architecture or Operations Specification.
+
+Where this document makes an explicit owner decision that differs from an older planning document, this document governs the operating direction. The detailed documents and implementation must then be aligned through reviewed issues and migrations; no conflicting behaviour should be changed silently.
+
+## Product outcome
+
+SuburbMates is a directory-first service for discovering local Darebin businesses and contacting them directly. It is not a lead-selling marketplace, quote funnel, merchant of record, or a platform that invents business facts.
+
+The finished public directory helps residents find useful local businesses. Business owners can discover their existing listing, claim it, and propose accurate updates. Routine operations happen in the protected `/ops` console, not in provider dashboards.
+
+## Current release posture
+
+The public site remains intentionally contained behind a no-index holding page until the owner authorises public release. Unfinished public routes redirect home and the public sitemap remains empty during this posture.
+
+This containment is temporary. It must not be treated as the final directory product or as a reason to postpone the operational model below.
+
+## Directory publication policy
+
+### Owner decision
+
+Qualifying businesses discovered from approved sources are published by default as **unclaimed** listings. They do not need to register, claim their listing, provide an ABN, pay SuburbMates, or be owner-verified before appearing in the directory.
+
+This is the primary acquisition model: a business should be able to find itself on SuburbMates and then choose to claim its listing.
+
+### Minimum qualification
+
+"Found" does not mean every raw record from the internet. Before publication, a candidate must:
+
+1. come from an approved, storage-and-display-permitted source;
+2. be within the directory's geographic and category scope;
+3. have enough evidence to identify it as a real business, normally a name plus an address, phone, website, or public source record;
+4. be deduplicated against existing listings; and
+5. have no known evidence that its public page, destination, or identity is malicious, deceptive, closed, or materially unsupported.
+
+An operator may withhold, unpublish, reject, or correct a listing when those safeguards are not met. Those decisions must be reasoned and audit-recorded. They do not require a separate owner approval for every ordinary qualifying discovery.
+
+### Independent states
+
+Publication, ownership, verification, commercial status, source provenance and SEO eligibility remain independent. A published listing may correctly be:
+
+```text
+Published
+Unclaimed
+ABN not provided
+Free
+Approved import
+```
+
+Publication must never be caused solely by payment, a claim, an ABN result, or AI output. AI may prepare evidence-limited drafts only; it may not invent public facts.
+
+### Trust signals
+
+Use precise labels only where supported by stored evidence: `Claimed`, `Owner verified`, `ABN checked`, and, if a future paid offer is approved, an accurate commercial label. Do not use a vague universal `Verified` badge and do not imply that an unclaimed or unverified listing is illegitimate.
+
+## Operating authority
+
+| Actor | Authority |
+| --- | --- |
+| Owner / authorised operator | Reviews exceptions, makes normal listing lifecycle decisions, resolves claims and profile changes, and authorises public release. Every privileged decision is server-authorised and audit-recorded. |
+| Automation | Acquires, normalises, deduplicates and records evidence. It may publish only when the approved deterministic qualification policy is implemented and proven; it must surface exceptions rather than invent facts. |
+| Codex | Audits, implements approved work, runs tests and reports evidence. It does not make discretionary production decisions or send uncontrolled communications. |
+| Linear | Tracks approved work, ownership, dependencies, acceptance criteria, blockers and verification evidence. It is the coordination layer, not the product source of truth. |
+| GitHub | Holds source, branches, pull requests, CI and the technical merge record. `main` is the release and audit baseline. |
+
+## Capability status and guardrails
+
+### Explicitly deferred: monetisation
+
+Stripe checkout, subscriptions, entitlement enforcement and webhook processing are deferred until the owner defines a genuine paid benefit, price, entitlement lifecycle, cancellation/failure behaviour and reconciliation model. The current Stripe webhook remains non-operational. Payment must never determine publication, ownership, legitimacy or ranking.
+
+### Required for the completed product
+
+The following are build commitments, not indefinite deferrals:
+
+- approved-source discovery, evidence capture, deduplication and the deterministic qualification policy for default unclaimed publication;
+- optional ABN and website evidence checks, presented as precise supporting signals rather than entry requirements;
+- a public missing-business submission path, protected by validation and abuse controls, that creates a candidate record rather than publishing raw input;
+- claim, ownership, request-status and moderated profile-update journeys;
+- the public contact path, private Ops handling and only the transactional communications genuinely needed by approved user workflows;
+- a safe, evidence-backed media/logo capability when it improves a public listing; and
+- observable operational jobs, exception queues, audit history, mobile accessibility, SEO and public-route acceptance.
+
+These capabilities must be implemented with their relevant safety controls and verified before public release. They must not remain merely documented.
+
+### Permanent guardrails
+
+The following are prohibited product behaviours, not postponed features:
+
+- AI-generated public facts or AI deciding publication;
+- an ABN, payment, claim, tier or email match independently publishing a listing;
+- automatic publication from raw, unqualified or unlicensed discovery data;
+- destructive legacy pruning or silent deletion of business and audit history;
+- marketing email, uncontrolled retries, or an exposed public support inbox; and
+- broad service-role or privileged Edge-function paths that bypass the server-authorised workflow and audit boundaries.
+
+Default publication applies only after the qualification policy above is implemented, tested and operationally observable. Public contact intake becomes available with the public release rather than during the holding posture.
+
+## Release gates
+
+Before public directory release, prove that:
+
+1. the public directory shows only qualifying published listings with accurate trust signals;
+2. `/ops` lets the authorised operator understand and complete routine exception, claim, correction and lifecycle work without provider dashboards;
+3. source, duplicate, safety and publication safeguards are tested and auditable;
+4. owner claim and proposed-edit workflows are authenticated and moderated;
+5. public pages, metadata, sitemap and no-index rules match the active release posture; and
+6. production, database and relevant integrations are verified after deployment.
+
+## Operating workflow
+
+```text
+Expected-state authority and locked specifications
+        ↓
+Linear issue with owner, dependency, acceptance criteria and verification
+        ↓
+Codex implementation and evidence
+        ↓
+GitHub review, CI and merge to main
+        ↓
+Production and database verification
+        ↓
+Linear records the verified outcome
+```
+
+## Alignment required
+
+The older manual-publication wording in the Master Architecture, Unified Operations Specification and Handover must be revised to match this owner decision before the default-publication implementation is enabled. Until that alignment and its tests are complete, existing safe-off behaviour remains in force.

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -6,6 +6,8 @@ This is the owner-approved, concise definition of the expected SuburbMates produ
 
 Where this document makes an explicit owner decision that differs from an older planning document, this document governs the operating direction. The detailed documents and implementation must then be aligned through reviewed issues and migrations; no conflicting behaviour should be changed silently.
 
+Owner decisions and material implementation deviations are recorded in [SuburbMates — Decision Log](./SuburbMates%20%E2%80%94%20Decision%20Log.md). Linear holds the linked work and verification record; this repository holds the durable product authority.
+
 ## Product outcome
 
 SuburbMates is a directory-first service for discovering local Darebin businesses and contacting them directly. It is not a lead-selling marketplace, quote funnel, merchant of record, or a platform that invents business facts.

--- a/docs/claim-flow-readiness.md
+++ b/docs/claim-flow-readiness.md
@@ -1,10 +1,14 @@
 # Self-Service Claim Flow
 
-Listings are public before, during, and after ownership is claimed. There is no staff queue, approval step, rejection step, or publication gate.
+## Status
+
+This records the current direct email-match implementation. It is not the complete approved public claim policy.
+
+Listings are public before, during, and after ownership is claimed. An exact match to the recorded contact email is the approved normal claim path. The completed product also requires a protected, auditable exception, challenge, recovery and revocation path for conflicts, sensitive changes and non-matching evidence. That exception path is not established merely by the direct claim flow below.
 
 1. A business owner signs in through the magic-link flow using the email address recorded on their listing.
 2. `/claim` calls `list_claimable_vendors_for_current_email()`, which returns only unclaimed listings whose `contact_email` matches the authenticated email.
 3. The owner selects a listing. `claim_vendor_for_current_email(UUID)` locks that row, checks the same email match again, then atomically assigns `owner_id` and sets `is_claimed`.
-4. The owner can update their profile from the dashboard. The listing stays public throughout.
+4. The owner can update their profile from the dashboard. The listing stays public throughout. Sensitive changes and any conflict/revocation path follow the separate approved Ops workflow.
 
 `npm run claim:test` verifies that anonymous users cannot inspect eligible listings, another authenticated email cannot see or claim the listing, the matching email can claim it, and publication survives the claim. The temporary test users and listing are removed afterwards.


### PR DESCRIPTION
## Summary
- Add Target State authority, decision log, execution governance and journey-map updates.
- Add lifecycle/release-state and communications/account-access implementation contracts.
- Record the approved directory-first and staged-release decisions.

## Scope
Documentation and governance only; no deployment, data or feature activation.