### PR TITLE
Add operator ABN evidence checks

### DIFF
--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -95,6 +95,14 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Identity rule:** The same email may be used by a submitter and later by a business owner. Authentication never makes it an owner; only an approved claim creates the ownership link.
 - **Owner-submitted candidate rule:** A person who owns, manages, or represents a missing business signs in first, submits the private candidate and a relationship explanation, and receives a pending claim request. That combined intake never publishes the candidate or grants ownership automatically.
 
+### D-010 — Operator-run ABN evidence
+
+- **Date:** 22 July 2026
+- **Decision:** An operator may check one supplied ABN at a time using ABN Lookup. The full ABN and returned supporting details are private evidence. The public product may show only `ABN checked` when the latest result is active and less than 90 days old.
+- **Guardrail:** An ABN check cannot publish or unpublish a listing, grant or remove ownership, affect ranking, change a commercial state, or create a general `verified` badge. Missing, invalid, inactive, not-found and unavailable results are plain-language Ops outcomes, not a negative public label.
+- **Operational rule:** There is no bulk job or automatic recheck. When the 90-day evidence window expires, the public signal disappears until an operator deliberately checks again.
+- **Evidence to close:** Authorisation, active/inactive/invalid/provider-failure tests; persisted private evidence and audit record; live operator check; and a public projection showing the signal without exposing the ABN.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run abn-check:test && npm run abn-evidence:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -12,6 +12,8 @@
     "candidate-handoff:test": "tsx scripts/test-candidate-handoff-boundary.ts",
     "candidate:handoff": "tsx --env-file-if-exists=.env.local scripts/submit-candidate-handoff.ts",
     "candidate-automation-ingest:test": "tsx scripts/test-candidate-automation-ingest-boundary.ts",
+    "abn-check:test": "tsx scripts/test-abn-lookup.ts",
+    "abn-evidence:test": "tsx scripts/test-abn-evidence-boundary.ts",
     "claim:test": "tsx --env-file=.env.local scripts/test-claims.ts",
     "audit": "tsx --env-file-if-exists=.env.local scripts/audit-vendor-candidates.ts",
     "audit:test": "tsx --env-file-if-exists=.env.local scripts/test-audit.ts",

--- a/scripts/test-abn-evidence-boundary.ts
+++ b/scripts/test-abn-evidence-boundary.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const migration = fs.readFileSync(path.join(root, "supabase/migrations/20260722020000_operator_abn_evidence.sql"), "utf8");
+const action = fs.readFileSync(path.join(root, "web/src/app/ops/listings/actions.ts"), "utf8");
+const publicPage = fs.readFileSync(path.join(root, "web/src/app/vendor/[slug]/page.tsx"), "utf8");
+
+assert.match(migration, /private\.require_active_operator\(\)/);
+assert.match(migration, /REVOKE ALL ON FUNCTION public\.ops_record_abn_check[\s\S]*FROM PUBLIC, anon, service_role/);
+assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.ops_record_abn_check[\s\S]*TO authenticated/);
+assert.doesNotMatch(migration, /UPDATE public\.vendors/);
+assert.match(migration, /evidence\.checked_at >= timezone\('utc'::text, now\(\)\) - interval '90 days'/);
+assert.match(migration, /evidence\.evidence_data ->> 'abn_status' = 'active'/);
+assert.match(action, /verifyOpsAdmin\(detailPath\)/);
+assert.match(action, /ops_record_abn_check/);
+assert.doesNotMatch(action, /createAdminClient/);
+assert.match(publicPage, /vendor\.abn_checked/);
+
+console.log("ABN evidence boundary checks passed.");

--- a/scripts/test-abn-lookup.ts
+++ b/scripts/test-abn-lookup.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { isValidAbn, normalizeAbn, parseAbnResponse, providerFailure } from "../web/src/lib/automation/abn-policy";
+
+assert.equal(normalizeAbn("34 241 177 887"), "34241177887");
+assert.equal(isValidAbn("34241177887"), true);
+assert.equal(isValidAbn("34241177888"), false);
+assert.equal(isValidAbn("not-an-abn"), false);
+
+const checkedAt = "2026-07-22T00:00:00.000Z";
+assert.deepEqual(parseAbnResponse("<root><entityStatusCode>Active</entityStatusCode><organisationName>Example &amp; Co</organisationName></root>", checkedAt), {
+  abnStatus: "active", entityStatus: "Active", officialNames: ["Example & Co"], checkedAt, errorMessage: null,
+});
+assert.equal(parseAbnResponse("<root><entityStatusCode>Cancelled</entityStatusCode></root>", checkedAt).abnStatus, "inactive");
+assert.equal(parseAbnResponse("<root><exceptionCode>SEARCH</exceptionCode><exceptionDescription>No records found</exceptionDescription></root>", checkedAt).abnStatus, "not_found");
+assert.equal(providerFailure(checkedAt).abnStatus, "provider_failure");
+
+console.log("ABN validation checks passed.");

