### PR TITLE
Add cross-device sign-in and private submission status

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -134,7 +134,7 @@ Current allowed sources and rules are documented in `docs/vendor-acquisition-str
 | GitHub | Source, CI, scheduled safe discovery | Connected; `Verify` runs on branch pushes and pull requests |
 | Supabase | PostgreSQL, Auth, RLS, RPC workflows | Connected; migrations aligned through `20260716128000` |
 | Cloudflare | DNS, Worker delivery, Turnstile | Live; contact widget restricted to `suburbmates.com.au`; runtime secrets are managed bindings |
-| Resend | Supabase Auth SMTP only at launch | Domain verified; one controlled magic-link sign-in into `/ops` is complete |
+| Resend | Supabase Auth SMTP only at launch | Domain verified; passwordless email-code sign-in into `/ops` is the approved path |
 | Stripe | Future optional paid upgrades | Test account only; webhook returns 501; keep disabled until benefits and pricing are approved |
 | ABN Lookup | Optional supporting evidence | Credential works; no workflow enabled; never gate listing, claim, or publication on ABN alone |
 

--- a/docs/OPS/README.md
+++ b/docs/OPS/README.md
@@ -15,7 +15,7 @@ Write the reason in the decision note. The system keeps it as permanent audit ev
 
 ## Getting in
 
-Open `/ops` and sign in with `admin@suburbmates.com.au`. Open the email link in the same browser that requested it. If a link fails, wait for the stated email limit and use the newest link; do not repeatedly request more links.
+Open `/ops` and sign in with `admin@suburbmates.com.au`. Request a sign-in code, then enter the newest eight-digit code in the browser you are using. The email can be opened on another device. If a code fails, wait for the stated email limit before requesting another.
 
 ## Daily order
 

--- a/docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md
+++ b/docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md
@@ -13,7 +13,7 @@ The product status screen is the source of a person's request outcome. A message
 | Capability | Status |
 | --- | --- |
 | Passwordless sign-in from `auth@suburbmates.com.au` | Active for authorised access. |
-| Expired/superseded-link recovery | Active through the login page's newest-link and rate-limit guidance. |
+| Cross-device passwordless access | Active through an eight-digit email code entered in the browser being used. |
 | Public contact/support form | Implemented but not publicly reachable while holding is active. |
 | Contact dispatcher / general notification sender | Dormant; not enabled. |
 | Marketing, newsletters, public support inbox, bulk messages, automatic retries | Prohibited. |
@@ -24,7 +24,7 @@ No row below becomes enabled until its associated user journey and Ops workflow 
 
 | Stage | Message | Trigger | Recipient | In-product fallback | Ops evidence |
 | --- | --- | --- | --- | --- | --- |
-| Active | Magic-link sign-in | Person requests authorised sign-in. | Requesting email. | Login page/retry guidance. | Auth provider result; no application message ledger required. |
+| Active | Email-code sign-in | Person requests authorised sign-in. | Requesting email. | Login page/retry guidance. | Auth provider result; no application message ledger required. |
 | 1 | Claim status | Claim needs information, is approved, rejected or revoked. | Authenticated claimant's approved address. | Owner request-status feed. | Claim ID, status, template/version, delivery result. |
 | 1 | Profile-change status | Proposed change is approved or rejected. | Authenticated owner. | Owner request-status feed. | Change-request ID, status, template/version, delivery result. |
 | 2 | Missing-business outcome | Candidate is accepted, needs information or declined. | Submitter only when they supplied a valid contact basis. | Submitted reference/status path where offered. | Candidate ID, outcome, consent/contact basis, delivery result. |
@@ -48,7 +48,7 @@ The public form must classify the request before it reaches Ops: correction, cla
 
 ## Evidence required before review
 
-- authenticated magic-link and expired-link recovery check;
+- authenticated email-code, expiry and recovery check;
 - contact input validation/abuse-control and private-queue boundary check;
 - review of delivery-ledger access, audit and retention boundaries;
 - explicit confirmation that no dormant dispatcher became active; and

--- a/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
+++ b/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
@@ -39,7 +39,7 @@ mindmap
             Track request or claim outcome
               Manage profile changes
       Communications and account access
-        Magic-link sign in and recovery
+        Email-code sign in and recovery
         Approved status messages only
         Contact help and privacy intake
     Business not listed
@@ -150,7 +150,7 @@ This is a first-class service journey, not a background detail of claims or form
 
 ### Current holding posture
 
-The only approved outbound email is the passwordless sign-in link from `auth@suburbmates.com.au`. It supports the authorised operator's sign-in and recovery path. There is no public support inbox, contact dispatcher, marketing mail, bulk notification system or automatic retry loop.
+The only approved outbound email is the passwordless sign-in code from `auth@suburbmates.com.au`. It supports the authorised operator's sign-in and recovery path, including when the email is read on another device. There is no public support inbox, contact dispatcher, marketing mail, bulk notification system or automatic retry loop.
 
 ### Finished public posture
 
@@ -158,7 +158,7 @@ Before any new message is enabled, `SUB-15` must approve a message catalogue. Ea
 
 The possible public intents are:
 
-1. **Account access:** request a magic link, use it in the same browser, recover safely from an expired or superseded link, and reach only the authorised private area.
+1. **Account access:** request an email code, enter it in the browser being used, recover safely from an expired or superseded code, and reach only the authorised private area.
 2. **Claim or profile request status:** see the status in the authenticated product; any email is an approved supplement, never the only record.
 3. **Contact, help and privacy request:** select a plain-language request type, submit a private request, receive an honest on-screen outcome and, only where approved and permitted, a transactional reply.
 4. **Submission or report outcome:** receive a status through the approved channel only when a contact basis exists and the message catalogue permits it.

--- a/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
+++ b/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
@@ -172,17 +172,20 @@ The possible public intents are:
 
 ## 5. New-business journey: add a business that is not yet listed
 
-1. A person selects **Add a business** from Home or a directory empty state.
-2. They provide the minimum useful details and a way to support the business's existence and local relevance.
-3. Validation and abuse controls reject obvious spam, malformed input and duplicates before anything becomes public.
-4. The system creates a **private candidate**, explains that the information will be reviewed, and gives the person a reference or authenticated status path when appropriate.
-5. Background and operator checks compare it with approved sources, scope, duplicate records and safety concerns.
-6. A qualifying candidate follows the approved directory-first lifecycle; an uncertain one becomes an Ops exception rather than a silent public listing.
-7. The journey is complete when the submitter can understand the outcome where contact is appropriate, and the candidate has an auditable decision.
+1. A person selects **Add a business** from Home or a directory empty state, then searches first for an existing listing.
+2. If it is missing, they choose one clear route: **I own or represent it** or **I am suggesting it**.
+3. An owner or authorised representative signs in, supplies the minimum useful business facts and explains their connection. The system creates a **private candidate** and a **pending claim** together; neither publishes the business nor grants ownership.
+4. A community suggester provides the minimum useful facts and a private status email. Their submission creates only a private candidate and no ownership request.
+5. Validation and abuse controls reject obvious spam, malformed input and duplicates before anything becomes public.
+6. Background and operator checks compare the candidate with approved sources, scope, duplicate records and safety concerns. The operator separately reviews any pending ownership evidence.
+7. A qualifying candidate follows the approved directory-first lifecycle; an uncertain one becomes an Ops exception rather than a silent public listing.
+8. The journey is complete when the submitter or owner can understand the private outcome, and the candidate and any claim have auditable decisions.
 
 ### Behind the page
 
 - A submission is not a self-service profile creator and cannot overwrite an existing listing.
+- An authenticated account can be both a community submitter and a business owner. Sign-in identifies the request account; only an approved claim creates the ownership link.
+- An owner-submitted candidate is intentional evidence for a manual claim review, not an automatic claim or a substitute for the exact-email claim route for existing listings.
 - Source, contact permission, evidence, anti-abuse signals and duplicate matches stay private.
 - Automation may assist evidence gathering and matching, but cannot invent public facts or make discretionary publication/ownership decisions.
 

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -80,6 +80,13 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **First launch:** The initial public launch is complete when the minimum end-to-end journeys above are proven. Stripe, broad email, bulk ABN checks, AI publication and optional polish are not launch prerequisites.
 - **Evidence to close:** Update authority/issue descriptions; build the ready foundation work; then verify each public journey and release gate.
 
+### D-008 — Cross-device passwordless access
+
+- **Date:** 22 July 2026
+- **Decision:** The approved `auth@suburbmates.com.au` passwordless email uses an eight-digit, one-time code entered in the browser where the person wants to sign in. It replaces the browser-bound magic-link interaction.
+- **Guardrail:** This changes neither the approved sender nor any other communications capability. Codes expire through Supabase Auth, are single-use, and do not decide a claim, publication, ownership or any other product state.
+- **Evidence to close:** A live owner-device test of code delivery, expiry, supersession and successful session handoff, followed by removal of the temporary review callback.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -87,6 +87,12 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Guardrail:** This changes neither the approved sender nor any other communications capability. Codes expire through Supabase Auth, are single-use, and do not decide a claim, publication, ownership or any other product state.
 - **Evidence to close:** A live owner-device test of code delivery, expiry, supersession and successful session handoff, followed by removal of the temporary review callback.
 
+### D-009 — Private missing-business status
+
+- **Date:** 22 July 2026
+- **Decision:** A missing-business submission records a separate submitter email for private, signed-in status access. The business contact details remain governed by the at-least-one-contact rule.
+- **Guardrail:** Status is plain language only and separate from the operator listing queue. It cannot publish a listing, assign ownership, or send a general notification.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -93,6 +93,7 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Decision:** A missing-business submission records a separate submitter email for private, signed-in status access. The business contact details remain governed by the at-least-one-contact rule.
 - **Guardrail:** Status is plain language only and separate from the operator listing queue. It cannot publish a listing, assign ownership, or send a general notification.
 - **Identity rule:** The same email may be used by a submitter and later by a business owner. Authentication never makes it an owner; only an approved claim creates the ownership link.
+- **Owner-submitted candidate rule:** A person who owns, manages, or represents a missing business signs in first, submits the private candidate and a relationship explanation, and receives a pending claim request. That combined intake never publishes the candidate or grants ownership automatically.
 
 ## Open deviations to track
 

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -92,6 +92,7 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Date:** 22 July 2026
 - **Decision:** A missing-business submission records a separate submitter email for private, signed-in status access. The business contact details remain governed by the at-least-one-contact rule.
 - **Guardrail:** Status is plain language only and separate from the operator listing queue. It cannot publish a listing, assign ownership, or send a general notification.
+- **Identity rule:** The same email may be used by a submitter and later by a business owner. Authentication never makes it an owner; only an approved claim creates the ownership link.
 
 ## Open deviations to track
 

--- a/docs/REFERENCE/SuburbMates — SUB-7 Owner Decision Sheet.md
+++ b/docs/REFERENCE/SuburbMates — SUB-7 Owner Decision Sheet.md
@@ -8,7 +8,7 @@ These are the few decisions that affect many future issues. Choose the recommend
 
 The owner approved the recommended position for every decision: **1C, 2B, 3B, 4B, 5B**, and the recommended first-launch definition in decision 6. The Decision Log is the durable policy record; this sheet remains the concise explanation of the choices.
 
-Current fact remains: the site is in holding mode; the directory is not publicly browsable; the only approved outbound email is the operator magic-link sign-in path; Stripe is disabled.
+Current fact remains: the site is in holding mode; the directory is not publicly browsable; the only approved outbound email is the operator email-code sign-in path; Stripe is disabled.
 
 ## 1. How an existing business owner claims a listing
 

--- a/docs/claim-flow-readiness.md
+++ b/docs/claim-flow-readiness.md
@@ -6,7 +6,7 @@ This records the current direct email-match implementation. It is not the comple
 
 Listings are public before, during, and after ownership is claimed. An exact match to the recorded contact email is the approved normal claim path. The completed product also requires a protected, auditable exception, challenge, recovery and revocation path for conflicts, sensitive changes and non-matching evidence. That exception path is not established merely by the direct claim flow below.
 
-1. A business owner signs in through the magic-link flow using the email address recorded on their listing.
+1. A business owner signs in through the email-code flow using the email address recorded on their listing.
 2. `/claim` calls `list_claimable_vendors_for_current_email()`, which returns only unclaimed listings whose `contact_email` matches the authenticated email.
 3. The owner selects a listing. `claim_vendor_for_current_email(UUID)` locks that row, checks the same email match again, then atomically assigns `owner_id` and sets `is_claimed`.
 4. The owner can update their profile from the dashboard. The listing stays public throughout. Sensitive changes and any conflict/revocation path follow the separate approved Ops workflow.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "owner-status:test": "tsx scripts/test-owner-status-boundary.ts && npm run owner-request-withdrawal:test",
     "owner-request-withdrawal:test": "tsx scripts/test-owner-request-withdrawal-boundary.ts",
     "claim-evidence-handoff:test": "tsx scripts/test-claim-evidence-handoff-boundary.ts",
+    "cross-device-email-code:test": "tsx scripts/test-cross-device-email-code-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "claim-evidence-handoff:test": "tsx scripts/test-claim-evidence-handoff-boundary.ts",
     "cross-device-email-code:test": "tsx scripts/test-cross-device-email-code-boundary.ts",
     "private-business-submission-status:test": "tsx scripts/test-private-business-submission-status-boundary.ts",
+    "submitter-owner-identity:test": "tsx scripts/test-submitter-owner-identity-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cross-device-email-code:test": "tsx scripts/test-cross-device-email-code-boundary.ts",
     "private-business-submission-status:test": "tsx scripts/test-private-business-submission-status-boundary.ts",
     "submitter-owner-identity:test": "tsx scripts/test-submitter-owner-identity-boundary.ts",
+    "owner-submitted-business-candidate:test": "tsx scripts/test-owner-submitted-business-candidate-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "owner-request-withdrawal:test": "tsx scripts/test-owner-request-withdrawal-boundary.ts",
     "claim-evidence-handoff:test": "tsx scripts/test-claim-evidence-handoff-boundary.ts",
     "cross-device-email-code:test": "tsx scripts/test-cross-device-email-code-boundary.ts",
+    "private-business-submission-status:test": "tsx scripts/test-private-business-submission-status-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },

--- a/scripts/test-cross-device-email-code-boundary.ts
+++ b/scripts/test-cross-device-email-code-boundary.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const login = fs.readFileSync("web/src/app/(directory)/login/page.tsx", "utf8");
+const communications = fs.readFileSync("docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md", "utf8");
+
+assert.match(login, /supabase\.auth\.signInWithOtp\(\{\s*email,/);
+assert.match(login, /supabase\.auth\.verifyOtp\(\{ email, token, type: "email" \}\)/);
+assert.match(login, /autoComplete="one-time-code"/);
+assert.match(login, /safeNext\(/);
+assert.match(login, /startsWith\("\/"\) && !value\.startsWith\("\/\/"\)/);
+assert.doesNotMatch(login, /emailRedirectTo/);
+assert.match(communications, /Email-code sign-in/);
+
+console.log("Cross-device email-code boundary checks passed.");

--- a/scripts/test-owner-submitted-business-candidate-boundary.ts
+++ b/scripts/test-owner-submitted-business-candidate-boundary.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const migration = fs.readFileSync("supabase/migrations/20260722003158_owner_submitted_business_candidate.sql", "utf8");
+const actions = fs.readFileSync("web/src/app/(directory)/join/actions.ts", "utf8");
+const join = fs.readFileSync("web/src/app/(directory)/join/page.tsx", "utf8");
+
+assert.match(migration, /auth\.uid\(\)/);
+assert.match(migration, /INSERT INTO public\.claim_requests/);
+assert.match(migration, /'owner_submitted_candidate', true/);
+assert.match(migration, /SET ownership_status = 'claim_pending'/);
+assert.match(migration, /'publication_unchanged', true/);
+assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.submit_owned_business_candidate_for_current_user[\s\S]*TO authenticated/);
+assert.match(actions, /submit_owned_business_candidate_for_current_user/);
+assert.match(actions, /createClient\(\)/);
+assert.match(join, /I own or represent it/);
+assert.match(join, /Suggest a local business/);
+assert.match(join, /Submit business and ownership request/);
+for (const forbidden of ["is_published = true", "SET owner_id =", "is_claimed = true", "TO anon"]) {
+  assert(!migration.includes(forbidden), `Owner candidate flow must not contain ${forbidden}.`);
+}
+console.log("Owner-submitted business candidate boundary checks passed.");

--- a/scripts/test-private-business-submission-status-boundary.ts
+++ b/scripts/test-private-business-submission-status-boundary.ts
@@ -2,7 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const migration = fs.readFileSync("supabase/migrations/20260722000839_private_business_submission_status.sql", "utf8");
-const join = fs.readFileSync("web/src/app/(directory)/join/actions.ts", "utf8");
+const joinActions = fs.readFileSync("web/src/app/(directory)/join/actions.ts", "utf8");
+const joinPage = fs.readFileSync("web/src/app/(directory)/join/page.tsx", "utf8");
 const dashboard = fs.readFileSync("web/src/app/(directory)/dashboard/page.tsx", "utf8");
 
 assert.match(migration, /submitter_email TEXT NOT NULL/);
@@ -10,7 +11,9 @@ assert.match(migration, /request\.submitter_email=v_email/);
 assert.match(migration, /REVOKE ALL ON TABLE public\.business_submission_requests FROM PUBLIC, anon, authenticated/);
 assert.match(migration, /'publication_unchanged',true/);
 assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.list_current_business_submission_statuses\(\) TO authenticated/);
-assert.match(join, /submit_business_listing_with_status/);
+assert.match(joinActions, /submit_business_listing_with_status/);
 assert.match(dashboard, /list_current_business_submission_statuses/);
+assert.match(joinPage, /No sign-in is needed\./);
+assert.match(joinPage, /You do not need an account to submit\./);
 for (const forbidden of ["is_published = true", "SET owner_id =", "TO anon"]) assert(!migration.includes(forbidden), `Private submission status must not contain ${forbidden}.`);
 console.log("Private business-submission status boundary checks passed.");

--- a/scripts/test-private-business-submission-status-boundary.ts
+++ b/scripts/test-private-business-submission-status-boundary.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const migration = fs.readFileSync("supabase/migrations/20260722000839_private_business_submission_status.sql", "utf8");
+const join = fs.readFileSync("web/src/app/(directory)/join/actions.ts", "utf8");
+const dashboard = fs.readFileSync("web/src/app/(directory)/dashboard/page.tsx", "utf8");
+
+assert.match(migration, /submitter_email TEXT NOT NULL/);
+assert.match(migration, /request\.submitter_email=v_email/);
+assert.match(migration, /REVOKE ALL ON TABLE public\.business_submission_requests FROM PUBLIC, anon, authenticated/);
+assert.match(migration, /'publication_unchanged',true/);
+assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.list_current_business_submission_statuses\(\) TO authenticated/);
+assert.match(join, /submit_business_listing_with_status/);
+assert.match(dashboard, /list_current_business_submission_statuses/);
+for (const forbidden of ["is_published = true", "SET owner_id =", "TO anon"]) assert(!migration.includes(forbidden), `Private submission status must not contain ${forbidden}.`);
+console.log("Private business-submission status boundary checks passed.");

--- a/scripts/test-submitter-owner-identity-boundary.ts
+++ b/scripts/test-submitter-owner-identity-boundary.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const submission = fs.readFileSync("supabase/migrations/20260722000839_private_business_submission_status.sql", "utf8");
+const claim = fs.readFileSync("supabase/migrations/20260721235307_claim_evidence_handoff.sql", "utf8");
+
+assert.match(submission, /submitter_email TEXT NOT NULL/);
+assert.doesNotMatch(submission, /submitter_email TEXT NOT NULL UNIQUE/);
+assert.doesNotMatch(submission, /submitter_email UUID/);
+assert.match(claim, /lower\(coalesce\(v_vendor\.contact_email, ''\)\) <> v_email/);
+assert.match(claim, /claimant_user_id, claimant_email/);
+assert.doesNotMatch(claim, /business_submission_requests/);
+
+console.log("Submitter-owner identity boundary checks passed.");

--- a/supabase/migrations/20260722000839_private_business_submission_status.sql
+++ b/supabase/migrations/20260722000839_private_business_submission_status.sql
@@ -1,0 +1,73 @@
+CREATE TABLE public.business_submission_requests (
+  id UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  vendor_id UUID NOT NULL UNIQUE REFERENCES public.vendors(id) ON DELETE RESTRICT,
+  submitter_email TEXT NOT NULL,
+  submission_status TEXT NOT NULL DEFAULT 'received' CHECK (submission_status IN ('received', 'needs_information', 'approved', 'declined')),
+  operator_message TEXT,
+  updated_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now())
+);
+ALTER TABLE public.business_submission_requests ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.business_submission_requests FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.business_submission_requests TO service_role;
+
+CREATE FUNCTION public.submit_business_listing_with_status(
+  p_submitter_name TEXT, p_submitter_email TEXT, p_business_name TEXT, p_category_slug TEXT, p_suburb_slug TEXT,
+  p_contact_email TEXT, p_phone TEXT, p_website TEXT, p_street_address TEXT, p_abn TEXT, p_turnstile_hostname TEXT, p_turnstile_action TEXT
+) RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE v_email TEXT := nullif(lower(trim(coalesce(p_submitter_email,''))), ''); v_vendor_id UUID;
+BEGIN
+  IF v_email IS NULL OR length(v_email)>254 OR v_email !~* '^[^[:space:]@]+@[^[:space:]@]+\\.[^[:space:]@]+$' THEN RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='Enter a valid email for private status.'; END IF;
+  v_vendor_id := public.submit_business_listing(p_submitter_name,p_business_name,p_category_slug,p_suburb_slug,p_contact_email,p_phone,p_website,p_street_address,p_abn,p_turnstile_hostname,p_turnstile_action);
+  INSERT INTO public.business_submission_requests (vendor_id,submitter_email) VALUES (v_vendor_id,v_email);
+  RETURN v_vendor_id;
+END;
+$$;
+
+CREATE FUNCTION public.list_current_business_submission_statuses()
+RETURNS TABLE (business_name TEXT, submission_status TEXT, status_message TEXT, next_step TEXT, submitted_at TIMESTAMPTZ, updated_at TIMESTAMPTZ)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE v_user_id UUID := auth.uid(); v_email TEXT := lower(trim(coalesce(auth.jwt() ->> 'email', '')));
+BEGIN
+  IF v_user_id IS NULL OR v_email='' THEN RAISE EXCEPTION USING ERRCODE='42501', MESSAGE='Authentication with an email address is required.'; END IF;
+  RETURN QUERY SELECT vendor.business_name, request.submission_status,
+    CASE request.submission_status WHEN 'received' THEN 'We received this business for private review.' WHEN 'needs_information' THEN coalesce(request.operator_message,'SuburbMates needs more information before making a decision.') WHEN 'approved' THEN coalesce(request.operator_message,'This submission has been approved. Public directory availability is controlled separately.') ELSE coalesce(request.operator_message,'This submission was not approved for the directory.') END,
+    CASE request.submission_status WHEN 'received' THEN 'No action is needed while the submission is reviewed.' WHEN 'needs_information' THEN 'Use the private claim-help path if you can provide the requested information.' WHEN 'approved' THEN 'No action is needed. This does not create ownership of the listing.' ELSE 'You may submit a new request only if you have materially different information.' END,
+    request.created_at,request.updated_at
+  FROM public.business_submission_requests request JOIN public.vendors vendor ON vendor.id=request.vendor_id WHERE request.submitter_email=v_email ORDER BY request.created_at DESC;
+END;
+$$;
+
+CREATE FUNCTION public.ops_get_business_submission_status(p_vendor_id UUID)
+RETURNS TABLE (submission_status TEXT, operator_message TEXT, updated_at TIMESTAMPTZ)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = ''
+AS $$ BEGIN PERFORM private.require_active_operator(); RETURN QUERY SELECT request.submission_status,request.operator_message,request.updated_at FROM public.business_submission_requests request WHERE request.vendor_id=p_vendor_id; END; $$;
+
+CREATE FUNCTION public.ops_set_business_submission_status(p_vendor_id UUID,p_status TEXT,p_message TEXT)
+RETURNS TABLE (submission_status TEXT,updated_at TIMESTAMPTZ)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE v_operator_id UUID := private.require_active_operator(); v_status TEXT := lower(trim(coalesce(p_status,''))); v_message TEXT := nullif(trim(coalesce(p_message,'')), ''); v_before public.business_submission_requests%ROWTYPE; v_now TIMESTAMPTZ := timezone('utc'::text, now());
+BEGIN
+  IF v_status NOT IN ('needs_information','approved','declined') OR v_message IS NULL OR length(v_message)>2000 THEN RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='Choose a valid outcome and enter a plain-language message.'; END IF;
+  SELECT * INTO v_before FROM public.business_submission_requests request WHERE request.vendor_id=p_vendor_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION USING ERRCODE='02000', MESSAGE='No private submission exists for this listing.'; END IF;
+  IF v_before.submission_status IN ('approved','declined') THEN RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='This submission already has a final outcome.'; END IF;
+  UPDATE public.business_submission_requests SET submission_status=v_status,operator_message=v_message,updated_by=v_operator_id,updated_at=v_now WHERE vendor_id=p_vendor_id;
+  INSERT INTO public.audit_events (actor_type,actor_user_id,action,entity_type,entity_id,reason,before_data,after_data) VALUES ('operator',v_operator_id,'business_submission_status_updated','business_submission_request',p_vendor_id::text,v_message,jsonb_build_object('submission_status',v_before.submission_status),jsonb_build_object('submission_status',v_status,'publication_unchanged',true));
+  RETURN QUERY SELECT request.submission_status,request.updated_at FROM public.business_submission_requests request WHERE request.vendor_id=p_vendor_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.submit_business_listing_with_status(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_current_business_submission_statuses() FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.ops_get_business_submission_status(UUID) FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.ops_set_business_submission_status(UUID,TEXT,TEXT) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.submit_business_listing_with_status(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION public.list_current_business_submission_statuses() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.ops_get_business_submission_status(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.ops_set_business_submission_status(UUID,TEXT,TEXT) TO authenticated;

--- a/supabase/migrations/20260722003158_owner_submitted_business_candidate.sql
+++ b/supabase/migrations/20260722003158_owner_submitted_business_candidate.sql
@@ -1,0 +1,89 @@
+-- An authenticated business owner or authorised representative can submit a
+-- missing business and a related claim together. Both remain private and
+-- pending until an operator makes separate listing and claim decisions.
+
+CREATE FUNCTION public.submit_owned_business_candidate_for_current_user(
+  p_submitter_name TEXT,
+  p_business_name TEXT,
+  p_category_slug TEXT,
+  p_suburb_slug TEXT,
+  p_contact_email TEXT,
+  p_phone TEXT,
+  p_website TEXT,
+  p_street_address TEXT,
+  p_abn TEXT,
+  p_relationship_explanation TEXT,
+  p_turnstile_hostname TEXT,
+  p_turnstile_action TEXT
+)
+RETURNS TABLE (vendor_id UUID, claim_request_id UUID, claim_status TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_email TEXT := lower(trim(coalesce(auth.jwt() ->> 'email', '')));
+  v_note TEXT := nullif(trim(coalesce(p_relationship_explanation, '')), '');
+  v_abn TEXT := nullif(regexp_replace(coalesce(p_abn, ''), '\\s', '', 'g'), '');
+  v_vendor_id UUID;
+  v_claim public.claim_requests%ROWTYPE;
+BEGIN
+  IF v_user_id IS NULL OR v_email = '' THEN
+    RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'Authentication with an email address is required.';
+  END IF;
+  IF v_note IS NULL OR char_length(v_note) < 10 OR char_length(v_note) > 1000 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Explain your connection to the business using 10 to 1,000 characters.';
+  END IF;
+  IF v_abn IS NOT NULL AND v_abn !~ '^\\d{11}$' THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'ABN must contain 11 digits when provided.';
+  END IF;
+
+  v_vendor_id := public.submit_business_listing_with_status(
+    p_submitter_name, v_email, p_business_name, p_category_slug, p_suburb_slug,
+    p_contact_email, p_phone, p_website, p_street_address, v_abn,
+    p_turnstile_hostname, p_turnstile_action
+  );
+
+  INSERT INTO public.claim_requests (
+    vendor_id, claimant_user_id, claimant_email, evidence, claimant_note
+  ) VALUES (
+    v_vendor_id,
+    v_user_id,
+    v_email,
+    jsonb_build_object(
+      'email_match', false,
+      'owner_submitted_candidate', true,
+      'relationship_explanation', v_note,
+      'abn', v_abn,
+      'abn_status', CASE WHEN v_abn IS NULL THEN 'not_provided' ELSE 'provided_unverified' END
+    ),
+    v_note
+  ) RETURNING * INTO v_claim;
+
+  UPDATE public.vendors
+  SET ownership_status = 'claim_pending', updated_at = timezone('utc'::text, now())
+  WHERE id = v_vendor_id;
+
+  INSERT INTO public.audit_events (
+    actor_type, actor_user_id, action, entity_type, entity_id, reason, after_data
+  ) VALUES (
+    'owner', v_user_id, 'owner_submitted_business_candidate', 'vendor', v_vendor_id::text, v_note,
+    jsonb_build_object(
+      'listing_status', 'pending_review',
+      'ownership_status', 'claim_pending',
+      'claim_request_id', v_claim.id,
+      'publication_unchanged', true,
+      'ownership_unchanged', true
+    )
+  );
+
+  RETURN QUERY SELECT v_vendor_id, v_claim.id, v_claim.claim_status;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.submit_owned_business_candidate_for_current_user(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.submit_owned_business_candidate_for_current_user(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.submit_owned_business_candidate_for_current_user(TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT,TEXT) IS
+  'Creates a private missing-business candidate and a pending ownership claim for the signed-in owner or representative. It never publishes a listing or grants ownership.';

--- a/web/src/app/(directory)/dashboard/page.tsx
+++ b/web/src/app/(directory)/dashboard/page.tsx
@@ -36,6 +36,14 @@ type ClaimRequest = {
   created_at: string
 }
 
+type BusinessSubmissionStatus = {
+  business_name: string
+  submission_status: string
+  status_message: string
+  next_step: string
+  submitted_at: string
+}
+
 export default async function DashboardPage() {
   const supabase = await createClient()
   
@@ -51,8 +59,10 @@ export default async function DashboardPage() {
   const { data: profileChanges } = await supabase.rpc('list_current_owner_profile_changes')
   const { data: requestStatuses } = await supabase.rpc('list_current_owner_request_statuses')
   const { data: claimRequests } = await supabase.rpc('list_current_owner_claim_requests')
+  const { data: businessSubmissionStatuses } = await supabase.rpc('list_current_business_submission_statuses')
   const ownerRequestStatuses = (requestStatuses ?? []) as RequestStatus[]
   const ownerClaimRequests = (claimRequests ?? []) as ClaimRequest[]
+  const privateSubmissionStatuses = (businessSubmissionStatuses ?? []) as BusinessSubmissionStatus[]
   const latestChangeByVendor = new Map<string, (typeof profileChanges)[number]>()
   for (const change of profileChanges ?? []) {
     if (!latestChangeByVendor.has(change.vendor_id)) latestChangeByVendor.set(change.vendor_id, change)
@@ -84,6 +94,13 @@ export default async function DashboardPage() {
                 </div>
               ))}
             </div>
+          </section>
+        )}
+
+        {privateSubmissionStatuses.length > 0 && (
+          <section className="space-y-4">
+            <div><h2 className="text-2xl font-bold">Your business submissions</h2><p className="mt-1 text-sm text-slate-600">These are private review updates. They do not publish a listing or assign ownership.</p></div>
+            <div className="grid gap-4">{privateSubmissionStatuses.map((request) => <div key={`${request.business_name}-${request.submitted_at}`} className="rounded-2xl border bg-white p-5 shadow-sm"><p className="font-bold">{request.business_name}</p><p className="mt-2 text-sm text-slate-600">{request.status_message}</p><p className="mt-2 text-sm font-medium text-slate-800">Next step: {request.next_step}</p></div>)}</div>
           </section>
         )}
 

--- a/web/src/app/(directory)/join/actions.ts
+++ b/web/src/app/(directory)/join/actions.ts
@@ -12,6 +12,7 @@ export async function submitBusinessAction(formData: FormData) {
   if (String(formData.get("companyWebsite") ?? "").trim()) redirect("/join?submitted=1");
 
   const submitterName = String(formData.get("submitterName") ?? "").trim();
+  const submitterEmail = String(formData.get("submitterEmail") ?? "").trim().toLowerCase();
   const businessName = String(formData.get("businessName") ?? "").trim();
   const categorySlug = String(formData.get("categorySlug") ?? "").trim();
   const suburbSlug = String(formData.get("suburbSlug") ?? "").trim();
@@ -25,6 +26,7 @@ export async function submitBusinessAction(formData: FormData) {
 
   if (
     submitterName.length < 2 || submitterName.length > 120 ||
+    submitterEmail.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(submitterEmail) ||
     businessName.length < 2 || businessName.length > 200 ||
     !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(categorySlug) ||
     !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(suburbSlug) ||
@@ -46,8 +48,9 @@ export async function submitBusinessAction(formData: FormData) {
 
   try {
     const supabase = createAdminClient();
-    const { error } = await supabase.rpc("submit_business_listing", {
+    const { error } = await supabase.rpc("submit_business_listing_with_status", {
       p_submitter_name: submitterName,
+      p_submitter_email: submitterEmail,
       p_business_name: businessName,
       p_category_slug: categorySlug,
       p_suburb_slug: suburbSlug,

--- a/web/src/app/(directory)/join/actions.ts
+++ b/web/src/app/(directory)/join/actions.ts
@@ -3,30 +3,32 @@
 import { redirect } from "next/navigation";
 import { TurnstileVerificationError, verifyTurnstileToken } from "@/lib/turnstile";
 import { createAdminClient } from "@/utils/supabase/admin";
+import { createClient } from "@/utils/supabase/server";
 
 function fail(code: string): never {
   redirect(`/join?error=${encodeURIComponent(code)}`);
 }
 
-export async function submitBusinessAction(formData: FormData) {
-  if (String(formData.get("companyWebsite") ?? "").trim()) redirect("/join?submitted=1");
+function readBusinessFields(formData: FormData) {
+  return {
+    submitterName: String(formData.get("submitterName") ?? "").trim(),
+    businessName: String(formData.get("businessName") ?? "").trim(),
+    categorySlug: String(formData.get("categorySlug") ?? "").trim(),
+    suburbSlug: String(formData.get("suburbSlug") ?? "").trim(),
+    contactEmail: String(formData.get("contactEmail") ?? "").trim().toLowerCase(),
+    phone: String(formData.get("phone") ?? "").trim(),
+    website: String(formData.get("website") ?? "").trim(),
+    streetAddress: String(formData.get("streetAddress") ?? "").trim(),
+    abn: String(formData.get("abn") ?? "").replace(/\s/g, ""),
+    token: String(formData.get("cf-turnstile-response") ?? ""),
+    consent: formData.get("consent") === "on",
+  };
+}
 
-  const submitterName = String(formData.get("submitterName") ?? "").trim();
-  const submitterEmail = String(formData.get("submitterEmail") ?? "").trim().toLowerCase();
-  const businessName = String(formData.get("businessName") ?? "").trim();
-  const categorySlug = String(formData.get("categorySlug") ?? "").trim();
-  const suburbSlug = String(formData.get("suburbSlug") ?? "").trim();
-  const contactEmail = String(formData.get("contactEmail") ?? "").trim().toLowerCase();
-  const phone = String(formData.get("phone") ?? "").trim();
-  const website = String(formData.get("website") ?? "").trim();
-  const streetAddress = String(formData.get("streetAddress") ?? "").trim();
-  const abn = String(formData.get("abn") ?? "").replace(/\s/g, "");
-  const token = String(formData.get("cf-turnstile-response") ?? "");
-  const consent = formData.get("consent") === "on";
-
-  if (
+function validBusinessFields(fields: ReturnType<typeof readBusinessFields>) {
+  const { submitterName, businessName, categorySlug, suburbSlug, contactEmail, phone, website, streetAddress, abn, consent } = fields;
+  return !(
     submitterName.length < 2 || submitterName.length > 120 ||
-    submitterEmail.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(submitterEmail) ||
     businessName.length < 2 || businessName.length > 200 ||
     !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(categorySlug) ||
     !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(suburbSlug) ||
@@ -34,17 +36,33 @@ export async function submitBusinessAction(formData: FormData) {
     phone.length > 40 || website.length > 500 || streetAddress.length > 500 ||
     (website && !/^https:\/\/[^\s]+$/i.test(website)) || (abn && !/^\d{11}$/.test(abn)) ||
     (!contactEmail && !phone && !website) || !consent
-  ) {
-    fail("invalid");
-  }
+  );
+}
 
-  let verification: { hostname: string; action: string };
+async function verifyBusinessSubmission(token: string) {
   try {
-    verification = await verifyTurnstileToken(token, "business_submission");
+    return await verifyTurnstileToken(token, "business_submission");
   } catch (error) {
     if (error instanceof TurnstileVerificationError) fail(error.code);
     fail("verification");
   }
+}
+
+export async function submitBusinessAction(formData: FormData) {
+  if (String(formData.get("companyWebsite") ?? "").trim()) redirect("/join?submitted=1");
+
+  const fields = readBusinessFields(formData);
+  const { submitterName, businessName, categorySlug, suburbSlug, contactEmail, phone, website, streetAddress, abn, token } = fields;
+  const submitterEmail = String(formData.get("submitterEmail") ?? "").trim().toLowerCase();
+
+  if (
+    submitterEmail.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(submitterEmail) ||
+    !validBusinessFields(fields)
+  ) {
+    fail("invalid");
+  }
+
+  const verification = await verifyBusinessSubmission(token);
 
   try {
     const supabase = createAdminClient();
@@ -73,4 +91,42 @@ export async function submitBusinessAction(formData: FormData) {
   }
 
   redirect("/join?submitted=1");
+}
+
+export async function submitOwnedBusinessAction(formData: FormData) {
+  const next = "/join?path=owner";
+  if (String(formData.get("companyWebsite") ?? "").trim()) redirect(`${next}&submitted=1`);
+
+  const fields = readBusinessFields(formData);
+  const relationshipExplanation = String(formData.get("relationshipExplanation") ?? "").trim();
+  if (!validBusinessFields(fields) || relationshipExplanation.length < 10 || relationshipExplanation.length > 1000) {
+    redirect(`${next}&error=invalid`);
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.email) redirect(`/login?next=${encodeURIComponent(next)}`);
+  const verification = await verifyBusinessSubmission(fields.token);
+
+  const { error } = await supabase.rpc("submit_owned_business_candidate_for_current_user", {
+    p_submitter_name: fields.submitterName,
+    p_business_name: fields.businessName,
+    p_category_slug: fields.categorySlug,
+    p_suburb_slug: fields.suburbSlug,
+    p_contact_email: fields.contactEmail,
+    p_phone: fields.phone || null,
+    p_website: fields.website || null,
+    p_street_address: fields.streetAddress || null,
+    p_abn: fields.abn || null,
+    p_relationship_explanation: relationshipExplanation,
+    p_turnstile_hostname: verification.hostname,
+    p_turnstile_action: verification.action,
+  });
+  if (error) {
+    if (error.code === "23505" || error.message.includes("matching listing")) redirect(`${next}&error=duplicate`);
+    if (error.message.includes("Too many recent submissions")) redirect(`${next}&error=rate_limit`);
+    redirect(`${next}&error=submit`);
+  }
+
+  redirect(`${next}&submitted=1`);
 }

--- a/web/src/app/(directory)/join/page.tsx
+++ b/web/src/app/(directory)/join/page.tsx
@@ -71,7 +71,7 @@ export default async function JoinPage({ searchParams }: {
         <Link href={choiceHref("suggest")} className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-1 hover:border-indigo-300 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
           <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-600">I am suggesting it</p>
           <h2 className="mt-2 text-xl font-black">Suggest a local business</h2>
-          <p className="mt-2 text-sm leading-6 text-slate-600">Share accurate, reachable business details. The candidate stays private while an operator reviews it; this does not create ownership.</p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">No sign-in is needed. Share accurate, reachable business details and the candidate stays private while an operator reviews it; this does not create ownership.</p>
           <span className="mt-4 inline-block font-bold text-indigo-700 group-hover:underline">Continue as a community suggester →</span>
         </Link>
       </section>}
@@ -80,14 +80,14 @@ export default async function JoinPage({ searchParams }: {
         <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">Suggest a local business</p>
         <h2 className="mt-2 text-2xl font-black">Submit a missing business</h2>
         <p className="mt-2 text-sm leading-6 text-slate-600">Submission does not publish a listing or assign ownership. An operator reviews the original facts before any public change.</p>
-        {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Submission received for review. It is not public yet. <Link href="/login?next=/dashboard" className="underline">Sign in with the email you provided</Link> to check its private status later.</p>}
+        {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Submission received for review. It is not public yet. You do not need an account to submit. If you want to check its private status later, you can optionally <Link href="/login?next=/dashboard" className="underline">sign in with the email you provided</Link>.</p>}
         {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
 
         {!siteKey ? <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Secure business submission is temporarily unavailable. You can still search and claim an existing listing.</p> : (
           <form action={submitBusinessAction} className="mt-6 grid gap-5 sm:grid-cols-2">
             <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
             <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
-            <Field label="Your email for private status" name="submitterEmail" type="email" required maxLength={254} autoComplete="email" />
+            <div><Field label="Your email" name="submitterEmail" type="email" required maxLength={254} autoComplete="email" /><p className="mt-2 text-xs font-normal leading-5 text-slate-600">No account is created. This is only used if you later choose to check the private submission status.</p></div>
             <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
             <Select label="Category" name="categorySlug" options={categoriesResult.data ?? []} />
             <Select label="Location" name="suburbSlug" options={suburbsResult.data ?? []} />

--- a/web/src/app/(directory)/join/page.tsx
+++ b/web/src/app/(directory)/join/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Script from "next/script";
 import { runtimeEnv } from "@/lib/runtime-env";
 import { createClient } from "@/utils/supabase/server";
-import { submitBusinessAction } from "./actions";
+import { submitBusinessAction, submitOwnedBusinessAction } from "./actions";
 
 export const dynamic = "force-dynamic";
 
@@ -14,14 +14,15 @@ export const metadata: Metadata = {
 };
 
 export default async function JoinPage({ searchParams }: {
-  searchParams: Promise<{ submitted?: string; error?: string; q?: string; suburb?: string; add?: string }>;
+  searchParams: Promise<{ submitted?: string; error?: string; q?: string; suburb?: string; add?: string; choose?: string; path?: string }>;
 }) {
   const message = await searchParams;
   const siteKey = runtimeEnv("TURNSTILE_SITE_KEY");
   const supabase = await createClient();
-  const [categoriesResult, suburbsResult] = await Promise.all([
+  const [categoriesResult, suburbsResult, authResult] = await Promise.all([
     supabase.from("categories").select("name, slug").order("name"),
     supabase.from("suburbs").select("name, slug").order("name"),
+    supabase.auth.getUser(),
   ]);
   if (categoriesResult.error || suburbsResult.error) throw new Error("Business submission options could not be loaded.");
   const query = typeof message.q === "string" ? message.q.trim().slice(0, 200) : "";
@@ -32,7 +33,12 @@ export default async function JoinPage({ searchParams }: {
       .ilike("business_name", `%${query.replace(/[%_\\]/g, "\\$&")}%`).eq("suburb_slug", suburb).order("business_name").limit(5);
     matches = data ?? [];
   }
-  const showAddForm = message.add === "1" || (query.length >= 2 && suburb && matches.length === 0);
+  const path = message.path === "owner" ? "owner" : message.path === "suggest" || message.add === "1" ? "suggest" : null;
+  const showPathChoice = query.length >= 2 && suburb && (matches.length === 0 || message.choose === "1") && !path;
+  const showSuggestionForm = path === "suggest";
+  const showOwnerForm = path === "owner";
+  const choiceHref = (selectedPath: "owner" | "suggest") => `/join?path=${selectedPath}&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`;
+  const returnToChoice = `/join?choose=1&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`;
 
   return (
     <div className="mx-auto max-w-4xl px-6 py-16">
@@ -51,12 +57,28 @@ export default async function JoinPage({ searchParams }: {
 
       {query.length >= 2 && suburb && (
         <section className="mt-6" aria-live="polite">
-          {matches.length > 0 ? <><h2 className="text-xl font-black">Is this your business?</h2><div className="mt-4 grid gap-3">{matches.map((match) => <article key={match.id} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm"><p className="font-black">{match.business_name}</p><p className="mt-1 text-sm text-slate-600">{match.category_slug.replaceAll("-", " ")} · {match.suburb_slug.replaceAll("-", " ")}</p><Link href={`/claim?listing=${encodeURIComponent(match.id)}`} className="btn btn-primary mt-4">Claim this profile</Link></article>)}</div><p className="mt-4 text-sm text-slate-600">Not your business? <Link href={`/join?add=1&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`} className="font-bold underline">Add a missing business instead</Link>.</p></> : <><h2 className="text-xl font-black">No likely match found</h2><p className="mt-2 text-slate-600">Try another spelling or suburb. If it is still missing, you can add it for private review.</p><Link href={`/join?add=1&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`} className="btn btn-primary mt-4">Add a missing business</Link></>}
+          {matches.length > 0 ? <><h2 className="text-xl font-black">Is this your business?</h2><div className="mt-4 grid gap-3">{matches.map((match) => <article key={match.id} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm"><p className="font-black">{match.business_name}</p><p className="mt-1 text-sm text-slate-600">{match.category_slug.replaceAll("-", " ")} · {match.suburb_slug.replaceAll("-", " ")}</p><Link href={`/claim?listing=${encodeURIComponent(match.id)}`} className="btn btn-primary mt-4">Claim this profile</Link></article>)}</div><p className="mt-4 text-sm text-slate-600">Not the business you meant? <Link href={returnToChoice} className="font-bold underline">Add a missing business instead</Link>.</p></> : <><h2 className="text-xl font-black">No likely match found</h2><p className="mt-2 text-slate-600">Try another spelling or suburb. If it is still missing, choose the route that matches why you are adding it.</p></>}
         </section>
       )}
 
-      {showAddForm && <section id="missing-business" className="mt-8 scroll-mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
-        <h2 className="text-2xl font-black">Submit a missing business</h2>
+      {showPathChoice && <section className="mt-8 grid gap-4 sm:grid-cols-2" aria-label="Choose your missing business path">
+        <Link href={choiceHref("owner")} className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-1 hover:border-indigo-300 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-indigo-700">I own or represent it</p>
+          <h2 className="mt-2 text-xl font-black">Add my business and request ownership</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">Sign in, submit the missing business, and provide your connection. Both the listing and ownership request stay private for manual review.</p>
+          <span className="mt-4 inline-block font-bold text-indigo-700 group-hover:underline">Continue as owner or representative →</span>
+        </Link>
+        <Link href={choiceHref("suggest")} className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition duration-200 hover:-translate-y-1 hover:border-indigo-300 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+          <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-600">I am suggesting it</p>
+          <h2 className="mt-2 text-xl font-black">Suggest a local business</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">Share accurate, reachable business details. The candidate stays private while an operator reviews it; this does not create ownership.</p>
+          <span className="mt-4 inline-block font-bold text-indigo-700 group-hover:underline">Continue as a community suggester →</span>
+        </Link>
+      </section>}
+
+      {showSuggestionForm && <section id="missing-business" className="mt-8 scroll-mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-bold uppercase tracking-[0.16em] text-slate-500">Suggest a local business</p>
+        <h2 className="mt-2 text-2xl font-black">Submit a missing business</h2>
         <p className="mt-2 text-sm leading-6 text-slate-600">Submission does not publish a listing or assign ownership. An operator reviews the original facts before any public change.</p>
         {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Submission received for review. It is not public yet. <Link href="/login?next=/dashboard" className="underline">Sign in with the email you provided</Link> to check its private status later.</p>}
         {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
@@ -78,6 +100,34 @@ export default async function JoinPage({ searchParams }: {
             <label className="flex items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4" /><span>I confirm these are genuine business details and agree that SuburbMates may review them for directory publication as described in the <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
             <div className="sm:col-span-2"><div className="cf-turnstile" data-sitekey={siteKey} data-action="business_submission" data-theme="light" /></div>
             <div className="sm:col-span-2"><button className="btn btn-primary">Submit for review</button></div>
+          </form>
+        )}
+      </section>}
+
+      {showOwnerForm && <section id="owner-submission" className="mt-8 scroll-mt-6 rounded-2xl border border-indigo-200 bg-white p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-bold uppercase tracking-[0.16em] text-indigo-700">Owner or authorised representative</p>
+        <h2 className="mt-2 text-2xl font-black">Add this business and request ownership</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-600">This creates a private candidate and a pending ownership request together. An operator reviews both. It does not publish the business or give you ownership automatically.</p>
+        {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Your business candidate and ownership request were received for review. They remain private and pending until an operator decides.</p>}
+        {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
+        {!authResult.data.user?.email ? <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-5"><h3 className="font-black">Sign in to continue</h3><p className="mt-2 text-sm leading-6 text-slate-600">Your pending ownership request must be attached to your account so you can track it privately. Signing in does not approve ownership.</p><Link href={`/login?next=${encodeURIComponent(`/join?path=owner&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`)}`} className="btn btn-primary mt-4">Sign in to continue</Link></div> : !siteKey ? <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Secure business submission is temporarily unavailable. Please try again shortly.</p> : (
+          <form action={submitOwnedBusinessAction} className="mt-6 grid gap-5 sm:grid-cols-2">
+            <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
+            <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
+            <p className="rounded-xl bg-slate-50 p-3 text-sm leading-6 text-slate-600">Signed in as <strong>{authResult.data.user.email}</strong>. This email is used only for your private request status.</p>
+            <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
+            <Select label="Category" name="categorySlug" options={categoriesResult.data ?? []} />
+            <Select label="Location" name="suburbSlug" options={suburbsResult.data ?? []} />
+            <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" />
+            <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" />
+            <Field label="Website (optional, HTTPS)" name="website" type="url" maxLength={500} placeholder="https://" />
+            <p className="text-sm text-slate-600 sm:col-span-2">Provide at least one way customers can contact this business: email, phone, or website.</p>
+            <Field label="ABN (optional)" name="abn" maxLength={14} placeholder="11 digits" />
+            <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" />
+            <label className="text-sm font-bold sm:col-span-2">Your connection to this business<textarea name="relationshipExplanation" required minLength={10} maxLength={1000} className="mt-2 min-h-28 w-full rounded-xl border border-slate-300 p-3 font-normal" placeholder="For example: I am the owner, manager, or authorised representative…" /></label>
+            <label className="flex items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4" /><span>I confirm these are genuine business details and that I am authorised to request ownership review. SuburbMates may review the details and evidence under its <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
+            <div className="sm:col-span-2"><div className="cf-turnstile" data-sitekey={siteKey} data-action="business_submission" data-theme="light" /></div>
+            <div className="sm:col-span-2"><button className="btn btn-primary">Submit business and ownership request</button></div>
           </form>
         )}
       </section>}

--- a/web/src/app/(directory)/join/page.tsx
+++ b/web/src/app/(directory)/join/page.tsx
@@ -58,13 +58,14 @@ export default async function JoinPage({ searchParams }: {
       {showAddForm && <section id="missing-business" className="mt-8 scroll-mt-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
         <h2 className="text-2xl font-black">Submit a missing business</h2>
         <p className="mt-2 text-sm leading-6 text-slate-600">Submission does not publish a listing or assign ownership. An operator reviews the original facts before any public change.</p>
-        {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Submission received for review. It is not public yet.</p>}
+        {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Submission received for review. It is not public yet. <Link href="/login?next=/dashboard" className="underline">Sign in with the email you provided</Link> to check its private status later.</p>}
         {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
 
         {!siteKey ? <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Secure business submission is temporarily unavailable. You can still search and claim an existing listing.</p> : (
           <form action={submitBusinessAction} className="mt-6 grid gap-5 sm:grid-cols-2">
             <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
             <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
+            <Field label="Your email for private status" name="submitterEmail" type="email" required maxLength={254} autoComplete="email" />
             <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
             <Select label="Category" name="categorySlug" options={categoriesResult.data ?? []} />
             <Select label="Location" name="suburbSlug" options={suburbsResult.data ?? []} />

--- a/web/src/app/(directory)/login/page.tsx
+++ b/web/src/app/(directory)/login/page.tsx
@@ -15,24 +15,21 @@ export default function LoginPage() {
 function LoginForm() {
   const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
+  const [codeSent, setCodeSent] = useState(false);
   const [message, setMessage] = useState<{ kind: "error" | "success"; text: string } | null>(null);
+
+  const next = safeNext(searchParams.get("next"));
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setMessage(null);
     
-    const next = searchParams.get("next");
-    const redirectTo = new URL(`${window.location.origin}/auth/callback`);
-    if (next) redirectTo.searchParams.set("next", next);
-    
     const supabase = createClient();
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: {
-        emailRedirectTo: redirectTo.toString(),
-      },
     });
 
     if (error) {
@@ -41,7 +38,27 @@ function LoginForm() {
         : "We could not send a sign-in link. Check the email address and try again.";
       setMessage({ kind: "error", text });
     } else {
-      setMessage({ kind: "success", text: "Check your email for the sign-in link. Open the newest link in this same browser." });
+      setCodeSent(true);
+      setMessage({ kind: "success", text: "Check your email for the eight-digit sign-in code. Enter it here; the email can be opened on another device." });
+    }
+    setLoading(false);
+  };
+
+  const handleCodeVerification = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const token = code.replace(/\s/g, "");
+    if (!/^\d{8}$/.test(token)) {
+      setMessage({ kind: "error", text: "Enter the eight-digit code from your newest email." });
+      return;
+    }
+    setLoading(true);
+    setMessage(null);
+    const supabase = createClient();
+    const { error } = await supabase.auth.verifyOtp({ email, token, type: "email" });
+    if (error) {
+      setMessage({ kind: "error", text: "That code could not be used. Check you entered the newest code, or request another after the rate limit clears." });
+    } else {
+      window.location.assign(next);
     }
     setLoading(false);
   };
@@ -55,7 +72,7 @@ function LoginForm() {
         </div>
         {searchParams.get("error") === "magic-link" && (
           <p role="alert" className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm font-medium text-amber-900">
-            This sign-in link could not be completed. Open the newest link in the same browser that requested it. Do not request another link until the email rate limit has cleared.
+            That older sign-in link could not be completed. Request a new email code below and enter it in this browser. Do not request another code until the email rate limit has cleared.
           </p>
         )}
         <form className="mt-8 space-y-6" onSubmit={handleLogin}>
@@ -78,7 +95,7 @@ function LoginForm() {
               disabled={loading}
               className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-[#121212] hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#121212] disabled:opacity-50"
             >
-              {loading ? "Sending magic link..." : "Send Magic Link"}
+              {loading ? "Sending code..." : codeSent ? "Send a new code" : "Send sign-in code"}
             </button>
           </div>
           {message && (
@@ -90,7 +107,20 @@ function LoginForm() {
             </p>
           )}
         </form>
+        {codeSent && (
+          <form className="space-y-4 border-t border-gray-200 pt-6" onSubmit={handleCodeVerification}>
+            <div>
+              <label htmlFor="code" className="text-sm font-medium text-gray-700">Sign-in code</label>
+              <input id="code" name="code" inputMode="numeric" autoComplete="one-time-code" pattern="[0-9]{8}" maxLength={8} required className="mt-2 block w-full rounded-md border border-gray-300 px-3 py-2 tracking-[0.35em] text-[#121212] focus:outline-none focus:ring-2 focus:ring-[#121212]" placeholder="12345678" value={code} onChange={(event) => setCode(event.target.value.replace(/\D/g, ""))} />
+            </div>
+            <button type="submit" disabled={loading} className="group relative flex w-full justify-center rounded-md border border-transparent bg-[#121212] px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-[#121212] focus:ring-offset-2 disabled:opacity-50">{loading ? "Verifying code..." : "Verify and sign in"}</button>
+          </form>
+        )}
       </div>
     </div>
   );
+}
+
+function safeNext(value: string | null) {
+  return value?.startsWith("/") && !value.startsWith("//") ? value : "/ops";
 }

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
-import { decideListingAction, saveListingDraftAction } from "../actions";
+import { decideListingAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
 
 type Listing = {
   vendor_id: string;
@@ -34,6 +34,7 @@ type ListingEvidence = {
   checked_at: string | null;
   created_at: string;
 };
+type SubmissionStatus = { submission_status: string; operator_message: string | null; updated_at: string };
 
 export default async function OpsListingDetailPage({ params, searchParams }: {
   params: Promise<{ vendorId: string }>;
@@ -42,12 +43,13 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const { vendorId } = await params;
   const message = await searchParams;
   const { supabase } = await verifyOpsAdmin(`/ops/listings/${vendorId}`);
-  const [{ data, error }, categoriesResult, suburbsResult, evidenceResult, routeResult] = await Promise.all([
+  const [{ data, error }, categoriesResult, suburbsResult, evidenceResult, routeResult, submissionResult] = await Promise.all([
     supabase.rpc("ops_list_listings", { p_status: "all", p_query: null, p_vendor_id: vendorId, p_limit: 1, p_offset: 0 }),
     supabase.from("categories").select("name, slug").order("name"),
     supabase.from("suburbs").select("name, slug").order("name"),
     supabase.rpc("ops_list_listing_evidence", { p_vendor_id: vendorId }),
     supabase.rpc("resolve_public_vendor_route", { p_route_key: vendorId }),
+    supabase.rpc("ops_get_business_submission_status", { p_vendor_id: vendorId }),
   ]);
   if (error || categoriesResult.error || suburbsResult.error || evidenceResult.error) throw new Error("The listing could not be loaded.");
   const listing = data?.[0] as Listing | undefined;
@@ -56,6 +58,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const status = listing.listing_status;
   const evidence = (evidenceResult.data ?? []) as ListingEvidence[];
   const publicSlug = routeResult.data?.[0]?.current_slug as string | undefined;
+  const submission = submissionResult.data?.[0] as SubmissionStatus | undefined;
   const successfulAction = ["draft", "publish", "approve_changes", "reject", "unpublish", "restore"].includes(message.success ?? "");
 
   return (
@@ -80,6 +83,8 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
           <div className="mt-5 space-y-4">{evidence.map((item) => <EvidenceCard key={item.evidence_id} evidence={item} />)}</div>
         )}
       </section>
+
+      {submission && <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"><h3 className="text-xl font-bold">Private submitter status</h3><p className="mt-2 text-sm text-slate-600">This is a private, signed-in status only. It does not send email or change publication.</p><p className="mt-4 font-semibold">Current status: {statusLabel(submission.submission_status)}</p>{submission.operator_message && <p className="mt-2 text-sm">Current message: {submission.operator_message}</p>}{!['approved','declined'].includes(submission.submission_status) && <form action={setBusinessSubmissionStatusAction} className="mt-5 space-y-4"><input type="hidden" name="vendorId" value={vendorId} /><label className="block text-sm font-bold">Outcome<select name="outcome" required className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="">Choose one</option><option value="needs_information">Needs information</option><option value="approved">Approved</option><option value="declined">Declined</option></select></label><label className="block text-sm font-bold">Plain-language message<textarea name="message" required maxLength={2000} rows={3} className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label><button className="btn btn-outline">Save private status</button></form>}</section>}
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">Approved public fields and operator draft</h3>

--- a/web/src/app/ops/listings/actions.ts
+++ b/web/src/app/ops/listings/actions.ts
@@ -6,6 +6,20 @@ import { verifyOpsAdmin } from "@/lib/ops/auth";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const decisions = new Set(["publish", "approve_changes", "reject", "unpublish", "restore"]);
+const submissionOutcomes = new Set(["needs_information", "approved", "declined"]);
+
+export async function setBusinessSubmissionStatusAction(formData: FormData) {
+  const vendorId = String(formData.get("vendorId") ?? "");
+  const outcome = String(formData.get("outcome") ?? "");
+  const message = String(formData.get("message") ?? "").trim();
+  const detailPath = `/ops/listings/${vendorId}`;
+  const { supabase } = await verifyOpsAdmin(detailPath);
+  if (!uuidPattern.test(vendorId) || !submissionOutcomes.has(outcome) || message.length < 1 || message.length > 2000) redirect(`${detailPath}?error=submission_status`);
+  const { error } = await supabase.rpc("ops_set_business_submission_status", { p_vendor_id: vendorId, p_status: outcome, p_message: message });
+  if (error) redirect(`${detailPath}?error=submission_status`);
+  revalidatePath("/dashboard"); revalidatePath(detailPath);
+  redirect(`${detailPath}?success=submission_status`);
+}
 
 export async function saveListingDraftAction(formData: FormData) {
   const vendorId = String(formData.get("vendorId") ?? "");


### PR DESCRIPTION
Summary
- replace browser-bound passwordless links with eight-digit email codes
- add private signed-in status for missing-business submitters
- add an operator-only plain-language outcome control
- preserve holding posture and prohibit automatic publication, ownership changes, and general notifications

Verification
- lint and production build passed
- cross-device email-code and private-submission boundary tests passed
- Supabase Auth template updated and read back as Token-only
- remote migration applied and verified with authenticated-only privileges and an unauthenticated status guard