### PR TITLE
Clarify operator ABN check outcomes

### DIFF
--- a/scripts/test-abn-lookup.ts
+++ b/scripts/test-abn-lookup.ts
@@ -10,6 +10,7 @@ const checkedAt = "2026-07-22T00:00:00.000Z";
 assert.deepEqual(parseAbnResponse("<root><entityStatusCode>Active</entityStatusCode><organisationName>Example &amp; Co</organisationName></root>", checkedAt), {
   abnStatus: "active", entityStatus: "Active", officialNames: ["Example & Co"], checkedAt, errorMessage: null,
 });
+assert.deepEqual(parseAbnResponse("<root><entityStatusCode>Active</entityStatusCode><mainName>Example Holdings</mainName><businessName>Example Services</businessName></root>", checkedAt).officialNames, ["Example Holdings", "Example Services"]);
 assert.equal(parseAbnResponse("<root><entityStatusCode>Cancelled</entityStatusCode></root>", checkedAt).abnStatus, "inactive");
 assert.equal(parseAbnResponse("<root><exceptionCode>SEARCH</exceptionCode><exceptionDescription>No records found</exceptionDescription></root>", checkedAt).abnStatus, "not_found");
 assert.equal(providerFailure(checkedAt).abnStatus, "provider_failure");

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -59,7 +59,9 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const evidence = (evidenceResult.data ?? []) as ListingEvidence[];
   const publicSlug = routeResult.data?.[0]?.current_slug as string | undefined;
   const submission = submissionResult.data?.[0] as SubmissionStatus | undefined;
-  const successfulAction = ["draft", "publish", "approve_changes", "reject", "unpublish", "restore"].includes(message.success ?? "") || (message.success ?? "").startsWith("abn_");
+  const success = message.success ?? "";
+  const abnStatus = success.startsWith("abn_") ? success.slice(4) : null;
+  const successfulAction = ["draft", "publish", "approve_changes", "reject", "unpublish", "restore"].includes(success);
 
   return (
     <div className="space-y-7">
@@ -74,7 +76,8 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
       </div>
 
       {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 font-semibold text-red-800">{message.error === "draft" ? "The draft could not be saved. Check required fields and formats." : message.error === "abn" ? "The ABN check could not be recorded. Enter 11 digits and try again." : "The action failed. Refresh and check the listing state, draft and reason."}</p>}
-      {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">{message.success === "draft" ? "Operator draft saved. The public listing and sitemap were not changed." : (message.success ?? "").startsWith("abn_") ? "ABN check recorded. It has not changed publication, ownership, ranking or tier." : "Decision recorded with an audit event."}</p>}
+      {abnStatus && <AbnResult status={abnStatus} />}
+      {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">{success === "draft" ? "Operator draft saved. The public listing and sitemap were not changed." : "Decision recorded with an audit event."}</p>}
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">Source evidence</h3>
@@ -161,6 +164,18 @@ function value(source: Listing | Record<string, string | null>, key: string) {
 function statusLabel(status: string) {
   if (status === "unclassified") return "Needs classification";
   return status.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function AbnResult({ status }: { status: string }) {
+  const message = {
+    active: "ABN is active. The result has been saved as private evidence. It has not changed publication, ownership, ranking or plan.",
+    inactive: "ABN is not active. The result has been saved as private evidence. Review it alongside the rest of the listing evidence.",
+    invalid: "This number did not pass ABN validation. No external lookup was made; the result has been recorded privately.",
+    not_found: "ABN Lookup did not find this number. The result has been saved as private evidence for review.",
+    provider_failure: "ABN Lookup could not complete the check. Nothing else changed; try again later.",
+  }[status] ?? "ABN check recorded. It has not changed publication, ownership, ranking or plan.";
+  const caution = status !== "active";
+  return <p role={caution ? "status" : undefined} className={`rounded-xl border p-4 font-semibold ${caution ? "border-amber-300 bg-amber-50 text-amber-900" : "border-green-300 bg-green-50 text-green-800"}`}>{message}</p>;
 }
 
 function EvidenceCard({ evidence }: { evidence: ListingEvidence }) {

--- a/web/src/lib/automation/abn-policy.ts
+++ b/web/src/lib/automation/abn-policy.ts
@@ -42,7 +42,11 @@ function text(xml: string, tag: string) {
 }
 
 function names(xml: string) {
-  const values = ["organisationName", "givenName", "familyName", "businessName"]
+  // ABN Lookup may return different name types depending on whether the
+  // entity is an individual, non-individual, or has suppressed details.
+  // Preserve the available official names as private evidence; no name is
+  // used to make an ownership or publication decision.
+  const values = ["organisationName", "mainName", "legalName", "givenName", "familyName", "businessName", "mainTradingName", "otherTradingName"]
     .flatMap((tag) => [...xml.matchAll(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tag}>`, "gi"))].map((match) => decode(match[1].trim())))
     .filter(Boolean);
   return [...new Set(values)].slice(0, 10);


### PR DESCRIPTION
## Outcome
Makes the existing ABN check easier for Ops to interpret without changing the underlying safety model.

## What changed
- Adds plain-English result feedback for active, inactive, invalid, not-found and temporary-provider-failure outcomes.
- Captures the official ABR name variants that may be returned for different entity types as private evidence.
- Keeps publication, ownership, ranking, tier and plan unchanged by every ABN outcome.

## Verification
- `npm run check`
- `npm --prefix web run lint`
- `npm --prefix web run build`
- Successful read-only ABR endpoint and credential check with an official ABR test case.