### PR TITLE
Complete owner request recovery journey

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "vendor-slug:test": "tsx scripts/test-vendor-slug-policy.ts",
     "website-safety": "node scripts/website-safety.mjs",
     "website-safety:test": "node scripts/test-website-safety.mjs",
-    "owner-status:test": "tsx scripts/test-owner-status-boundary.ts",
+    "owner-status:test": "tsx scripts/test-owner-status-boundary.ts && npm run owner-request-withdrawal:test",
+    "owner-request-withdrawal:test": "tsx scripts/test-owner-request-withdrawal-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },

--- a/scripts/test-owner-request-withdrawal-boundary.ts
+++ b/scripts/test-owner-request-withdrawal-boundary.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync("supabase/migrations/20260720125025_owner_request_withdrawal.sql", "utf8");
+
+for (const functionName of [
+  "list_current_owner_claim_requests()",
+  "withdraw_current_owner_claim(UUID)",
+  "withdraw_current_owner_profile_change(UUID)",
+]) {
+  assert.match(source, new RegExp(`REVOKE ALL ON FUNCTION public\\.${functionName.replace(/[()]/g, "\\$&")} FROM PUBLIC, anon, service_role`));
+}
+
+assert.match(source, /CREATE OR REPLACE FUNCTION public\.withdraw_current_owner_claim\(p_claim_request_id UUID\)/);
+assert.match(source, /claim\.claimant_user_id = v_user_id/);
+assert.match(source, /claim\.claim_status IN \('pending', 'needs_information'\)/);
+assert.match(source, /'claim_withdrawn'/);
+assert.match(source, /CREATE OR REPLACE FUNCTION public\.withdraw_current_owner_profile_change\(p_change_request_id UUID\)/);
+assert.match(source, /change\.submitted_by = v_user_id/);
+assert.match(source, /change\.change_status = 'pending'/);
+assert.match(source, /'profile_change_withdrawn'/);
+assert.match(source, /'publication_unchanged', v_vendor\.is_published/);
+
+for (const forbidden of ["SET owner_id =", "is_published = true", "GRANT EXECUTE ON FUNCTION public.withdraw_current_owner_claim(UUID) TO anon"]) {
+  assert(!source.includes(forbidden), `Owner withdrawal must not contain ${forbidden}.`);
+}
+
+console.log("Owner-request withdrawal security boundary checks passed.");

