### PR TITLE
Harden automation evidence acquisition fallback

### DIFF
--- a/.github/workflows/catalogue-discovery.yml
+++ b/.github/workflows/catalogue-discovery.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm run audit -- data/vendor-candidates-merged.csv
       - run: npm run catalogue:report -- data/vendor-candidates-merged.csv
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: catalogue-candidates-${{ github.run_id }}
           retention-days: 30

--- a/.github/workflows/website-safety.yml
+++ b/.github/workflows/website-safety.yml
@@ -29,7 +29,7 @@ jobs:
           WEBSITE_CHECK_SUPABASE_URL: ${{ secrets.SMOKE_SUPABASE_URL }}
           WEBSITE_CHECK_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SMOKE_SUPABASE_PUBLISHABLE_KEY }}
         run: npm run website-safety
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: website-safety-evidence-${{ github.run_id }}
           retention-days: 30

--- a/scripts/acquire-openstreetmap.ts
+++ b/scripts/acquire-openstreetmap.ts
@@ -14,6 +14,8 @@ export const NON_COMMERCIAL_TOKENS = new Set([
   'ngo', 'charity', 'library', 'townhall'
 ]);
 
+const OVERPASS_REQUEST_TIMEOUT_MS = 20_000;
+
 export function slugify(text: string): string {
   if (!text) return '';
   return text
@@ -30,14 +32,38 @@ export function escapeCsv(val: string): string {
   return val;
 }
 
-export function getTodayAest(): string {
+export function getTodayAest(now: Date = new Date()): string {
   const formatter = new Intl.DateTimeFormat('en-CA', {
     timeZone: 'Australia/Melbourne',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit'
   });
-  return formatter.format(new Date());
+  const parts = Object.fromEntries(
+    formatter.formatToParts(now)
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, part.value]),
+  );
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+export async function requestOverpass(endpoint: string, query: string, fetchImpl: typeof fetch = fetch): Promise<{ elements: any[] }> {
+  const response = await fetchImpl(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json',
+      'User-Agent': 'SuburbMates-directory-importer/1.0 (+https://suburbmates.com.au/contact)',
+    },
+    body: new URLSearchParams({ data: query }),
+    signal: AbortSignal.timeout(OVERPASS_REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`Endpoint returned status ${response.status}`);
+  const data: unknown = await response.json();
+  if (!data || typeof data !== 'object' || !Array.isArray((data as { elements?: unknown }).elements)) {
+    throw new Error('Endpoint returned an invalid Overpass response.');
+  }
+  return data as { elements: any[] };
 }
 
 export function filterAndProcessElements(elements: any[], catchments: string[]): any[] {
@@ -160,24 +186,11 @@ out tags center;`;
   for (const endpoint of endpoints) {
     console.log(`Trying ${endpoint}...`);
     try {
-      const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json',
-        'User-Agent': 'SuburbMates-directory-importer/1.0 (+https://suburbmates.com.au/contact)'
-        },
-        body: `data=${encodeURIComponent(query)}`
-      });
-      if (response.ok) {
-        data = await response.json();
-        console.log(`Successfully fetched from ${endpoint}`);
-        break;
-      } else {
-        console.warn(`Endpoint ${endpoint} returned status ${response.status}`);
-      }
+      data = await requestOverpass(endpoint, query);
+      console.log(`Successfully fetched from ${endpoint}`);
+      break;
     } catch (e) {
-      console.warn(`Error connecting to ${endpoint}:`, e);
+      console.warn(`Endpoint ${endpoint} failed:`, e instanceof Error ? e.message : e);
     }
   }
 

--- a/scripts/acquire-openstreetmap.ts
+++ b/scripts/acquire-openstreetmap.ts
@@ -66,6 +66,30 @@ export async function requestOverpass(endpoint: string, query: string, fetchImpl
   return data as { elements: any[] };
 }
 
+export async function requestFromOverpassEndpoints(
+  endpoints: string[],
+  query: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ elements: any[] }> {
+  let lastError: unknown;
+
+  for (const endpoint of endpoints) {
+    console.log(`Trying ${endpoint}...`);
+    try {
+      const data = await requestOverpass(endpoint, query, fetchImpl);
+      console.log(`Successfully fetched from ${endpoint}`);
+      return data;
+    } catch (error) {
+      lastError = error;
+      console.warn(`Endpoint ${endpoint} failed:`, error instanceof Error ? error.message : error);
+    }
+  }
+
+  throw new Error(
+    `Failed to acquire OSM data from all endpoints${lastError instanceof Error ? `: ${lastError.message}` : ''}`,
+  );
+}
+
 export function filterAndProcessElements(elements: any[], catchments: string[]): any[] {
   const results = [];
   const seen = new Set<string>();
@@ -182,20 +206,11 @@ area["name"="City of Darebin"]->.searchArea;
 );
 out tags center;`;
 
-  let data = null;
-  for (const endpoint of endpoints) {
-    console.log(`Trying ${endpoint}...`);
-    try {
-      data = await requestOverpass(endpoint, query);
-      console.log(`Successfully fetched from ${endpoint}`);
-      break;
-    } catch (e) {
-      console.warn(`Endpoint ${endpoint} failed:`, e instanceof Error ? e.message : e);
-    }
-  }
-
-  if (!data || !data.elements) {
-    console.error('Failed to acquire OSM data from all endpoints.');
+  let data: { elements: any[] };
+  try {
+    data = await requestFromOverpassEndpoints(endpoints, query);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
     process.exit(1);
   }
 

--- a/scripts/test-acquire-openstreetmap.ts
+++ b/scripts/test-acquire-openstreetmap.ts
@@ -1,7 +1,7 @@
-import { filterAndProcessElements, slugify, escapeCsv, COMMERCIAL_AMENITIES } from './acquire-openstreetmap';
+import { filterAndProcessElements, slugify, escapeCsv, getTodayAest, requestOverpass } from './acquire-openstreetmap';
 import assert from 'node:assert';
 
-function runTests() {
+async function runTests() {
   const catchments = ['northcote', 'preston', 'darebin'];
   
   // Test 1: filter out missing name
@@ -58,9 +58,31 @@ function runTests() {
   assert.strictEqual(escapeCsv('Hello "World"'), '"Hello ""World"""');
   assert.strictEqual(escapeCsv('Line\nBreak'), '"Line\nBreak"');
 
+  // Test 8: Melbourne dates stay ISO-formatted across a UTC day boundary.
+  assert.strictEqual(getTodayAest(new Date('2026-07-18T14:30:00Z')), '2026-07-19');
+
+  // Test 9: an Overpass response must be successful JSON with an elements array.
+  const response = await requestOverpass('https://example.test/interpreter', '[out:json];', async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ elements: [] }),
+  }) as Response);
+  assert.deepStrictEqual(response.elements, []);
+  await assert.rejects(
+    requestOverpass('https://example.test/interpreter', '[out:json];', async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ invalid: true }),
+    }) as Response),
+    /invalid Overpass response/,
+  );
+
   console.log('All tests passed.');
 }
 
 if (process.argv[1] && process.argv[1].endsWith('test-acquire-openstreetmap.ts')) {
-  runTests();
+  runTests().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
 }

