### PR TITLE
Prepare resident discovery journey for launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -18,6 +18,7 @@
     "catalogue:report": "tsx scripts/report-catalogue-coverage.ts",
     "public-catalogue:test": "tsx scripts/test-public-catalogue-pagination.ts",
     "directory-ranking:test": "tsx scripts/test-directory-ranking-policy.ts",
+    "resident-journey:test": "tsx scripts/test-resident-journey-policy.ts",
     "edge-functions:test": "tsx scripts/test-disabled-edge-functions.ts",
     "vendor-slug:test": "tsx scripts/test-vendor-slug-policy.ts",
     "website-safety": "node scripts/website-safety.mjs",

--- a/scripts/test-resident-journey-policy.ts
+++ b/scripts/test-resident-journey-policy.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+async function source(path: string) {
+  return readFile(path, "utf8");
+}
+
+async function run() {
+  const [home, browse, taxonomy, profile, contact] = await Promise.all([
+    source("web/src/app/(directory)/page.tsx"),
+    source("web/src/app/(directory)/businesses/page.tsx"),
+    source("web/src/app/(directory)/[suburb]/[service]/page.tsx"),
+    source("web/src/app/vendor/[slug]/page.tsx"),
+    source("web/src/components/minisite/contact/ContactComponents.tsx"),
+  ]);
+
+  assert.match(home, /NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED/, "public home must remain behind the launch flag");
+  assert.match(home, /<LaunchPage\s*\/>/, "holding home must remain available before release");
+  assert.match(browse, /vendorsError/, "directory fetch failures must not appear as an empty result");
+  assert.match(taxonomy, /vendorsRes\.error/, "taxonomy fetch failures must not appear as an empty result");
+  assert.doesNotMatch(browse, /tier === "premium"/, "public browse must not present an unapproved premium tier");
+  assert.doesNotMatch(taxonomy, /tier === "premium"/, "taxonomy results must not present an unapproved premium tier");
+  assert.match(contact, /google\.com\/maps\/search/, "public address must provide a directions action");
+  assert.match(profile, /listing_correction/, "profiles must provide a safe report-problem entry point");
+
+  console.log("Resident journey policy tests passed.");
+}
+
+await run();

--- a/web/src/app/(directory)/[suburb]/[service]/error.tsx
+++ b/web/src/app/(directory)/[suburb]/[service]/error.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function TaxonomyDirectoryError({ reset }: { reset: () => void }) {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-24 text-center">
+      <h1 className="text-3xl font-black tracking-tight">These directory results are temporarily unavailable</h1>
+      <p className="mt-4 text-slate-600">No listing has changed. Please try again in a moment.</p>
+      <button type="button" onClick={reset} className="btn btn-primary mt-8">Try again</button>
+    </main>
+  );
+}

