### PR TITLE
Fix Ops sign-in session handoff

### DIFF
--- a/scripts/test-cross-device-email-code-boundary.ts
+++ b/scripts/test-cross-device-email-code-boundary.ts
@@ -6,6 +6,8 @@ const communications = fs.readFileSync("docs/REFERENCE/SuburbMates — Communica
 
 assert.match(login, /supabase\.auth\.signInWithOtp\(\{\s*email,/);
 assert.match(login, /supabase\.auth\.verifyOtp\(\{ email, token, type: "email" \}\)/);
+assert.match(login, /data\.session/);
+assert.match(login, /requestAnimationFrame/);
 assert.match(login, /autoComplete="one-time-code"/);
 assert.match(login, /safeNext\(/);
 assert.match(login, /startsWith\("\/"\) && !value\.startsWith\("\/\/"\)/);

--- a/web/src/app/(directory)/login/page.tsx
+++ b/web/src/app/(directory)/login/page.tsx
@@ -34,8 +34,8 @@ function LoginForm() {
 
     if (error) {
       const text = error.message.toLowerCase().includes("rate")
-        ? "Too many sign-in links were requested. Wait a little while, then try again."
-        : "We could not send a sign-in link. Check the email address and try again.";
+        ? "Too many sign-in codes were requested. Wait a little while, then try again."
+        : "We could not send a sign-in code. Check the email address and try again.";
       setMessage({ kind: "error", text });
     } else {
       setCodeSent(true);
@@ -54,10 +54,13 @@ function LoginForm() {
     setLoading(true);
     setMessage(null);
     const supabase = createClient();
-    const { error } = await supabase.auth.verifyOtp({ email, token, type: "email" });
-    if (error) {
+    const { data, error } = await supabase.auth.verifyOtp({ email, token, type: "email" });
+    if (error || !data.session) {
       setMessage({ kind: "error", text: "That code could not be used. Check you entered the newest code, or request another after the rate limit clears." });
     } else {
+      // Let the browser persist the new session before the protected page is
+      // rendered on the server.
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
       window.location.assign(next);
     }
     setLoading(false);
@@ -68,7 +71,7 @@ function LoginForm() {
       <div className="w-full max-w-md space-y-8 bg-white text-[#121212] p-8 rounded-lg shadow-xl">
         <div className="text-center">
           <h1 className="text-3xl font-extrabold tracking-tight">Sign in to SuburbMates</h1>
-          <p className="mt-2 text-sm text-gray-600">Enter your email to receive a one-time sign-in link for your authorised area.</p>
+          <p className="mt-2 text-sm text-gray-600">Enter your email to receive a one-time sign-in code for your authorised area.</p>
         </div>
         {searchParams.get("error") === "magic-link" && (
           <p role="alert" className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm font-medium text-amber-900">

--- a/web/src/app/ops/claims/[claimId]/page.tsx
+++ b/web/src/app/ops/claims/[claimId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
 import { reviewClaimAction } from "../actions";
 
@@ -32,7 +32,7 @@ export default async function OpsClaimDetailPage({
 }) {
   const { claimId } = await params;
   const message = await searchParams;
-  const { supabase } = await verifyOpsAdmin(`/ops/claims/${claimId}`);
+  const supabase = await createOpsDataClient();
   const { data, error } = await supabase.rpc("ops_list_claim_requests", {
     p_status: null,
     p_claim_request_id: claimId,

--- a/web/src/app/ops/claims/page.tsx
+++ b/web/src/app/ops/claims/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDate } from "@/lib/ops/date";
 
 const statuses = ["pending", "needs_information", "approved", "rejected", "revoked"] as const;
@@ -25,7 +25,7 @@ export default async function OpsClaimsPage({
   const params = await searchParams;
   const status = statuses.includes(params.status as ClaimStatus) ? (params.status as ClaimStatus) : "pending";
   const page = pageNumber(params.page);
-  const { supabase } = await verifyOpsAdmin(`/ops/claims?status=${status}`);
+  const supabase = await createOpsDataClient();
   const { data, error } = await supabase.rpc("ops_list_claim_requests", {
     p_status: status,
     p_claim_request_id: null,

--- a/web/src/app/ops/contact/[requestId]/page.tsx
+++ b/web/src/app/ops/contact/[requestId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
 import { reviewContactAction } from "../actions";
 
@@ -33,7 +33,7 @@ export default async function OpsContactDetailPage({
 }) {
   const { requestId } = await params;
   const message = await searchParams;
-  const { supabase } = await verifyOpsAdmin(`/ops/contact/${requestId}`);
+  const supabase = await createOpsDataClient();
   const { data, error } = await supabase.rpc("ops_list_contact_requests", {
     p_status: null,
     p_contact_request_id: requestId,

--- a/web/src/app/ops/contact/page.tsx
+++ b/web/src/app/ops/contact/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDate } from "@/lib/ops/date";
 
 const statuses = ["new", "in_progress", "resolved", "spam"] as const;
@@ -25,7 +25,7 @@ export default async function OpsContactPage({
   const params = await searchParams;
   const status = statuses.includes(params.status as ContactStatus) ? (params.status as ContactStatus) : "new";
   const page = pageNumber(params.page);
-  const { supabase } = await verifyOpsAdmin(`/ops/contact?status=${status}`);
+  const supabase = await createOpsDataClient();
   const { data, error } = await supabase.rpc("ops_list_contact_requests", {
     p_status: status,
     p_contact_request_id: null,

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
 import { decideListingAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
 
@@ -42,7 +42,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
 }) {
   const { vendorId } = await params;
   const message = await searchParams;
-  const { supabase } = await verifyOpsAdmin(`/ops/listings/${vendorId}`);
+  const supabase = await createOpsDataClient();
   const [{ data, error }, categoriesResult, suburbsResult, evidenceResult, routeResult, submissionResult] = await Promise.all([
     supabase.rpc("ops_list_listings", { p_status: "all", p_query: null, p_vendor_id: vendorId, p_limit: 1, p_offset: 0 }),
     supabase.from("categories").select("name, slug").order("name"),

--- a/web/src/app/ops/listings/page.tsx
+++ b/web/src/app/ops/listings/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 
 const statuses = ["review", "unclassified", "draft", "pending_review", "published", "rejected", "unpublished"] as const;
 type Status = (typeof statuses)[number];
@@ -23,7 +23,7 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
   const status = statuses.includes(params.status as Status) ? (params.status as Status) : "review";
   const q = typeof params.q === "string" ? params.q.slice(0, 200) : "";
   const page = pageNumber(params.page);
-  const { supabase } = await verifyOpsAdmin(`/ops/listings?status=${status}`);
+  const supabase = await createOpsDataClient();
   const { data, error } = await supabase.rpc("ops_list_listings", {
     p_status: status,
     p_query: q || null,

--- a/web/src/app/ops/page.tsx
+++ b/web/src/app/ops/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 
 type ClaimOverview = {
   pending_count: number;
@@ -37,7 +37,7 @@ type ContactOverview = {
 };
 
 export default async function OpsOverviewPage() {
-  const { supabase } = await verifyOpsAdmin("/ops");
+  const supabase = await createOpsDataClient();
   const [listingResult, claimResult, profileResult, contactResult, systemResult] = await Promise.all([
     supabase.rpc("ops_listing_overview"),
     supabase.rpc("ops_claim_overview"),

--- a/web/src/app/ops/profile-edits/[requestId]/page.tsx
+++ b/web/src/app/ops/profile-edits/[requestId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { reviewProfileChangeAction } from "../actions";
 
 const fieldLabels: Record<string, string> = {
@@ -37,7 +37,7 @@ export default async function OpsProfileEditDetailPage({
 }) {
   const { requestId } = await params;
   const message = await searchParams;
-  const { supabase } = await verifyOpsAdmin(`/ops/profile-edits/${requestId}`);
+  const supabase = await createOpsDataClient();
   const { data, error } = await supabase.rpc("ops_list_profile_changes", {
     p_status: null,
     p_change_request_id: requestId,

--- a/web/src/app/ops/profile-edits/page.tsx
+++ b/web/src/app/ops/profile-edits/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDate } from "@/lib/ops/date";
 
 const statuses = ["pending", "approved", "rejected"] as const;
@@ -21,7 +21,7 @@ export default async function OpsProfileEditsPage({ searchParams }: { searchPara
   const params = await searchParams;
   const status = statuses.includes(params.status as Status) ? (params.status as Status) : "pending";
   const page = pageNumber(params.page);
-  const { supabase } = await verifyOpsAdmin(`/ops/profile-edits?status=${status}`);
+  const supabase = await createOpsDataClient();
   const { data, error } = await supabase.rpc("ops_list_profile_changes", {
     p_status: status,
     p_change_request_id: null,

--- a/web/src/app/ops/system/page.tsx
+++ b/web/src/app/ops/system/page.tsx
@@ -1,4 +1,4 @@
-import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
 
 type Health = {
@@ -16,7 +16,7 @@ type Audit = { event_id: string; actor_type: string; action: string; entity_type
 type AttentionItem = { title: string; explanation: string; reference: string };
 
 export default async function OpsSystemPage() {
-  const { supabase } = await verifyOpsAdmin("/ops/system");
+  const supabase = await createOpsDataClient();
   const [healthResult, jobsResult, auditResult] = await Promise.all([
     supabase.rpc("ops_list_integration_health"),
     supabase.rpc("ops_list_automation_jobs", { p_limit: 200 }),

--- a/web/src/lib/ops/auth.ts
+++ b/web/src/lib/ops/auth.ts
@@ -3,6 +3,13 @@ import "server-only";
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/utils/supabase/server";
 
+// OpsLayout makes the access decision for every rendered /ops route. Child
+// pages use this for data queries so a just-established browser session is not
+// checked twice during the same initial render.
+export async function createOpsDataClient() {
+  return createClient();
+}
+
 export async function verifyOpsAdmin(nextPath: string) {
   const supabase = await createClient();
   const {


### PR DESCRIPTION
## Summary
- avoid the duplicate Ops authorisation check that races a newly verified browser session
- wait for the browser to persist a verified email-code session before navigation
- align sign-in text with code-based access

## Verification
- npm run cross-device-email-code:test
- npm --prefix web run lint
- npm --prefix web run build