--- a/scripts/test-acquire-openstreetmap.ts
+++ b/scripts/test-acquire-openstreetmap.ts
@@ -1,4 +1,4 @@
-import { filterAndProcessElements, slugify, escapeCsv, getTodayAest, requestOverpass } from './acquire-openstreetmap';
+import { filterAndProcessElements, slugify, escapeCsv, getTodayAest, requestFromOverpassEndpoints, requestOverpass } from './acquire-openstreetmap';
 import assert from 'node:assert';
 
 async function runTests() {
@@ -76,6 +76,29 @@ async function runTests() {
     }) as Response),
     /invalid Overpass response/,
   );
+
+  // Test 10: a failed provider leaves a clear trail and the next provider can supply the evidence.
+  const attemptedEndpoints: string[] = [];
+  const fallbackResponse = await requestFromOverpassEndpoints(
+    ['https://first.example.test/interpreter', 'https://second.example.test/interpreter'],
+    '[out:json];',
+    async (endpoint) => {
+      attemptedEndpoints.push(String(endpoint));
+      if (String(endpoint).includes('first')) {
+        throw new Error('provider unavailable');
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ elements: [] }),
+      } as Response;
+    },
+  );
+  assert.deepStrictEqual(attemptedEndpoints, [
+    'https://first.example.test/interpreter',
+    'https://second.example.test/interpreter',
+  ]);
+  assert.deepStrictEqual(fallbackResponse.elements, []);
 
   console.log('All tests passed.');
 }


### PR DESCRIPTION
## Summary
- Bound external Overpass requests with a timeout.
- Reject malformed responses.
- Fall back to the next configured source on failure.
- Add regression coverage and update GitHub artifact actions.

## Safety
This does not write to Supabase, publish listings, alter claims, or change holding mode.

## Verification
- `npm run acquire:osm:test`
- `npm run check`
- web lint
- production build with webpack