--- a/web/src/app/(directory)/[suburb]/[service]/page.tsx
+++ b/web/src/app/(directory)/[suburb]/[service]/page.tsx
@@ -55,7 +55,7 @@ export default async function Page({ params }: PageProps) {
       .single(),
     supabase
       .from("published_vendors")
-      .select("id, slug, business_name, description, contact_email, phone, website, tier, is_claimed, street_address")
+      .select("id, slug, business_name, description, contact_email, phone, website, is_claimed, street_address")
       .eq("suburb_slug", suburbSlug)
       .eq("category_slug", serviceSlug)
       .order("business_name", { ascending: true })
@@ -68,6 +68,9 @@ export default async function Page({ params }: PageProps) {
 
   const suburb = suburbRes.data;
   const category = categoryRes.data;
+  if (vendorsRes.error) {
+    throw new Error("The directory results could not be loaded.");
+  }
   const vendors = vendorsRes.data || [];
 
   return (
@@ -116,34 +119,25 @@ export default async function Page({ params }: PageProps) {
             </div>
             <h3 className="text-2xl font-black tracking-tight mb-3">No Businesses Listed Yet</h3>
             <p className="text-slate-600 mb-8 max-w-sm mx-auto leading-relaxed">
-              We don&apos;t have any local {category.name.toLowerCase()} registered in {suburb.name} at this time.
+              We don&apos;t have any local {category.name.toLowerCase()} listings in {suburb.name} at this time.
             </p>
             <Link
               href="/join"
               className="btn btn-primary"
               aria-label={`List your ${category.name.toLowerCase()} business in ${suburb.name}`}
             >
-              List your business
+              Suggest a business
             </Link>
           </div>
         ) : (
           /* List of Providers */
           <div className="grid gap-6">
             {vendors.map((vendor) => {
-              const isPremium = vendor.tier === "premium";
               return (
                 <article
                   key={vendor.id}
-                  className={`card relative overflow-hidden transition-all duration-300 ${
-                    isPremium ? 'border-black ring-1 ring-black/10' : 'border-slate-200'
-                  }`}
+                  className="card relative overflow-hidden transition-all duration-300 border-slate-200"
                 >
-                  {/* Premium Badge */}
-                  {isPremium && (
-                    <div className="absolute top-0 right-0 bg-black text-white text-[10px] font-black uppercase tracking-widest px-3 py-1 rounded-bl">
-                      Featured
-                    </div>
-                  )}
 
                   <div className="flex flex-col md:flex-row md:items-start justify-between gap-6">
                     <div className="flex-1">

--- a/web/src/app/(directory)/businesses/error.tsx
+++ b/web/src/app/(directory)/businesses/error.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export default function DirectoryError({ reset }: { reset: () => void }) {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-24 text-center">
+      <h1 className="text-3xl font-black tracking-tight">The directory is temporarily unavailable</h1>
+      <p className="mt-4 text-slate-600">No search or listing change was made. Please try again in a moment.</p>
+      <button type="button" onClick={reset} className="btn btn-primary mt-8">Try again</button>
+    </main>
+  );
+}

--- a/web/src/app/(directory)/businesses/page.tsx
+++ b/web/src/app/(directory)/businesses/page.tsx
@@ -54,7 +54,7 @@ export default async function BusinessesPage({
   // 2. Fetch clamped page data
   let query = supabase
     .from('published_vendors')
-    .select('id, slug, business_name, description, contact_email, phone, website, tier, is_claimed, street_address, suburb_slug, category_slug');
+    .select('id, slug, business_name, description, contact_email, phone, website, is_claimed, street_address, suburb_slug, category_slug');
 
   if (escapedQ) query = query.ilike('business_name', `%${escapedQ}%`);
   if (suburb) query = query.eq('suburb_slug', suburb);
@@ -66,7 +66,11 @@ export default async function BusinessesPage({
   const to = from + pageSize - 1;
   query = query.range(from, to);
 
-  const { data: vendors } = await query;
+  const { data: vendors, error: vendorsError } = await query;
+
+  if (suburbsRes.error || categoriesRes.error || vendorsError) {
+    throw new Error("The directory could not be loaded.");
+  }
 
   return (
     <DirectoryBrowseClient

--- a/web/src/app/(directory)/contact/page.tsx
+++ b/web/src/app/(directory)/contact/page.tsx
@@ -15,10 +15,12 @@ export const metadata: Metadata = {
 export default async function ContactPage({
   searchParams,
 }: {
-  searchParams: Promise<{ sent?: string; error?: string }>;
+  searchParams: Promise<{ sent?: string; error?: string; topic?: string; business?: string }>;
 }) {
   const message = await searchParams;
   const siteKey = runtimeEnv("TURNSTILE_SITE_KEY");
+  const initialTopic = message.topic === "listing_correction" ? "listing_correction" : "general";
+  const initialBusiness = typeof message.business === "string" ? message.business.slice(0, 200) : "";
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-16">
@@ -78,7 +80,7 @@ export default async function ContactPage({
 
             <label className="block text-sm font-bold">
               What do you need help with?
-              <select name="topic" required defaultValue="general" className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal">
+              <select name="topic" required defaultValue={initialTopic} className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal">
                 <option value="general">General support</option>
                 <option value="listing_correction">Correct a listing</option>
                 <option value="claim_help">Claim help</option>
@@ -91,7 +93,7 @@ export default async function ContactPage({
 
             <label className="block text-sm font-bold">
               Business name <span className="font-normal text-slate-500">(optional)</span>
-              <input name="businessName" maxLength={200} autoComplete="organization" className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" />
+              <input name="businessName" defaultValue={initialBusiness} maxLength={200} autoComplete="organization" className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" />
             </label>
 
             <label className="block text-sm font-bold">

--- a/web/src/app/(directory)/page.tsx
+++ b/web/src/app/(directory)/page.tsx
@@ -1,7 +1,34 @@
+import { HomeClient } from "@/components/ui/HomeClient";
 import { LaunchPage } from "@/components/ui/LaunchPage";
+import { createClient } from "@/utils/supabase/server";
 
 export const dynamic = "force-dynamic";
 
-export default function Home() {
-  return <LaunchPage />;
+export default async function Home() {
+  if (process.env.NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED !== "true") {
+    return <LaunchPage />;
+  }
+
+  const supabase = await createClient();
+  const [categoriesResult, suburbsResult, listingsResult] = await Promise.all([
+    supabase.from("categories").select("name, slug").order("name"),
+    supabase.from("suburbs").select("name, slug").order("name"),
+    supabase
+      .from("published_vendors")
+      .select("id, slug, business_name, description, phone, website, street_address, suburbs(name)")
+      .order("business_name", { ascending: true })
+      .limit(6),
+  ]);
+
+  if (categoriesResult.error || suburbsResult.error || listingsResult.error) {
+    throw new Error("The directory home could not be loaded.");
+  }
+
+  return (
+    <HomeClient
+      categories={categoriesResult.data ?? []}
+      suburbs={suburbsResult.data ?? []}
+      featuredVendors={listingsResult.data ?? []}
+    />
+  );
 }

--- a/web/src/app/vendor/[slug]/page.tsx
+++ b/web/src/app/vendor/[slug]/page.tsx
@@ -145,7 +145,7 @@ export default async function VendorWebsite({ params }: PageProps) {
               </section>
             </div>
             <div className="space-y-6">
-              <ContactSticky data={vendor} styling={design} />
+              <ContactSticky data={{ ...vendor, suburb_name: vendor.suburbs?.name }} styling={design} />
             </div>
           </div>
         ) : (
@@ -160,7 +160,7 @@ export default async function VendorWebsite({ params }: PageProps) {
                 </div>
               </section>
             </div>
-            <ContactInline data={vendor} styling={design} />
+            <ContactInline data={{ ...vendor, suburb_name: vendor.suburbs?.name }} styling={design} />
           </div>
         )}
       </main>
@@ -185,6 +185,12 @@ export default async function VendorWebsite({ params }: PageProps) {
               SuburbMates
             </Link>
           </div>
+          <Link
+            href={`/contact?topic=listing_correction&business=${encodeURIComponent(vendor.business_name)}`}
+            className="text-xs underline hover:text-white transition-colors"
+          >
+            Report a problem with this listing
+          </Link>
         </div>
       </footer>
     </div>

--- a/web/src/components/minisite/contact/ContactComponents.tsx
+++ b/web/src/components/minisite/contact/ContactComponents.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Phone, Mail, Globe, MapPin } from "lucide-react";
+import { Phone, Mail, Globe, Navigation } from "lucide-react";
 import type { getVendorDesign } from "@/lib/minisite/engine";
 
 type ContactData = {
@@ -7,6 +7,7 @@ type ContactData = {
   phone?: string | null;
   contact_email?: string | null;
   website?: string | null;
+  suburb_name?: string | null;
 };
 
 type MinisiteStyling = ReturnType<typeof getVendorDesign>;
@@ -51,15 +52,21 @@ function ContactGridItems({
   return (
     <>
       {data.street_address && (
-        <div className={`flex items-center gap-4 p-4 ${corners.btn} ${palette.btnSecondary}`}>
+        <a
+          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent([data.street_address, data.suburb_name].filter(Boolean).join(", "))}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`flex items-center gap-4 p-4 transition-all group ${corners.btn} ${palette.btnSecondary}`}
+          aria-label={`Get directions to ${data.street_address}`}
+        >
           <div className={`w-12 h-12 flex items-center justify-center shrink-0 opacity-80 ${corners.btn}`}>
-            <MapPin size={20} />
+            <Navigation size={20} />
           </div>
           <div>
-            <div className="text-xs font-bold uppercase tracking-wider mb-0.5 opacity-60">Address</div>
+            <div className="text-xs font-bold uppercase tracking-wider mb-0.5 opacity-60">Get directions</div>
             <div className="font-bold">{data.street_address}</div>
           </div>
-        </div>
+        </a>
       )}
       {data.phone && (
         <a href={`tel:${data.phone}`} className={`flex items-center gap-4 p-4 transition-all group ${corners.btn} ${palette.btnSecondary}`}>

--- a/web/src/components/minisite/heroes/HeroSplit.tsx
+++ b/web/src/components/minisite/heroes/HeroSplit.tsx
@@ -51,10 +51,10 @@ export function HeroSplit({ data, styling }: { data: MinisiteVendor; styling: Ve
                   <CheckCircle size={24} />
                 </div>
                 <div>
-                  <h3 className="font-bold text-lg">{data.is_claimed ? "Approved Owner" : "Ownership Available for Review"}</h3>
+                  <h3 className="font-bold text-lg">{data.is_claimed ? "Profile ownership recorded" : "Ownership available to claim"}</h3>
                   <p className="text-white/60 text-sm mt-1">
                     {data.is_claimed
-                      ? "The approved owner can submit profile changes for review."
+                      ? "The recorded owner can submit profile changes for review. This does not verify every public fact."
                       : "The business owner can submit an evidence-backed ownership request."}
                   </p>
                 </div>

--- a/web/src/components/ui/DirectoryBrowseClient.tsx
+++ b/web/src/components/ui/DirectoryBrowseClient.tsx
@@ -13,7 +13,6 @@ type DirectoryVendor = {
   contact_email: string | null;
   phone: string | null;
   website: string | null;
-  tier: string;
   is_claimed: boolean;
   street_address: string | null;
   suburb_slug: string;
@@ -89,7 +88,9 @@ export function DirectoryBrowseClient({
           <form onSubmit={handleSearch} className="flex flex-col md:flex-row gap-4">
             <div className="flex-1 relative">
               <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+              <label className="sr-only" htmlFor="directory-search">Search by business name</label>
               <input
+                id="directory-search"
                 type="text"
                 placeholder="Search by business name..."
                 value={q}
@@ -99,7 +100,9 @@ export function DirectoryBrowseClient({
             </div>
             
             <div className="md:w-64">
+              <label className="sr-only" htmlFor="directory-category">Filter by category</label>
               <select
+                id="directory-category"
                 value={category}
                 onChange={(e) => {
                   setCategory(e.target.value);
@@ -115,7 +118,9 @@ export function DirectoryBrowseClient({
             </div>
 
             <div className="md:w-64">
+              <label className="sr-only" htmlFor="directory-suburb">Filter by suburb</label>
               <select
+                id="directory-suburb"
                 value={suburb}
                 onChange={(e) => {
                   setSuburb(e.target.value);
@@ -163,22 +168,14 @@ export function DirectoryBrowseClient({
         ) : (
           <div className="grid gap-6">
             {vendors.map((vendor) => {
-              const isPremium = vendor.tier === "premium";
               const subName = suburbs.find(s => s.slug === vendor.suburb_slug)?.name || vendor.suburb_slug;
               const catName = categories.find(c => c.slug === vendor.category_slug)?.name || vendor.category_slug;
 
               return (
                 <article
                   key={vendor.id}
-                  className={`card relative overflow-hidden transition-all duration-300 bg-white p-6 rounded-xl ${
-                    isPremium ? 'border-black ring-1 ring-black/10 shadow-md' : 'border border-slate-200 shadow-sm hover:shadow-md hover:border-slate-300'
-                  }`}
+                  className="card relative overflow-hidden transition-all duration-300 bg-white p-6 rounded-xl border border-slate-200 shadow-sm hover:shadow-md hover:border-slate-300"
                 >
-                  {isPremium && (
-                    <div className="absolute top-0 right-0 bg-black text-white text-[10px] font-black uppercase tracking-widest px-3 py-1 rounded-bl">
-                      Featured
-                    </div>
-                  )}
 
                   <div className="flex flex-col md:flex-row md:items-start justify-between gap-6">
                     <div className="flex-1">

--- a/web/src/components/ui/HomeClient.tsx
+++ b/web/src/components/ui/HomeClient.tsx
@@ -18,7 +18,6 @@ interface HomeClientProps {
     description: string | null;
     phone: string | null;
     website: string | null;
-    tier: string;
     street_address: string | null;
     suburbs: Array<{ name: string }>;
   }>;
@@ -152,12 +151,12 @@ export function HomeClient({ categories, suburbs, featuredVendors }: HomeClientP
         </div>
       </section>
 
-      {/* ── Featured Vendors ─────────────────────────────────────── */}
+      {/* ── Local businesses ─────────────────────────────────────── */}
       {featuredVendors && featuredVendors.length > 0 && (
         <section
           className="py-24"
           style={{ backgroundColor: "var(--sm-surface-default)" }}
-          aria-label="Featured Providers"
+          aria-label="Local businesses"
         >
           <div className="max-w-7xl mx-auto px-6">
             <motion.div
@@ -168,7 +167,7 @@ export function HomeClient({ categories, suburbs, featuredVendors }: HomeClientP
             >
               <motion.div variants={fadeInUp} className="mb-12">
                 <h2 className="text-3xl font-black tracking-tight mb-4" style={{ color: "var(--sm-text-primary)" }}>
-                  Featured Local Businesses
+                  Local Businesses
                 </h2>
                 <p className="text-lg" style={{ color: "var(--sm-text-secondary)" }}>
                   A selection of real businesses from across the local directory.
@@ -182,11 +181,6 @@ export function HomeClient({ categories, suburbs, featuredVendors }: HomeClientP
                     variants={fadeInUp}
                     className="card relative overflow-hidden transition-all duration-300 border-slate-200 hover:border-black hover:shadow-lg flex flex-col h-full"
                   >
-                    {vendor.tier === "premium" && (
-                      <div className="absolute top-0 right-0 bg-black text-white text-[10px] font-black uppercase tracking-widest px-3 py-1 rounded-bl">
-                        Featured
-                      </div>
-                    )}
                     <div className="flex-1 p-6">
                       <div className="flex flex-wrap items-center gap-3 mb-3">
                         <h3 className="text-xl font-black tracking-tight text-black">


### PR DESCRIPTION
## Summary
- Keep the holding page active until the existing release flag is explicitly enabled.
- Render the directory home only after that flag, using neutral alphabetical listings.
- Add directions and a prefilled safe reporting entry point on listing profiles.
- Add clear directory error recovery, accessible browse labels, and remove unapproved premium presentation.

## Not included
- No release activation, database migration, publication change, new email, or full report-workflow change.

## Verification
- `npm run resident-journey:test`
- `npm run check`
- web lint
- production build with webpack