### PR TITLE
Fix Ops audit projection migration

### DIFF
--- a/scripts/test-ops-system-boundary.ts
+++ b/scripts/test-ops-system-boundary.ts
@@ -5,6 +5,7 @@ const migration = fs.readFileSync("supabase/migrations/20260720080458_ops_audit_
 const page = fs.readFileSync("web/src/app/ops/system/page.tsx", "utf8");
 
 assert.match(migration, /CREATE OR REPLACE FUNCTION private\.redact_ops_audit_state/);
+assert.match(migration, /DROP FUNCTION IF EXISTS public\.ops_list_audit_events\(INTEGER\)/);
 assert.match(migration, /PERFORM private\.require_active_operator\(\)/);
 assert.match(migration, /REVOKE ALL ON FUNCTION public\.ops_list_audit_events\(INTEGER\) FROM PUBLIC, anon, service_role/);
 assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.ops_list_audit_events\(INTEGER\) TO authenticated/);

--- a/supabase/migrations/20260720080458_ops_audit_evidence_projection.sql
+++ b/supabase/migrations/20260720080458_ops_audit_evidence_projection.sql
@@ -19,6 +19,10 @@ $$;
 
 REVOKE ALL ON FUNCTION private.redact_ops_audit_state(JSONB) FROM PUBLIC, anon, authenticated, service_role;
 
+-- PostgreSQL cannot replace a function when its OUT-column row type changes.
+-- This migration is intentionally safe to apply over the earlier audit feed.
+DROP FUNCTION IF EXISTS public.ops_list_audit_events(INTEGER);
+
 CREATE OR REPLACE FUNCTION public.ops_list_audit_events(p_limit INTEGER DEFAULT 50)
 RETURNS TABLE (
   event_id UUID, actor_type TEXT, action TEXT, entity_type TEXT,


### PR DESCRIPTION
## Summary
- drop the prior protected audit function before recreating it with its changed safe result shape
- add regression coverage for PostgreSQL output-row replacement rules

## Verification
- `npm run ops-system:test`
- executed the migration against the live database inside a transaction, verified the new result shape, then rolled it back

No production data or function was changed during verification.