### PR TITLE
Add moderated owner media proposals

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run abn-check:test && npm run abn-evidence:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run abn-check:test && npm run abn-evidence:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -14,6 +14,7 @@
     "candidate-automation-ingest:test": "tsx scripts/test-candidate-automation-ingest-boundary.ts",
     "abn-check:test": "tsx scripts/test-abn-lookup.ts",
     "abn-evidence:test": "tsx scripts/test-abn-evidence-boundary.ts",
+    "owner-media:test": "tsx scripts/test-owner-media-boundary.ts",
     "claim:test": "tsx --env-file=.env.local scripts/test-claims.ts",
     "audit": "tsx --env-file-if-exists=.env.local scripts/audit-vendor-candidates.ts",
     "audit:test": "tsx --env-file-if-exists=.env.local scripts/test-audit.ts",

--- a/scripts/test-owner-media-boundary.ts
+++ b/scripts/test-owner-media-boundary.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+const migration = fs.readFileSync(path.join(root, "supabase/migrations/20260722023000_moderated_owner_media.sql"), "utf8");
+const ownerRoute = fs.readFileSync(path.join(root, "web/src/app/api/owner/media/route.ts"), "utf8");
+const publicRoute = fs.readFileSync(path.join(root, "web/src/app/api/media/[mediaId]/route.ts"), "utf8");
+
+assert.match(migration, /'owner-media-proposals', 'owner-media-proposals', false, 2097152/);
+assert.match(migration, /REVOKE ALL ON TABLE public\.listing_media_proposals FROM PUBLIC, anon, authenticated/);
+assert.match(migration, /private\.require_active_operator\(\)/);
+assert.match(migration, /publication_unchanged/);
+assert.doesNotMatch(migration, /UPDATE public\.vendors/);
+assert.match(ownerRoute, /imageContentType\(bytes\)/);
+assert.match(ownerRoute, /const admin = createAdminClient\(\)/);
+assert.match(ownerRoute, /admin\.storage\.from\("owner-media-proposals"\)\.upload/);
+assert.match(ownerRoute, /Only the claimed owner can propose media/);
+assert.match(publicRoute, /NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED !== "true"/);
+assert.match(publicRoute, /resolve_public_media/);
+assert.doesNotMatch(ownerRoute, /getPublicUrl/);
+
+console.log("Owner media privacy and holding-gate boundary checks passed.");