--- a/supabase/migrations/20260722020000_operator_abn_evidence.sql
+++ b/supabase/migrations/20260722020000_operator_abn_evidence.sql
@@ -1,0 +1,130 @@
+-- Operator-run ABN evidence. This is supporting evidence only: it never
+-- changes publication, ownership, ranking, tier, payment or claim state.
+
+CREATE OR REPLACE FUNCTION public.ops_record_abn_check(
+  p_vendor_id UUID,
+  p_submitted_abn TEXT,
+  p_abn_status TEXT,
+  p_entity_status TEXT DEFAULT NULL,
+  p_official_names JSONB DEFAULT '[]'::jsonb,
+  p_checked_at TIMESTAMPTZ DEFAULT NULL,
+  p_error_message TEXT DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_operator_id UUID := private.require_active_operator();
+  v_abn TEXT := regexp_replace(trim(coalesce(p_submitted_abn, '')), '[[:space:]]', '', 'g');
+  v_status TEXT := lower(trim(coalesce(p_abn_status, '')));
+  v_entity_status TEXT := nullif(trim(coalesce(p_entity_status, '')), '');
+  v_error TEXT := nullif(trim(coalesce(p_error_message, '')), '');
+  v_checked_at TIMESTAMPTZ := coalesce(p_checked_at, timezone('utc'::text, now()));
+  v_evidence_status TEXT;
+  v_evidence_id UUID;
+  v_vendor public.vendors%ROWTYPE;
+BEGIN
+  IF p_vendor_id IS NULL OR NOT EXISTS (SELECT 1 FROM public.vendors WHERE id = p_vendor_id) THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Choose an existing listing.';
+  END IF;
+  IF v_abn !~ '^[0-9]{11}$' THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'ABN must contain 11 digits.';
+  END IF;
+  IF v_status NOT IN ('active', 'inactive', 'invalid', 'not_found', 'provider_failure') THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'ABN check status is invalid.';
+  END IF;
+  IF jsonb_typeof(coalesce(p_official_names, '[]'::jsonb)) <> 'array' THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'ABN names must be a list.';
+  END IF;
+  IF length(coalesce(v_error, '')) > 500 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'ABN error is too long.';
+  END IF;
+
+  SELECT * INTO v_vendor FROM public.vendors WHERE id = p_vendor_id FOR UPDATE;
+  v_evidence_status := CASE v_status WHEN 'active' THEN 'passed' WHEN 'provider_failure' THEN 'failed' ELSE 'warning' END;
+
+  INSERT INTO public.listing_evidence (
+    vendor_id, evidence_type, status, summary, evidence_data, checked_at
+  ) VALUES (
+    p_vendor_id,
+    'abn_lookup',
+    v_evidence_status,
+    CASE v_status
+      WHEN 'active' THEN 'ABN is active according to ABN Lookup.'
+      WHEN 'inactive' THEN 'ABN Lookup returned an inactive ABN.'
+      WHEN 'invalid' THEN 'The supplied ABN did not pass validation.'
+      WHEN 'not_found' THEN 'ABN Lookup did not find this ABN.'
+      ELSE 'ABN Lookup could not complete this check.'
+    END,
+    jsonb_build_object(
+      'submitted_abn', v_abn,
+      'abn_status', v_status,
+      'entity_status', v_entity_status,
+      'official_names', coalesce(p_official_names, '[]'::jsonb),
+      'provider', 'ABN Lookup',
+      'error_message', v_error
+    ),
+    v_checked_at
+  ) RETURNING id INTO v_evidence_id;
+
+  INSERT INTO public.audit_events (
+    actor_type, actor_user_id, action, entity_type, entity_id, reason, before_data, after_data
+  ) VALUES (
+    'operator', v_operator_id, 'abn_check_recorded', 'vendor', p_vendor_id::text,
+    'Operator-run ABN evidence check.',
+    jsonb_build_object('listing_status', v_vendor.listing_status, 'is_published', v_vendor.is_published, 'ownership_status', v_vendor.ownership_status, 'tier', v_vendor.tier),
+    jsonb_build_object('listing_status', v_vendor.listing_status, 'is_published', v_vendor.is_published, 'ownership_status', v_vendor.ownership_status, 'tier', v_vendor.tier, 'abn_status', v_status, 'evidence_id', v_evidence_id)
+  );
+
+  RETURN v_evidence_id;
+END;
+$$;
+
+CREATE OR REPLACE VIEW public.published_vendors
+WITH (security_barrier = true, security_invoker = false)
+AS
+SELECT
+  vendor.id,
+  vendor.slug,
+  vendor.business_name,
+  vendor.category_slug,
+  vendor.suburb_slug,
+  vendor.contact_email,
+  vendor.phone,
+  vendor.website,
+  vendor.description,
+  vendor.tier,
+  vendor.is_claimed,
+  vendor.street_address,
+  vendor.created_at,
+  vendor.is_published,
+  EXISTS (
+    SELECT 1
+    FROM public.listing_evidence AS evidence
+    WHERE evidence.vendor_id = vendor.id
+      AND evidence.evidence_type = 'abn_lookup'
+      AND evidence.status = 'passed'
+      AND evidence.evidence_data ->> 'abn_status' = 'active'
+      AND evidence.checked_at >= timezone('utc'::text, now()) - interval '90 days'
+      AND evidence.id = (
+        SELECT latest.id
+        FROM public.listing_evidence AS latest
+        WHERE latest.vendor_id = vendor.id AND latest.evidence_type = 'abn_lookup'
+        ORDER BY latest.checked_at DESC NULLS LAST, latest.created_at DESC
+        LIMIT 1
+      )
+  ) AS abn_checked
+FROM public.vendors AS vendor
+WHERE vendor.is_published = true;
+
+REVOKE ALL ON FUNCTION public.ops_record_abn_check(UUID, TEXT, TEXT, TEXT, JSONB, TIMESTAMPTZ, TEXT) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.ops_record_abn_check(UUID, TEXT, TEXT, TEXT, JSONB, TIMESTAMPTZ, TEXT) TO authenticated;
+REVOKE ALL ON TABLE public.published_vendors FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.published_vendors TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.ops_record_abn_check(UUID, TEXT, TEXT, TEXT, JSONB, TIMESTAMPTZ, TEXT) IS
+  'Operator-only ABN Lookup evidence recorder. Preserves every listing lifecycle, ownership, payment and tier field.';
+COMMENT ON VIEW public.published_vendors IS
+  'Safe public directory projection. ABN checked is a current active-evidence signal only; it never exposes the ABN or a verified-owner claim.';

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
-import { decideListingAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
+import { decideListingAction, runAbnCheckAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
 
 type Listing = {
   vendor_id: string;
@@ -59,7 +59,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const evidence = (evidenceResult.data ?? []) as ListingEvidence[];
   const publicSlug = routeResult.data?.[0]?.current_slug as string | undefined;
   const submission = submissionResult.data?.[0] as SubmissionStatus | undefined;
-  const successfulAction = ["draft", "publish", "approve_changes", "reject", "unpublish", "restore"].includes(message.success ?? "");
+  const successfulAction = ["draft", "publish", "approve_changes", "reject", "unpublish", "restore"].includes(message.success ?? "") || (message.success ?? "").startsWith("abn_");
 
   return (
     <div className="space-y-7">
@@ -73,8 +73,8 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
         {listing.is_published && publicSlug && <Link href={`/vendor/${publicSlug}`} className="btn btn-outline">View public profile</Link>}
       </div>
 
-      {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 font-semibold text-red-800">{message.error === "draft" ? "The draft could not be saved. Check required fields and formats." : "The action failed. Refresh and check the listing state, draft and reason."}</p>}
-      {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">{message.success === "draft" ? "Operator draft saved. The public listing and sitemap were not changed." : "Decision recorded with an audit event."}</p>}
+      {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 font-semibold text-red-800">{message.error === "draft" ? "The draft could not be saved. Check required fields and formats." : message.error === "abn" ? "The ABN check could not be recorded. Enter 11 digits and try again." : "The action failed. Refresh and check the listing state, draft and reason."}</p>}
+      {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">{message.success === "draft" ? "Operator draft saved. The public listing and sitemap were not changed." : (message.success ?? "").startsWith("abn_") ? "ABN check recorded. It has not changed publication, ownership, ranking or tier." : "Decision recorded with an audit event."}</p>}
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">Source evidence</h3>
@@ -82,6 +82,17 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
         {evidence.length === 0 ? <p className="mt-5 rounded-xl bg-slate-100 p-4 text-sm text-slate-600">No structured evidence record exists for this legacy listing.</p> : (
           <div className="mt-5 space-y-4">{evidence.map((item) => <EvidenceCard key={item.evidence_id} evidence={item} />)}</div>
         )}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 className="text-xl font-bold">ABN check</h3>
+        <p className="mt-2 text-sm text-slate-600">Use this only for a supplied ABN. The result is private evidence. It never publishes a listing, confirms ownership, changes ranking or changes a plan.</p>
+        <form action={runAbnCheckAction} className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-end">
+          <input type="hidden" name="vendorId" value={vendorId} />
+          <label className="block flex-1 text-sm font-bold">ABN<input name="abn" inputMode="numeric" pattern="[0-9 ]{11,20}" maxLength={20} required placeholder="11 digits" className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label>
+          <button className="btn btn-outline">Check ABN</button>
+        </form>
+        <p className="mt-3 text-xs text-slate-500">Only a latest active result less than 90 days old may show “ABN checked” publicly. The ABN number itself stays private.</p>
       </section>
 
       {submission && <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"><h3 className="text-xl font-bold">Private submitter status</h3><p className="mt-2 text-sm text-slate-600">This is a private, signed-in status only. It does not send email or change publication.</p><p className="mt-4 font-semibold">Current status: {statusLabel(submission.submission_status)}</p>{submission.operator_message && <p className="mt-2 text-sm">Current message: {submission.operator_message}</p>}{!['approved','declined'].includes(submission.submission_status) && <form action={setBusinessSubmissionStatusAction} className="mt-5 space-y-4"><input type="hidden" name="vendorId" value={vendorId} /><label className="block text-sm font-bold">Outcome<select name="outcome" required className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="">Choose one</option><option value="needs_information">Needs information</option><option value="approved">Approved</option><option value="declined">Declined</option></select></label><label className="block text-sm font-bold">Plain-language message<textarea name="message" required maxLength={2000} rows={3} className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label><button className="btn btn-outline">Save private status</button></form>}</section>}

--- a/web/src/app/ops/listings/actions.ts
+++ b/web/src/app/ops/listings/actions.ts
@@ -3,10 +3,35 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { checkAbn, normalizeAbn } from "@/lib/automation/abn-lookup";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const decisions = new Set(["publish", "approve_changes", "reject", "unpublish", "restore"]);
 const submissionOutcomes = new Set(["needs_information", "approved", "declined"]);
+
+export async function runAbnCheckAction(formData: FormData) {
+  const vendorId = String(formData.get("vendorId") ?? "");
+  const abn = normalizeAbn(String(formData.get("abn") ?? ""));
+  const detailPath = `/ops/listings/${vendorId}`;
+  const { supabase } = await verifyOpsAdmin(detailPath);
+  if (!uuidPattern.test(vendorId) || !/^\d{11}$/.test(abn)) redirect(`${detailPath}?error=abn`);
+
+  const result = await checkAbn(abn);
+  const { error } = await supabase.rpc("ops_record_abn_check", {
+    p_vendor_id: vendorId,
+    p_submitted_abn: abn,
+    p_abn_status: result.abnStatus,
+    p_entity_status: result.entityStatus,
+    p_official_names: result.officialNames,
+    p_checked_at: result.checkedAt,
+    p_error_message: result.errorMessage,
+  });
+  if (error) redirect(`${detailPath}?error=abn`);
+  revalidatePath("/ops");
+  revalidatePath("/ops/listings");
+  revalidatePath(detailPath);
+  redirect(`${detailPath}?success=abn_${result.abnStatus}`);
+}
 
 export async function setBusinessSubmissionStatusAction(formData: FormData) {
   const vendorId = String(formData.get("vendorId") ?? "");

--- a/web/src/app/vendor/[slug]/page.tsx
+++ b/web/src/app/vendor/[slug]/page.tsx
@@ -105,7 +105,7 @@ export default async function VendorWebsite({ params }: PageProps) {
             </div>
             <div>
               <div className="font-black text-xl tracking-tight leading-none">{vendor.business_name}</div>
-              <div className={`text-sm font-medium ${design.palette.bodyText}`}>{vendor.categories?.name}</div>
+              <div className={`mt-1 flex flex-wrap items-center gap-2 text-sm font-medium ${design.palette.bodyText}`}><span>{vendor.categories?.name}</span>{vendor.abn_checked && <span className="rounded-full border border-current/30 px-2 py-0.5 text-xs font-bold">ABN checked</span>}</div>
             </div>
           </div>
           

--- a/web/src/lib/automation/abn-lookup.ts
+++ b/web/src/lib/automation/abn-lookup.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { runtimeEnv } from "@/lib/runtime-env";
+import { isValidAbn, parseAbnResponse, providerFailure, type AbnCheckResult } from "@/lib/automation/abn-policy";
+
+export { ABN_CHECK_FRESHNESS_DAYS, normalizeAbn } from "@/lib/automation/abn-policy";
+
+export type { AbnCheckResult } from "@/lib/automation/abn-policy";
+
+export async function checkAbn(abn: string): Promise<AbnCheckResult> {
+  const checkedAt = new Date().toISOString();
+  if (!isValidAbn(abn)) return { abnStatus: "invalid", entityStatus: null, officialNames: [], checkedAt, errorMessage: "This is not a valid 11-digit ABN." };
+
+  const guid = runtimeEnv("ABR_GUID");
+  if (!guid) return { abnStatus: "provider_failure", entityStatus: null, officialNames: [], checkedAt, errorMessage: "ABN Lookup is not configured." };
+
+  const url = new URL("https://abr.business.gov.au/abrxmlsearch/ABRXMLSearch.asmx/SearchByABNv202001");
+  url.searchParams.set("searchString", abn);
+  url.searchParams.set("includeHistoricalDetails", "N");
+  url.searchParams.set("authenticationGuid", guid);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(url, { cache: "no-store", signal: controller.signal });
+    if (!response.ok) return providerFailure(checkedAt);
+    const xml = await response.text();
+    return parseAbnResponse(xml, checkedAt);
+  } catch {
+    return providerFailure(checkedAt);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/web/src/lib/automation/abn-policy.ts
+++ b/web/src/lib/automation/abn-policy.ts
@@ -1,0 +1,57 @@
+export const ABN_CHECK_FRESHNESS_DAYS = 90;
+
+export type AbnCheckResult = {
+  abnStatus: "active" | "inactive" | "invalid" | "not_found" | "provider_failure";
+  entityStatus: string | null;
+  officialNames: string[];
+  checkedAt: string;
+  errorMessage: string | null;
+};
+
+export function normalizeAbn(value: string) {
+  return value.replace(/\s+/g, "");
+}
+
+export function isValidAbn(value: string) {
+  if (!/^\d{11}$/.test(value)) return false;
+  const weights = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+  return value.split("").reduce((sum, digit, index) => sum + (Number(digit) - (index === 0 ? 1 : 0)) * weights[index], 0) % 89 === 0;
+}
+
+export function parseAbnResponse(xml: string, checkedAt: string): AbnCheckResult {
+  const exception = text(xml, "exceptionDescription");
+  if (exception) return {
+    abnStatus: text(xml, "exceptionCode") === "SEARCH" ? "not_found" : "provider_failure",
+    entityStatus: null, officialNames: [], checkedAt, errorMessage: safeProviderMessage(exception),
+  };
+  const entityStatus = text(xml, "entityStatusCode");
+  if (!entityStatus) return providerFailure(checkedAt);
+  return {
+    abnStatus: entityStatus.toLowerCase() === "active" ? "active" : "inactive",
+    entityStatus, officialNames: names(xml), checkedAt, errorMessage: null,
+  };
+}
+
+export function providerFailure(checkedAt: string): AbnCheckResult {
+  return { abnStatus: "provider_failure", entityStatus: null, officialNames: [], checkedAt, errorMessage: "ABN Lookup is temporarily unavailable. Try again later." };
+}
+
+function text(xml: string, tag: string) {
+  const match = xml.match(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, "i"));
+  return match ? decode(match[1].trim()) : null;
+}
+
+function names(xml: string) {
+  const values = ["organisationName", "givenName", "familyName", "businessName"]
+    .flatMap((tag) => [...xml.matchAll(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, "gi"))].map((match) => decode(match[1].trim())))
+    .filter(Boolean);
+  return [...new Set(values)].slice(0, 10);
+}
+
+function decode(value: string) {
+  return value.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#39;/g, "'");
+}
+
+function safeProviderMessage(value: string) {
+  return value.replace(/\s+/g, " ").trim().slice(0, 500);
+}


### PR DESCRIPTION
Builds the operator-only ABN Lookup workflow for SUB-25.

- One simple check action on an Ops listing
- Private ABN evidence and audit record
- Plain-language inactive, invalid, not-found, and provider-failure states
- Public ABN checked signal only for the latest active result within 90 days
- No listing lifecycle, ownership, ranking, tier, payment, or claim changes

Verification: remote migration aligned; service role cannot call the operator function; npm run check; npm --prefix web run lint; npm --prefix web run build.