### PR TITLE
Clarify business intake choices

### DIFF
--- a/web/src/app/(directory)/join/page.tsx
+++ b/web/src/app/(directory)/join/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
 };
 
 export default async function JoinPage({ searchParams }: {
-  searchParams: Promise<{ submitted?: string; error?: string }>;
+  searchParams: Promise<{ submitted?: string; error?: string; q?: string; suburb?: string; add?: string }>;
 }) {
   const message = await searchParams;
   const siteKey = runtimeEnv("TURNSTILE_SITE_KEY");
@@ -24,20 +24,38 @@ export default async function JoinPage({ searchParams }: {
     supabase.from("suburbs").select("name, slug").order("name"),
   ]);
   if (categoriesResult.error || suburbsResult.error) throw new Error("Business submission options could not be loaded.");
+  const query = typeof message.q === "string" ? message.q.trim().slice(0, 200) : "";
+  const suburb = typeof message.suburb === "string" ? message.suburb : "";
+  let matches: { id: string; business_name: string; suburb_slug: string; category_slug: string }[] = [];
+  if (query.length >= 2 && suburb) {
+    const { data } = await supabase.from("published_vendors").select("id, business_name, suburb_slug, category_slug")
+      .ilike("business_name", `%${query.replace(/[%_\\]/g, "\\$&")}%`).eq("suburb_slug", suburb).order("business_name").limit(5);
+    matches = data ?? [];
+  }
+  const showAddForm = message.add === "1" || (query.length >= 2 && suburb && matches.length === 0);
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-16">
-      <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">For business owners</p>
-      <h1 className="mt-3 text-4xl font-black tracking-tight sm:text-5xl">List or claim your business</h1>
-      <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600">Search first. If your business is already listed, submit a claim. If it is missing, send the facts below for private operator review.</p>
+      <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">For business owners and representatives</p>
+      <h1 className="mt-3 text-4xl font-black tracking-tight sm:text-5xl">Find your business first</h1>
+      <p className="mt-4 max-w-2xl text-lg leading-8 text-slate-600">Search SuburbMates before you claim a profile or add a missing business.</p>
 
-      <section className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-6">
-        <h2 className="text-xl font-bold">Already listed?</h2>
-        <p className="mt-2 text-sm leading-6 text-slate-600">A matching email supports the request, but ownership changes only after review.</p>
-        <div className="mt-5 flex flex-wrap gap-3"><Link href="/businesses" className="btn btn-outline">Search businesses</Link><Link href="/claim" className="btn btn-primary">Start a claim</Link></div>
+      <section className="mt-8 rounded-2xl border border-slate-200 bg-gradient-to-br from-white via-slate-50 to-indigo-50/70 p-5 shadow-sm sm:p-6">
+        <h2 className="text-xl font-black">Is your business already listed?</h2>
+        <form className="mt-5 grid gap-3 sm:grid-cols-[1fr_220px_auto]" action="/join">
+          <input name="q" required minLength={2} defaultValue={query} placeholder="Business name" className="rounded-xl border border-slate-300 bg-white px-4 py-3" />
+          <select name="suburb" required defaultValue={suburb} className="rounded-xl border border-slate-300 bg-white px-4 py-3"><option value="">Choose a suburb</option>{(suburbsResult.data ?? []).map((item) => <option key={item.slug} value={item.slug}>{item.name}</option>)}</select>
+          <button className="btn btn-primary whitespace-nowrap">Search</button>
+        </form>
       </section>
 
-      <section className="mt-8 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      {query.length >= 2 && suburb && (
+        <section className="mt-6" aria-live="polite">
+          {matches.length > 0 ? <><h2 className="text-xl font-black">Is this your business?</h2><div className="mt-4 grid gap-3">{matches.map((match) => <article key={match.id} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm"><p className="font-black">{match.business_name}</p><p className="mt-1 text-sm text-slate-600">{match.category_slug.replaceAll("-", " ")} · {match.suburb_slug.replaceAll("-", " ")}</p><Link href="/claim" className="btn btn-primary mt-4">Claim this profile</Link></article>)}</div><p className="mt-4 text-sm text-slate-600">Not your business? <Link href={`/join?add=1&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`} className="font-bold underline">Add a missing business instead</Link>.</p></> : <><h2 className="text-xl font-black">No likely match found</h2><p className="mt-2 text-slate-600">Try another spelling or suburb. If it is still missing, you can add it for private review.</p><Link href={`/join?add=1&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`} className="btn btn-primary mt-4">Add a missing business</Link></>}
+        </section>
+      )}
+
+      {showAddForm && <section id="missing-business" className="mt-8 scroll-mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
         <h2 className="text-2xl font-black">Submit a missing business</h2>
         <p className="mt-2 text-sm leading-6 text-slate-600">Submission does not publish a listing or assign ownership. An operator reviews the original facts before any public change.</p>
         {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Submission received for review. It is not public yet.</p>}
@@ -59,7 +77,7 @@ export default async function JoinPage({ searchParams }: {
             <div className="sm:col-span-2"><button className="btn btn-primary">Submit for review</button></div>
           </form>
         )}
-      </section>
+      </section>}
       {siteKey && <Script src="https://challenges.cloudflare.com/turnstile/v0/api.js" strategy="afterInteractive" />}
     </div>
   );


### PR DESCRIPTION
## Summary
- replaces the noisy mixed join layout with three clear choices
- separates claiming an existing business, adding a missing business, and reporting incorrect details
- keeps private-review and no-instant-publication language explicit

## Verification
- npm --prefix web run lint
- npm --prefix web run build