--- a/supabase/migrations/20260722023000_moderated_owner_media.sql
+++ b/supabase/migrations/20260722023000_moderated_owner_media.sql
@@ -1,0 +1,167 @@
+-- Private owner-media proposals. Storage stays private; no direct client
+-- storage policy is granted. Approval never changes listing lifecycle or ownership.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('owner-media-proposals', 'owner-media-proposals', false, 2097152, ARRAY['image/jpeg', 'image/png', 'image/webp'])
+ON CONFLICT (id) DO UPDATE SET public = false, file_size_limit = 2097152, allowed_mime_types = ARRAY['image/jpeg', 'image/png', 'image/webp'];
+
+CREATE TABLE IF NOT EXISTS public.listing_media_proposals (
+  id UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  vendor_id UUID NOT NULL REFERENCES public.vendors(id) ON DELETE RESTRICT,
+  submitted_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  media_kind TEXT NOT NULL CHECK (media_kind IN ('logo', 'listing_image')),
+  storage_path TEXT NOT NULL UNIQUE,
+  content_type TEXT NOT NULL CHECK (content_type IN ('image/jpeg', 'image/png', 'image/webp')),
+  byte_size INTEGER NOT NULL CHECK (byte_size > 0 AND byte_size <= 2097152),
+  checksum_sha256 TEXT NOT NULL CHECK (checksum_sha256 ~ '^[0-9a-f]{64}$'),
+  alt_text TEXT NOT NULL CHECK (length(alt_text) BETWEEN 2 AND 160),
+  source_basis TEXT NOT NULL CHECK (length(source_basis) BETWEEN 10 AND 1000),
+  proposal_status TEXT NOT NULL DEFAULT 'pending' CHECK (proposal_status IN ('pending', 'approved', 'rejected', 'removed')),
+  operator_reason TEXT,
+  decided_by UUID REFERENCES auth.users(id) ON DELETE RESTRICT,
+  decided_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now())
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS listing_media_one_pending_kind_idx
+  ON public.listing_media_proposals (vendor_id, media_kind)
+  WHERE proposal_status = 'pending';
+CREATE INDEX IF NOT EXISTS listing_media_vendor_status_idx
+  ON public.listing_media_proposals (vendor_id, proposal_status, created_at DESC);
+
+ALTER TABLE public.listing_media_proposals ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.listing_media_proposals FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.listing_media_proposals TO service_role;
+
+CREATE OR REPLACE FUNCTION public.submit_owner_media_proposal(
+  p_vendor_id UUID, p_media_kind TEXT, p_storage_path TEXT, p_content_type TEXT,
+  p_byte_size INTEGER, p_checksum_sha256 TEXT, p_alt_text TEXT, p_source_basis TEXT
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_kind TEXT := lower(trim(coalesce(p_media_kind, '')));
+  v_path TEXT := trim(coalesce(p_storage_path, ''));
+  v_type TEXT := lower(trim(coalesce(p_content_type, '')));
+  v_checksum TEXT := lower(trim(coalesce(p_checksum_sha256, '')));
+  v_alt TEXT := trim(coalesce(p_alt_text, ''));
+  v_basis TEXT := trim(coalesce(p_source_basis, ''));
+  v_id UUID;
+  v_vendor public.vendors%ROWTYPE;
+BEGIN
+  IF v_user_id IS NULL THEN RAISE EXCEPTION USING ERRCODE='42501', MESSAGE='Sign in to propose media.'; END IF;
+  SELECT * INTO v_vendor FROM public.vendors WHERE id = p_vendor_id FOR UPDATE;
+  IF NOT FOUND OR v_vendor.owner_id IS DISTINCT FROM v_user_id OR NOT v_vendor.is_claimed OR v_vendor.ownership_status NOT IN ('claimed', 'owner_verified') THEN
+    RAISE EXCEPTION USING ERRCODE='42501', MESSAGE='Only the claimed owner can propose media for this listing.';
+  END IF;
+  IF v_kind NOT IN ('logo', 'listing_image') OR v_type NOT IN ('image/jpeg', 'image/png', 'image/webp') OR p_byte_size IS NULL OR p_byte_size < 1 OR p_byte_size > 2097152 THEN
+    RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='The media file is not supported.';
+  END IF;
+  IF v_checksum !~ '^[0-9a-f]{64}$' OR v_path !~ '^proposals/[0-9a-f-]{36}/[0-9a-f-]{36}\.(jpg|png|webp)$' THEN
+    RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='The media upload reference is invalid.';
+  END IF;
+  IF length(v_alt) NOT BETWEEN 2 AND 160 OR length(v_basis) NOT BETWEEN 10 AND 1000 THEN
+    RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='Describe the media and your permission to use it.';
+  END IF;
+
+  INSERT INTO public.listing_media_proposals (vendor_id, submitted_by, media_kind, storage_path, content_type, byte_size, checksum_sha256, alt_text, source_basis)
+  VALUES (p_vendor_id, v_user_id, v_kind, v_path, v_type, p_byte_size, v_checksum, v_alt, v_basis)
+  RETURNING id INTO v_id;
+
+  INSERT INTO public.audit_events (actor_type, actor_user_id, action, entity_type, entity_id, reason, after_data)
+  VALUES ('owner', v_user_id, 'owner_media_proposed', 'listing_media_proposal', v_id::text, 'Owner submitted private media for moderation.', jsonb_build_object('vendor_id', p_vendor_id, 'media_kind', v_kind, 'proposal_status', 'pending', 'publication_unchanged', v_vendor.is_published));
+  RETURN v_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_current_owner_media_proposals()
+RETURNS TABLE (proposal_id UUID, vendor_id UUID, business_name TEXT, media_kind TEXT, proposal_status TEXT, alt_text TEXT, operator_reason TEXT, created_at TIMESTAMPTZ, decided_at TIMESTAMPTZ)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ''
+AS $$
+  SELECT proposal.id, proposal.vendor_id, vendor.business_name, proposal.media_kind, proposal.proposal_status, proposal.alt_text, proposal.operator_reason, proposal.created_at, proposal.decided_at
+  FROM public.listing_media_proposals proposal
+  JOIN public.vendors vendor ON vendor.id = proposal.vendor_id
+  WHERE proposal.submitted_by = auth.uid()
+  ORDER BY proposal.created_at DESC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ops_list_media_proposals(p_status TEXT DEFAULT NULL, p_vendor_id UUID DEFAULT NULL)
+RETURNS TABLE (proposal_id UUID, vendor_id UUID, business_name TEXT, media_kind TEXT, storage_path TEXT, content_type TEXT, byte_size INTEGER, alt_text TEXT, source_basis TEXT, proposal_status TEXT, operator_reason TEXT, created_at TIMESTAMPTZ, decided_at TIMESTAMPTZ)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_active_operator();
+  IF p_status IS NOT NULL AND p_status NOT IN ('pending', 'approved', 'rejected', 'removed') THEN RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='Invalid media status.'; END IF;
+  RETURN QUERY SELECT proposal.id, proposal.vendor_id, vendor.business_name, proposal.media_kind, proposal.storage_path, proposal.content_type, proposal.byte_size, proposal.alt_text, proposal.source_basis, proposal.proposal_status, proposal.operator_reason, proposal.created_at, proposal.decided_at
+  FROM public.listing_media_proposals proposal JOIN public.vendors vendor ON vendor.id = proposal.vendor_id
+  WHERE (p_status IS NULL OR proposal.proposal_status = p_status) AND (p_vendor_id IS NULL OR proposal.vendor_id = p_vendor_id)
+  ORDER BY CASE WHEN proposal.proposal_status = 'pending' THEN 0 ELSE 1 END, proposal.created_at DESC;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.ops_decide_media_proposal(p_proposal_id UUID, p_action TEXT, p_reason TEXT)
+RETURNS TABLE (proposal_id UUID, vendor_id UUID, proposal_status TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_operator_id UUID := private.require_active_operator();
+  v_action TEXT := lower(trim(coalesce(p_action, '')));
+  v_reason TEXT := trim(coalesce(p_reason, ''));
+  v_proposal public.listing_media_proposals%ROWTYPE;
+  v_vendor public.vendors%ROWTYPE;
+  v_status TEXT;
+BEGIN
+  IF v_action NOT IN ('approve', 'reject', 'remove') OR length(v_reason) NOT BETWEEN 1 AND 2000 THEN RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='Enter a valid media decision and reason.'; END IF;
+  SELECT * INTO v_proposal FROM public.listing_media_proposals WHERE id = p_proposal_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='Media proposal was not found.'; END IF;
+  SELECT * INTO v_vendor FROM public.vendors WHERE id = v_proposal.vendor_id FOR UPDATE;
+  IF v_action IN ('approve', 'reject') AND v_proposal.proposal_status <> 'pending' THEN RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='Only a pending proposal can be approved or rejected.'; END IF;
+  IF v_action = 'remove' AND v_proposal.proposal_status <> 'approved' THEN RAISE EXCEPTION USING ERRCODE='55000', MESSAGE='Only approved media can be removed.'; END IF;
+  v_status := CASE v_action WHEN 'approve' THEN 'approved' WHEN 'reject' THEN 'rejected' ELSE 'removed' END;
+  UPDATE public.listing_media_proposals SET proposal_status=v_status, operator_reason=v_reason, decided_by=v_operator_id, decided_at=timezone('utc'::text, now()), updated_at=timezone('utc'::text, now()) WHERE id=v_proposal.id;
+  INSERT INTO public.audit_events (actor_type, actor_user_id, action, entity_type, entity_id, reason, before_data, after_data)
+  VALUES ('operator', v_operator_id, 'owner_media_' || v_status, 'listing_media_proposal', v_proposal.id::text, v_reason, jsonb_build_object('proposal_status', v_proposal.proposal_status, 'vendor_id', v_proposal.vendor_id, 'publication_unchanged', v_vendor.is_published), jsonb_build_object('proposal_status', v_status, 'vendor_id', v_proposal.vendor_id, 'publication_unchanged', v_vendor.is_published));
+  RETURN QUERY SELECT v_proposal.id, v_proposal.vendor_id, v_status;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_public_vendor_media(p_vendor_id UUID)
+RETURNS TABLE (media_id UUID, media_kind TEXT, alt_text TEXT)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ''
+AS $$
+  SELECT proposal.id, proposal.media_kind, proposal.alt_text
+  FROM public.listing_media_proposals proposal
+  JOIN public.vendors vendor ON vendor.id = proposal.vendor_id
+  WHERE proposal.vendor_id = p_vendor_id AND proposal.proposal_status = 'approved' AND vendor.is_published = true
+  ORDER BY CASE WHEN proposal.media_kind = 'logo' THEN 0 ELSE 1 END, proposal.created_at ASC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.resolve_public_media(p_media_id UUID)
+RETURNS TABLE (storage_path TEXT, content_type TEXT)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = ''
+AS $$
+  SELECT proposal.storage_path, proposal.content_type
+  FROM public.listing_media_proposals proposal
+  JOIN public.vendors vendor ON vendor.id = proposal.vendor_id
+  WHERE proposal.id = p_media_id AND proposal.proposal_status = 'approved' AND vendor.is_published = true;
+$$;
+
+REVOKE ALL ON FUNCTION public.submit_owner_media_proposal(UUID, TEXT, TEXT, TEXT, INTEGER, TEXT, TEXT, TEXT) FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.list_current_owner_media_proposals() FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.ops_list_media_proposals(TEXT, UUID) FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.ops_decide_media_proposal(UUID, TEXT, TEXT) FROM PUBLIC, anon, service_role;
+REVOKE ALL ON FUNCTION public.list_public_vendor_media(UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.resolve_public_media(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.submit_owner_media_proposal(UUID, TEXT, TEXT, TEXT, INTEGER, TEXT, TEXT, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_current_owner_media_proposals() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.ops_list_media_proposals(TEXT, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.ops_decide_media_proposal(UUID, TEXT, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_public_vendor_media(UUID) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.resolve_public_media(UUID) TO anon, authenticated;
+
+COMMENT ON TABLE public.listing_media_proposals IS 'Private, moderated owner media. Storage objects remain private until an approved application route serves them after public release.';

--- a/supabase/migrations/20260722023100_media_ops_reader_volatility.sql
+++ b/supabase/migrations/20260722023100_media_ops_reader_volatility.sql
@@ -1,0 +1,3 @@
+-- The media review reader verifies the currently signed-in operator, so it
+-- must not be advertised to PostgreSQL as stable.
+ALTER FUNCTION public.ops_list_media_proposals(TEXT, UUID) VOLATILE;

--- a/web/src/app/(directory)/dashboard/MediaProposalForm.tsx
+++ b/web/src/app/(directory)/dashboard/MediaProposalForm.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+
+export default function MediaProposalForm({ vendorId }: { vendorId: string }) {
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault(); setPending(true); setMessage(null);
+    const response = await fetch("/api/owner/media", { method: "POST", body: new FormData(event.currentTarget) });
+    const body = await response.json().catch(() => ({}));
+    setPending(false);
+    setMessage(response.ok ? "Your image is private and awaiting operator review. It is not public yet." : body.error || "We could not submit this image.");
+    if (response.ok) event.currentTarget.reset();
+  }
+  return <form onSubmit={submit} className="mt-6 space-y-4 border-t border-slate-100 pt-6">
+    <div><h4 className="font-bold">Propose a logo or image</h4><p className="mt-1 text-sm text-slate-600">JPEG, PNG or WebP, up to 2 MB. It stays private until approved.</p></div>
+    <input type="hidden" name="vendorId" value={vendorId} />
+    <label className="block text-sm font-medium">Image type<select name="mediaKind" className="mt-1 block w-full rounded-lg border border-slate-300 bg-white p-3"><option value="logo">Logo</option><option value="listing_image">Listing image</option></select></label>
+    <label className="block text-sm font-medium">Image file<input name="file" type="file" accept="image/jpeg,image/png,image/webp" required className="mt-1 block w-full rounded-lg border border-slate-300 p-3" /></label>
+    <label className="block text-sm font-medium">Describe the image<input name="altText" required minLength={2} maxLength={160} placeholder="For example: Front entrance of Example Services" className="mt-1 block w-full rounded-lg border border-slate-300 p-3" /></label>
+    <label className="block text-sm font-medium">Permission to use it<textarea name="sourceBasis" required minLength={10} maxLength={1000} rows={3} placeholder="For example: I own this logo and authorise SuburbMates to display it on this listing." className="mt-1 block w-full rounded-lg border border-slate-300 p-3" /></label>
+    {message && <p role="status" className="rounded-lg bg-slate-100 p-3 text-sm">{message}</p>}
+    <button disabled={pending} className="btn btn-outline">{pending ? "Submitting…" : "Submit for review"}</button>
+  </form>;
+}

--- a/web/src/app/(directory)/dashboard/page.tsx
+++ b/web/src/app/(directory)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { ExternalLink } from 'lucide-react'
 import ProfileEditor from './ProfileEditor'
 import ClaimRequests from './ClaimRequests'
+import MediaProposalForm from './MediaProposalForm'
 
 type OwnerVendor = {
   id: string
@@ -44,6 +45,16 @@ type BusinessSubmissionStatus = {
   submitted_at: string
 }
 
+type MediaProposal = {
+  proposal_id: string
+  vendor_id: string
+  media_kind: string
+  proposal_status: string
+  alt_text: string
+  operator_reason: string | null
+  created_at: string
+}
+
 export default async function DashboardPage() {
   const supabase = await createClient()
   
@@ -60,9 +71,11 @@ export default async function DashboardPage() {
   const { data: requestStatuses } = await supabase.rpc('list_current_owner_request_statuses')
   const { data: claimRequests } = await supabase.rpc('list_current_owner_claim_requests')
   const { data: businessSubmissionStatuses } = await supabase.rpc('list_current_business_submission_statuses')
+  const { data: mediaProposalRows } = await supabase.rpc('list_current_owner_media_proposals')
   const ownerRequestStatuses = (requestStatuses ?? []) as RequestStatus[]
   const ownerClaimRequests = (claimRequests ?? []) as ClaimRequest[]
   const privateSubmissionStatuses = (businessSubmissionStatuses ?? []) as BusinessSubmissionStatus[]
+  const mediaProposals = (mediaProposalRows ?? []) as MediaProposal[]
   const latestChangeByVendor = new Map<string, (typeof profileChanges)[number]>()
   for (const change of profileChanges ?? []) {
     if (!latestChangeByVendor.has(change.vendor_id)) latestChangeByVendor.set(change.vendor_id, change)
@@ -149,6 +162,8 @@ export default async function DashboardPage() {
                   </div>
                   
                   <ProfileEditor vendor={vendor} latestChange={latestChangeByVendor.get(vendor.id) ?? null} />
+                  <MediaProposalForm vendorId={vendor.id} />
+                  {mediaProposals.filter((proposal) => proposal.vendor_id === vendor.id).length > 0 && <div className="border-t border-slate-100 pt-5"><h4 className="font-bold">Image review status</h4><div className="mt-3 space-y-2">{mediaProposals.filter((proposal) => proposal.vendor_id === vendor.id).map((proposal) => <div key={proposal.proposal_id} className="rounded-lg bg-slate-50 p-3 text-sm"><span className="font-semibold">{proposal.media_kind === 'logo' ? 'Logo' : 'Listing image'}:</span> {proposal.proposal_status.replaceAll('_', ' ')}{proposal.operator_reason && <p className="mt-1 text-slate-600">{proposal.operator_reason}</p>}</div>)}</div></div>}
                 </div>
               ))}
             </div>

--- a/web/src/app/api/media/[mediaId]/route.ts
+++ b/web/src/app/api/media/[mediaId]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+export async function GET(_: Request, { params }: { params: Promise<{ mediaId: string }> }) {
+  if (process.env.NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED !== "true") return new NextResponse(null, { status: 404 });
+  const { mediaId } = await params;
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(mediaId)) return new NextResponse(null, { status: 404 });
+  const supabase = await createClient();
+  const { data } = await supabase.rpc("resolve_public_media", { p_media_id: mediaId });
+  const media = data?.[0] as { storage_path: string; content_type: string } | undefined;
+  if (!media) return new NextResponse(null, { status: 404 });
+  const { data: blob } = await createAdminClient().storage.from("owner-media-proposals").download(media.storage_path);
+  if (!blob) return new NextResponse(null, { status: 404 });
+  return new NextResponse(blob, { headers: { "Content-Type": media.content_type, "Cache-Control": "public, max-age=3600", "X-Content-Type-Options": "nosniff" } });
+}

--- a/web/src/app/api/owner/media/route.ts
+++ b/web/src/app/api/owner/media/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/utils/supabase/admin";
+import { createClient } from "@/utils/supabase/server";
+
+const MAX_BYTES = 2 * 1024 * 1024;
+const kinds = new Set(["logo", "listing_image"]);
+
+export async function POST(request: Request) {
+  const form = await request.formData();
+  const vendorId = String(form.get("vendorId") ?? "");
+  const mediaKind = String(form.get("mediaKind") ?? "");
+  const altText = String(form.get("altText") ?? "").trim();
+  const sourceBasis = String(form.get("sourceBasis") ?? "").trim();
+  const file = form.get("file");
+
+  if (!isUuid(vendorId) || !kinds.has(mediaKind) || !(file instanceof File)) return error("Choose a business, media type and image.", 400);
+  if (file.size < 1 || file.size > MAX_BYTES) return error("Choose an image smaller than 2 MB.", 400);
+  if (altText.length < 2 || altText.length > 160 || sourceBasis.length < 10 || sourceBasis.length > 1000) return error("Describe the image and your permission to use it.", 400);
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return error("Sign in to propose media.", 401);
+  const { data: owned, error: ownedError } = await supabase.rpc("list_current_owner_vendors");
+  if (ownedError || !(owned ?? []).some((vendor: { id: string }) => vendor.id === vendorId)) return error("Only the claimed owner can propose media for this listing.", 403);
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const contentType = imageContentType(bytes);
+  if (!contentType) return error("Choose a JPEG, PNG or WebP image.", 400);
+  const extension = contentType === "image/jpeg" ? "jpg" : contentType === "image/png" ? "png" : "webp";
+  const storagePath = `proposals/${vendorId}/${crypto.randomUUID()}.${extension}`;
+  const checksum = await sha256(bytes);
+  const admin = createAdminClient();
+  const { error: uploadError } = await admin.storage.from("owner-media-proposals").upload(storagePath, bytes, { contentType, upsert: false });
+  if (uploadError) return error("The image could not be saved. Please try again.", 502);
+
+  const { error: proposalError } = await supabase.rpc("submit_owner_media_proposal", {
+    p_vendor_id: vendorId, p_media_kind: mediaKind, p_storage_path: storagePath, p_content_type: contentType,
+    p_byte_size: bytes.byteLength, p_checksum_sha256: checksum, p_alt_text: altText, p_source_basis: sourceBasis,
+  });
+  if (proposalError) {
+    await admin.storage.from("owner-media-proposals").remove([storagePath]);
+    return error(proposalError.message || "The proposal could not be recorded.", 400);
+  }
+  return NextResponse.json({ ok: true });
+}
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function imageContentType(bytes: Uint8Array): "image/jpeg" | "image/png" | "image/webp" | null {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (bytes.length >= 8 && String.fromCharCode(...bytes.slice(0, 8)) === "\x89PNG\r\n\x1a\n") return "image/png";
+  if (bytes.length >= 12 && String.fromCharCode(...bytes.slice(0, 4)) === "RIFF" && String.fromCharCode(...bytes.slice(8, 12)) === "WEBP") return "image/webp";
+  return null;
+}
+
+async function sha256(bytes: Uint8Array) {
+  const payload = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  const digest = await crypto.subtle.digest("SHA-256", payload);
+  return Array.from(new Uint8Array(digest), (value) => value.toString(16).padStart(2, "0")).join("");
+}
+
+function error(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status });
+}

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
-import { decideListingAction, runAbnCheckAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
+import { decideListingAction, decideMediaProposalAction, runAbnCheckAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
+import { createAdminClient } from "@/utils/supabase/admin";
 
 type Listing = {
   vendor_id: string;
@@ -35,6 +36,7 @@ type ListingEvidence = {
   created_at: string;
 };
 type SubmissionStatus = { submission_status: string; operator_message: string | null; updated_at: string };
+type MediaProposal = { proposal_id: string; media_kind: string; storage_path: string; content_type: string; byte_size: number; alt_text: string; source_basis: string; proposal_status: string; operator_reason: string | null; created_at: string; decided_at: string | null };
 
 export default async function OpsListingDetailPage({ params, searchParams }: {
   params: Promise<{ vendorId: string }>;
@@ -43,13 +45,14 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const { vendorId } = await params;
   const message = await searchParams;
   const supabase = await createOpsDataClient();
-  const [{ data, error }, categoriesResult, suburbsResult, evidenceResult, routeResult, submissionResult] = await Promise.all([
+  const [{ data, error }, categoriesResult, suburbsResult, evidenceResult, routeResult, submissionResult, mediaResult] = await Promise.all([
     supabase.rpc("ops_list_listings", { p_status: "all", p_query: null, p_vendor_id: vendorId, p_limit: 1, p_offset: 0 }),
     supabase.from("categories").select("name, slug").order("name"),
     supabase.from("suburbs").select("name, slug").order("name"),
     supabase.rpc("ops_list_listing_evidence", { p_vendor_id: vendorId }),
     supabase.rpc("resolve_public_vendor_route", { p_route_key: vendorId }),
     supabase.rpc("ops_get_business_submission_status", { p_vendor_id: vendorId }),
+    supabase.rpc("ops_list_media_proposals", { p_status: null, p_vendor_id: vendorId }),
   ]);
   if (error || categoriesResult.error || suburbsResult.error || evidenceResult.error) throw new Error("The listing could not be loaded.");
   const listing = data?.[0] as Listing | undefined;
@@ -59,6 +62,13 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const evidence = (evidenceResult.data ?? []) as ListingEvidence[];
   const publicSlug = routeResult.data?.[0]?.current_slug as string | undefined;
   const submission = submissionResult.data?.[0] as SubmissionStatus | undefined;
+  const media = (mediaResult.data ?? []) as MediaProposal[];
+  const admin = createAdminClient();
+  const mediaPreviews = new Map<string, string>();
+  await Promise.all(media.map(async (proposal) => {
+    const { data: signed } = await admin.storage.from("owner-media-proposals").createSignedUrl(proposal.storage_path, 60);
+    if (signed?.signedUrl) mediaPreviews.set(proposal.proposal_id, signed.signedUrl);
+  }));
   const success = message.success ?? "";
   const abnStatus = success.startsWith("abn_") ? success.slice(4) : null;
   const successfulAction = ["draft", "publish", "approve_changes", "reject", "unpublish", "restore"].includes(success);
@@ -85,6 +95,12 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
         {evidence.length === 0 ? <p className="mt-5 rounded-xl bg-slate-100 p-4 text-sm text-slate-600">No structured evidence record exists for this legacy listing.</p> : (
           <div className="mt-5 space-y-4">{evidence.map((item) => <EvidenceCard key={item.evidence_id} evidence={item} />)}</div>
         )}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 className="text-xl font-bold">Owner media proposals</h3>
+        <p className="mt-2 text-sm text-slate-600">These files remain private unless you approve them. Approval does not publish the listing or change ownership.</p>
+        {media.length === 0 ? <p className="mt-4 rounded-xl bg-slate-100 p-4 text-sm text-slate-600">No owner media has been proposed.</p> : <div className="mt-5 space-y-5">{media.map((proposal) => <article key={proposal.proposal_id} className="rounded-xl border border-slate-200 p-4"><div className="grid gap-4 sm:grid-cols-[11rem_1fr]"><div>{mediaPreviews.get(proposal.proposal_id) ? <img src={mediaPreviews.get(proposal.proposal_id)} alt={proposal.alt_text} className="h-40 w-full rounded-lg object-contain bg-slate-100" /> : <div className="flex h-40 items-center justify-center rounded-lg bg-slate-100 text-sm text-slate-500">Preview unavailable</div>}</div><div><p className="font-bold">{proposal.media_kind === "logo" ? "Logo" : "Listing image"} · {statusLabel(proposal.proposal_status)}</p><p className="mt-2 text-sm">Image description: {proposal.alt_text}</p><p className="mt-2 text-sm text-slate-600">Permission: {proposal.source_basis}</p><p className="mt-2 text-xs text-slate-500">Submitted {formatOpsDateTime(proposal.created_at)} · {Math.ceil(proposal.byte_size / 1024)} KB</p>{proposal.operator_reason && <p className="mt-2 text-sm"><span className="font-semibold">Decision note:</span> {proposal.operator_reason}</p>}</div></div>{proposal.proposal_status === "pending" && <MediaDecisionForm vendorId={vendorId} proposalId={proposal.proposal_id} />}{proposal.proposal_status === "approved" && <MediaDecisionForm vendorId={vendorId} proposalId={proposal.proposal_id} action="remove" />}</article>)}</div>}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
@@ -176,6 +192,11 @@ function AbnResult({ status }: { status: string }) {
   }[status] ?? "ABN check recorded. It has not changed publication, ownership, ranking or plan.";
   const caution = status !== "active";
   return <p role={caution ? "status" : undefined} className={`rounded-xl border p-4 font-semibold ${caution ? "border-amber-300 bg-amber-50 text-amber-900" : "border-green-300 bg-green-50 text-green-800"}`}>{message}</p>;
+}
+
+function MediaDecisionForm({ vendorId, proposalId, action }: { vendorId: string; proposalId: string; action?: "remove" }) {
+  const actions = action ? ["remove"] : ["approve", "reject"];
+  return <form action={decideMediaProposalAction} className="mt-4 space-y-3 border-t border-slate-200 pt-4"><input type="hidden" name="vendorId" value={vendorId} /><input type="hidden" name="proposalId" value={proposalId} /><label className="block text-sm font-bold">Decision note<textarea name="reason" required maxLength={2000} rows={2} className="mt-2 w-full rounded-lg border border-slate-300 p-3 font-normal" placeholder="Record why you are making this decision." /></label><div className="flex flex-wrap gap-3">{actions.map((choice) => <button key={choice} name="action" value={choice} className="btn btn-outline">{choice.replace(/^./, (letter) => letter.toUpperCase())} media</button>)}</div></form>;
 }
 
 function EvidenceCard({ evidence }: { evidence: ListingEvidence }) {

--- a/web/src/app/ops/listings/actions.ts
+++ b/web/src/app/ops/listings/actions.ts
@@ -8,6 +8,21 @@ import { checkAbn, normalizeAbn } from "@/lib/automation/abn-lookup";
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const decisions = new Set(["publish", "approve_changes", "reject", "unpublish", "restore"]);
 const submissionOutcomes = new Set(["needs_information", "approved", "declined"]);
+const mediaActions = new Set(["approve", "reject", "remove"]);
+
+export async function decideMediaProposalAction(formData: FormData) {
+  const vendorId = String(formData.get("vendorId") ?? "");
+  const proposalId = String(formData.get("proposalId") ?? "");
+  const action = String(formData.get("action") ?? "");
+  const reason = String(formData.get("reason") ?? "").trim();
+  const detailPath = `/ops/listings/${vendorId}`;
+  const { supabase } = await verifyOpsAdmin(detailPath);
+  if (!uuidPattern.test(vendorId) || !uuidPattern.test(proposalId) || !mediaActions.has(action) || reason.length < 1 || reason.length > 2000) redirect(`${detailPath}?error=media`);
+  const { error } = await supabase.rpc("ops_decide_media_proposal", { p_proposal_id: proposalId, p_action: action, p_reason: reason });
+  if (error) redirect(`${detailPath}?error=media`);
+  revalidatePath("/ops"); revalidatePath("/ops/listings"); revalidatePath(detailPath); revalidatePath("/dashboard");
+  redirect(`${detailPath}?success=media_${action}`);
+}
 
 export async function runAbnCheckAction(formData: FormData) {
   const vendorId = String(formData.get("vendorId") ?? "");

--- a/web/src/app/vendor/[slug]/page.tsx
+++ b/web/src/app/vendor/[slug]/page.tsx
@@ -69,6 +69,8 @@ export default async function VendorWebsite({ params }: PageProps) {
   if (error || !vendor) {
     notFound();
   }
+  const { data: mediaRows } = await supabase.rpc("list_public_vendor_media", { p_vendor_id: vendor.id });
+  const media = (mediaRows ?? []) as { media_id: string; media_kind: string; alt_text: string }[];
 
   // Compute design parameters out of existing data deterministically
   const design = getVendorDesign(vendor.id, vendor.created_at);
@@ -135,6 +137,7 @@ export default async function VendorWebsite({ params }: PageProps) {
         {design.contact === 'Sidebar' ? (
           <div className="grid md:grid-cols-3 gap-12">
             <div className="md:col-span-2 space-y-12">
+              {media.length > 0 && <section><h2 className="text-3xl font-black tracking-tight mb-6">Photos</h2><div className="grid gap-4 sm:grid-cols-2">{media.map((item) => <img key={item.media_id} src={`/api/media/${item.media_id}`} alt={item.alt_text} className="h-64 w-full rounded-2xl object-cover" />)}</div></section>}
               <section>
                 <h2 className="text-3xl font-black tracking-tight mb-6">About Us</h2>
                 <div className="prose prose-lg max-w-none">
@@ -151,6 +154,7 @@ export default async function VendorWebsite({ params }: PageProps) {
         ) : (
           <div className="space-y-16">
             <div className="max-w-3xl">
+              {media.length > 0 && <section className="mb-12"><h2 className="text-3xl font-black tracking-tight mb-6">Photos</h2><div className="grid gap-4 sm:grid-cols-2">{media.map((item) => <img key={item.media_id} src={`/api/media/${item.media_id}`} alt={item.alt_text} className="h-64 w-full rounded-2xl object-cover" />)}</div></section>}
               <section>
                 <h2 className="text-3xl font-black tracking-tight mb-6">About Us</h2>
                 <div className="prose prose-lg max-w-none">


### PR DESCRIPTION
## Outcome
Claimed owners can propose a logo or listing image; only an active operator can approve, reject, or remove it.

## Safety boundaries
- Private storage only; no direct browser storage access or public bucket.
- JPEG, PNG and WebP only; server verifies image bytes and limits each file to 2 MB.
- Every proposal and operator decision is auditable.
- Approval does not publish a listing, change ownership, ranking, tier, or billing.
- Approved files are served only after the existing public-launch gate is enabled.

## Verification
- `npm run check`
- `npm --prefix web run lint` (three expected direct-image warnings for private/signed previews)
- `npm --prefix web run build`
- Remote migrations aligned through `20260722023100`
- `supabase db lint --linked` has no new media warning.