--- a/supabase/migrations/20260720125025_owner_request_withdrawal.sql
+++ b/supabase/migrations/20260720125025_owner_request_withdrawal.sql
@@ -1,0 +1,157 @@
+-- Owners can see their own request references and withdraw only requests that
+-- are still awaiting a decision. Withdrawal never changes publication or
+-- grants/revokes ownership.
+
+CREATE OR REPLACE FUNCTION public.list_current_owner_claim_requests()
+RETURNS TABLE (
+  claim_request_id UUID,
+  business_name TEXT,
+  claim_status TEXT,
+  created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Authentication is required.';
+  END IF;
+
+  RETURN QUERY
+  SELECT claim.id, vendor.business_name, claim.claim_status, claim.created_at
+  FROM public.claim_requests AS claim
+  JOIN public.vendors AS vendor ON vendor.id = claim.vendor_id
+  WHERE claim.claimant_user_id = v_user_id
+  ORDER BY claim.created_at DESC;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.withdraw_current_owner_claim(p_claim_request_id UUID)
+RETURNS TABLE (claim_request_id UUID, claim_status TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_claim public.claim_requests%ROWTYPE;
+  v_vendor public.vendors%ROWTYPE;
+  v_now TIMESTAMPTZ := timezone('utc'::text, now());
+  v_correlation_id UUID := extensions.uuid_generate_v4();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Authentication is required.';
+  END IF;
+
+  SELECT * INTO v_claim
+  FROM public.claim_requests AS claim
+  WHERE claim.id = p_claim_request_id
+    AND claim.claimant_user_id = v_user_id
+    AND claim.claim_status IN ('pending', 'needs_information')
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'This claim can no longer be withdrawn.';
+  END IF;
+
+  SELECT * INTO v_vendor
+  FROM public.vendors AS vendor
+  WHERE vendor.id = v_claim.vendor_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = '02000', MESSAGE = 'Listing not found.';
+  END IF;
+
+  UPDATE public.claim_requests AS claim
+  SET claim_status = 'withdrawn',
+      decided_at = v_now,
+      updated_at = v_now
+  WHERE claim.id = v_claim.id;
+
+  UPDATE public.vendors AS vendor
+  SET ownership_status = 'unclaimed',
+      updated_at = v_now
+  WHERE vendor.id = v_vendor.id
+    AND vendor.owner_id IS NULL
+    AND vendor.is_claimed = false
+    AND vendor.ownership_status = 'claim_pending';
+
+  INSERT INTO public.audit_events (
+    actor_type, actor_user_id, action, entity_type, entity_id, reason,
+    before_data, after_data, correlation_id
+  ) VALUES (
+    'owner', v_user_id, 'claim_withdrawn', 'claim_request', v_claim.id::text, NULL,
+    jsonb_build_object('claim_status', v_claim.claim_status, 'vendor_id', v_claim.vendor_id),
+    jsonb_build_object('claim_status', 'withdrawn', 'vendor_id', v_claim.vendor_id, 'publication_unchanged', v_vendor.is_published),
+    v_correlation_id
+  );
+
+  RETURN QUERY SELECT v_claim.id, 'withdrawn'::TEXT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.withdraw_current_owner_profile_change(p_change_request_id UUID)
+RETURNS TABLE (change_request_id UUID, change_status TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_change public.listing_change_requests%ROWTYPE;
+  v_now TIMESTAMPTZ := timezone('utc'::text, now());
+  v_correlation_id UUID := extensions.uuid_generate_v4();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Authentication is required.';
+  END IF;
+
+  SELECT * INTO v_change
+  FROM public.listing_change_requests AS change
+  WHERE change.id = p_change_request_id
+    AND change.submitted_by = v_user_id
+    AND change.change_status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'This profile-change request can no longer be withdrawn.';
+  END IF;
+
+  UPDATE public.listing_change_requests AS change
+  SET change_status = 'withdrawn',
+      decided_at = v_now,
+      updated_at = v_now
+  WHERE change.id = v_change.id;
+
+  INSERT INTO public.audit_events (
+    actor_type, actor_user_id, action, entity_type, entity_id, reason,
+    before_data, after_data, correlation_id
+  ) VALUES (
+    'owner', v_user_id, 'profile_change_withdrawn', 'listing_change_request', v_change.id::text, NULL,
+    jsonb_build_object('change_status', v_change.change_status, 'vendor_id', v_change.vendor_id),
+    jsonb_build_object('change_status', 'withdrawn', 'vendor_id', v_change.vendor_id),
+    v_correlation_id
+  );
+
+  RETURN QUERY SELECT v_change.id, 'withdrawn'::TEXT;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.list_current_owner_claim_requests() FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.withdraw_current_owner_claim(UUID) FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.withdraw_current_owner_profile_change(UUID) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.list_current_owner_claim_requests() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.withdraw_current_owner_claim(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.withdraw_current_owner_profile_change(UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.list_current_owner_claim_requests() IS
+  'Owner-scoped claim references for dashboard presentation. It never exposes another requester or writes data.';
+COMMENT ON FUNCTION public.withdraw_current_owner_claim(UUID) IS
+  'Owner-scoped withdrawal of a pending claim. It never changes publication or grants ownership.';
+COMMENT ON FUNCTION public.withdraw_current_owner_profile_change(UUID) IS
+  'Owner-scoped withdrawal of a pending profile-change request. It never applies a public profile change.';

--- a/web/src/app/(directory)/claim/ClaimClient.tsx
+++ b/web/src/app/(directory)/claim/ClaimClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { createClient } from "@/utils/supabase/client";
 import { Building, MapPin, Tag, CheckCircle2, AlertCircle, Mail } from "lucide-react";
 
@@ -83,8 +84,9 @@ export default function ClaimClient() {
           <Mail className="mx-auto mb-4 text-slate-400" size={28} />
           <h2 className="text-xl font-bold">No listing is ready for a claim request</h2>
           <p className="mt-2 text-sm text-slate-600">
-            This email does not match an unclaimed listing contact. The business can remain publicly listed while its contact details are updated.
+            This email does not match an unclaimed listing contact. You can ask for private claim help; an operator will review the evidence and the listing will not change automatically.
           </p>
+          <Link href="/contact?topic=claim_help" className="btn btn-outline mt-5">Ask for claim help</Link>
         </div>
       )}
 

--- a/web/src/app/(directory)/contact/page.tsx
+++ b/web/src/app/(directory)/contact/page.tsx
@@ -19,7 +19,7 @@ export default async function ContactPage({
 }) {
   const message = await searchParams;
   const siteKey = runtimeEnv("TURNSTILE_SITE_KEY");
-  const initialTopic = message.topic === "listing_correction" ? "listing_correction" : "general";
+  const initialTopic = message.topic === "listing_correction" || message.topic === "claim_help" ? message.topic : "general";
   const initialBusiness = typeof message.business === "string" ? message.business.slice(0, 200) : "";
 
   return (

--- a/web/src/app/(directory)/dashboard/ClaimRequests.tsx
+++ b/web/src/app/(directory)/dashboard/ClaimRequests.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { AlertCircle, CheckCircle2 } from "lucide-react";
+import { createClient } from "@/utils/supabase/client";
+
+type ClaimRequest = {
+  claim_request_id: string;
+  business_name: string;
+  claim_status: string;
+  created_at: string;
+};
+
+export default function ClaimRequests({ initialRequests }: { initialRequests: ClaimRequest[] }) {
+  const [requests, setRequests] = useState(initialRequests);
+  const [withdrawingId, setWithdrawingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const supabase = createClient();
+
+  const withdraw = async (requestId: string) => {
+    setWithdrawingId(requestId);
+    setError(null);
+    setSuccess(null);
+    const { error: withdrawalError } = await supabase.rpc("withdraw_current_owner_claim", {
+      p_claim_request_id: requestId,
+    });
+
+    if (withdrawalError) {
+      setError(withdrawalError.message || "We could not withdraw that request. Please try again.");
+    } else {
+      setRequests((current) => current.map((request) => request.claim_request_id === requestId ? { ...request, claim_status: "withdrawn" } : request));
+      setSuccess("Your claim request was withdrawn. The business listing was not changed.");
+    }
+    setWithdrawingId(null);
+  };
+
+  if (requests.length === 0) return null;
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-2xl font-bold">Your ownership requests</h2>
+        <p className="mt-1 text-sm text-slate-600">A request does not change the public listing unless an operator approves it.</p>
+      </div>
+      {error && <div className="flex gap-3 rounded-lg bg-red-50 p-4 text-sm text-red-800"><AlertCircle size={20} className="shrink-0" /><p>{error}</p></div>}
+      {success && <div className="flex gap-3 rounded-lg bg-green-50 p-4 text-sm text-green-800"><CheckCircle2 size={20} className="shrink-0" /><p>{success}</p></div>}
+      <div className="grid gap-4">
+        {requests.map((request) => {
+          const canWithdraw = request.claim_status === "pending" || request.claim_status === "needs_information";
+          return <div key={request.claim_request_id} className="rounded-2xl border bg-white p-5 shadow-sm sm:flex sm:items-center sm:justify-between sm:gap-6">
+            <div>
+              <h3 className="font-bold">{request.business_name}</h3>
+              <p className="mt-1 text-sm text-slate-600">Status: {statusLabel(request.claim_status)}</p>
+            </div>
+            {canWithdraw && <button type="button" onClick={() => withdraw(request.claim_request_id)} disabled={withdrawingId === request.claim_request_id} className="btn btn-outline mt-4 text-sm sm:mt-0">
+              {withdrawingId === request.claim_request_id ? "Withdrawing…" : "Withdraw request"}
+            </button>}
+          </div>;
+        })}
+      </div>
+    </section>
+  );
+}
+
+function statusLabel(status: string) {
+  return status.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}

--- a/web/src/app/(directory)/dashboard/ProfileEditor.tsx
+++ b/web/src/app/(directory)/dashboard/ProfileEditor.tsx
@@ -34,6 +34,7 @@ export default function ProfileEditor({ vendor, latestChange }: { vendor: Vendor
   const [submitted, setSubmitted] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [withdrawn, setWithdrawn] = useState(false);
 
   const supabase = createClient();
 
@@ -64,13 +65,30 @@ export default function ProfileEditor({ vendor, latestChange }: { vendor: Vendor
     setLoading(false);
   };
 
+  const handleWithdraw = async () => {
+    if (!latestChange) return;
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+    const { error } = await supabase.rpc("withdraw_current_owner_profile_change", {
+      p_change_request_id: latestChange.change_request_id,
+    });
+    if (error) {
+      setError(error.message || "We could not withdraw this request. Please try again.");
+    } else {
+      setWithdrawn(true);
+      setSuccess("Your profile-change request was withdrawn. Your public listing was not changed.");
+    }
+    setLoading(false);
+  };
+
   return (
     <form onSubmit={handleSave} className="space-y-6 mt-6 border-t border-slate-100 pt-6">
       <p className="text-sm text-slate-600">
         Edits are reviewed before they appear publicly. Your current listing stays unchanged while a request is pending.
       </p>
 
-      {(latestChange?.change_status === "pending" || submitted) && (
+      {(latestChange?.change_status === "pending" || submitted) && !withdrawn && (
         <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">
           Changes awaiting review. A new request can be submitted after this one is decided.
         </div>
@@ -153,13 +171,18 @@ export default function ProfileEditor({ vendor, latestChange }: { vendor: Vendor
         </div>
       )}
 
-      <div className="flex justify-end pt-4">
+      <div className="flex flex-wrap justify-end gap-3 pt-4">
+        {latestChange?.change_status === "pending" && !withdrawn && (
+          <button type="button" onClick={handleWithdraw} disabled={loading} className="btn btn-outline px-6">
+            {loading ? "Withdrawing…" : "Withdraw request"}
+          </button>
+        )}
         <button 
           type="submit" 
-          disabled={loading || latestChange?.change_status === "pending" || submitted}
+          disabled={loading || (latestChange?.change_status === "pending" && !withdrawn) || submitted}
           className="btn btn-primary px-8"
         >
-          {loading ? "Submitting…" : latestChange?.change_status === "pending" || submitted ? "Awaiting review" : "Submit changes for review"}
+          {loading ? "Submitting…" : (latestChange?.change_status === "pending" && !withdrawn) || submitted ? "Awaiting review" : "Submit changes for review"}
         </button>
       </div>
     </form>

--- a/web/src/app/(directory)/dashboard/page.tsx
+++ b/web/src/app/(directory)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from '@/utils/supabase/server'
 import Link from 'next/link'
 import { ExternalLink } from 'lucide-react'
 import ProfileEditor from './ProfileEditor'
+import ClaimRequests from './ClaimRequests'
 
 type OwnerVendor = {
   id: string
@@ -19,6 +20,22 @@ type OwnerVendor = {
   description: string | null
 }
 
+type RequestStatus = {
+  request_type: string
+  request_status: string
+  safe_operator_reason: string
+  next_step: string
+  submitted_at: string
+  decided_at: string | null
+}
+
+type ClaimRequest = {
+  claim_request_id: string
+  business_name: string
+  claim_status: string
+  created_at: string
+}
+
 export default async function DashboardPage() {
   const supabase = await createClient()
   
@@ -32,6 +49,10 @@ export default async function DashboardPage() {
   const ownedVendors = ownerVendorRows as OwnerVendor[] | null
 
   const { data: profileChanges } = await supabase.rpc('list_current_owner_profile_changes')
+  const { data: requestStatuses } = await supabase.rpc('list_current_owner_request_statuses')
+  const { data: claimRequests } = await supabase.rpc('list_current_owner_claim_requests')
+  const ownerRequestStatuses = (requestStatuses ?? []) as RequestStatus[]
+  const ownerClaimRequests = (claimRequests ?? []) as ClaimRequest[]
   const latestChangeByVendor = new Map<string, (typeof profileChanges)[number]>()
   for (const change of profileChanges ?? []) {
     if (!latestChangeByVendor.has(change.vendor_id)) latestChangeByVendor.set(change.vendor_id, change)
@@ -47,6 +68,26 @@ export default async function DashboardPage() {
             <button className="text-sm font-medium underline text-slate-600 hover:text-black">Sign Out</button>
           </form>
         </header>
+
+        {ownerRequestStatuses.length > 0 && (
+          <section className="space-y-4">
+            <div>
+              <h2 className="text-2xl font-bold">Request status</h2>
+              <p className="mt-1 text-sm text-slate-600">Updates appear here even if an email cannot be delivered.</p>
+            </div>
+            <div className="grid gap-4">
+              {ownerRequestStatuses.map((request, index) => (
+                <div key={`${request.request_type}-${request.submitted_at}-${index}`} className="rounded-2xl border bg-white p-5 shadow-sm">
+                  <p className="font-bold">{request.request_type === 'claim' ? 'Ownership request' : 'Profile change'}</p>
+                  <p className="mt-1 text-sm text-slate-600">{request.safe_operator_reason}</p>
+                  <p className="mt-2 text-sm font-medium text-slate-800">Next step: {request.next_step}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <ClaimRequests initialRequests={ownerClaimRequests} />
 
         {/* Owned Businesses */}
         <section className="space-y-6">


### PR DESCRIPTION
## Summary
- show owner request status and allow authenticated withdrawal of pending claims and profile edits
- route non-matching-email claim recovery to the existing private, moderated claim-help queue
- add an audited, owner-scoped database boundary with no publication or automatic ownership change

## Verification
- npm run check
- npm --prefix web run lint
- npm --prefix web run build
- migration executed successfully in a remote database transaction and rolled back