### PR TITLE
Stage approved owner status communications

### DIFF
--- a/supabase/migrations/20260722030000_stage1_status_communications.sql
+++ b/supabase/migrations/20260722030000_stage1_status_communications.sql
@@ -1,0 +1,75 @@
+-- Stage 1 prepares only the two approved owner-status message types. It does
+-- not grant a sender, create a dispatcher, or send an email by itself.
+
+ALTER TABLE public.communication_deliveries
+  DROP CONSTRAINT IF EXISTS communication_deliveries_message_type_check;
+ALTER TABLE public.communication_deliveries
+  ADD CONSTRAINT communication_deliveries_message_type_check CHECK (message_type IN (
+    'contact_receipt', 'operator_contact_alert', 'operator_stripe_exception', 'operator_abn_exception',
+    'claim_status', 'profile_change_status'
+  ));
+ALTER TABLE public.communication_deliveries
+  ADD COLUMN IF NOT EXISTS template_version TEXT;
+
+CREATE OR REPLACE FUNCTION public.prepare_stage1_status_communication(
+  p_entity_type TEXT,
+  p_entity_id UUID
+)
+RETURNS TABLE (
+  communication_delivery_id UUID,
+  message_type TEXT,
+  recipient_email TEXT,
+  request_status TEXT,
+  business_name TEXT,
+  template_version TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_type TEXT := lower(trim(coalesce(p_entity_type, '')));
+  v_email TEXT;
+  v_status TEXT;
+  v_business_name TEXT;
+  v_message_type TEXT;
+  v_delivery_id UUID;
+  v_template TEXT := 'stage1-status-v1';
+BEGIN
+  IF v_type = 'claim_request' THEN
+    SELECT claim.claimant_email, claim.claim_status, vendor.business_name
+    INTO v_email, v_status, v_business_name
+    FROM public.claim_requests claim JOIN public.vendors vendor ON vendor.id = claim.vendor_id
+    WHERE claim.id = p_entity_id;
+    v_message_type := 'claim_status';
+  ELSIF v_type = 'profile_change' THEN
+    SELECT lower(user_record.email), change.change_status, vendor.business_name
+    INTO v_email, v_status, v_business_name
+    FROM public.listing_change_requests change
+    JOIN public.vendors vendor ON vendor.id = change.vendor_id
+    JOIN auth.users user_record ON user_record.id = change.submitted_by
+    WHERE change.id = p_entity_id;
+    v_message_type := 'profile_change_status';
+  ELSE
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Unsupported communication entity.';
+  END IF;
+  IF v_email IS NULL OR v_status NOT IN ('needs_information', 'approved', 'rejected', 'revoked') THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'This request does not have an approved Stage 1 status message.';
+  END IF;
+  INSERT INTO public.communication_deliveries (message_type, entity_type, entity_id, recipient_email, template_version)
+  VALUES (v_message_type, v_type, p_entity_id::text, v_email, v_template)
+  ON CONFLICT (message_type, entity_type, entity_id, recipient_email) DO NOTHING
+  RETURNING id INTO v_delivery_id;
+  IF v_delivery_id IS NULL THEN
+    SELECT id INTO v_delivery_id FROM public.communication_deliveries
+    WHERE message_type = v_message_type AND entity_type = v_type AND entity_id = p_entity_id::text AND recipient_email = v_email;
+  END IF;
+  RETURN QUERY SELECT v_delivery_id, v_message_type, v_email, v_status, v_business_name, v_template;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prepare_stage1_status_communication(TEXT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.prepare_stage1_status_communication(TEXT, UUID) TO service_role;
+
+COMMENT ON FUNCTION public.prepare_stage1_status_communication(TEXT, UUID) IS
+  'Creates a private, idempotent Stage 1 status-delivery record. A separate explicitly enabled server path is required to send.';

--- a/web/src/app/ops/claims/actions.ts
+++ b/web/src/app/ops/claims/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { sendStage1Status } from "@/lib/communications/stage1-status";
 
 const allowedActions = new Set(["needs_information", "approve", "reject", "revoke"]);
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -28,6 +29,7 @@ export async function reviewClaimAction(formData: FormData) {
   if (error) {
     redirect(`${detailPath}?error=decision`);
   }
+  await sendStage1Status("claim_request", claimId);
 
   revalidatePath("/ops");
   revalidatePath("/ops/claims");

--- a/web/src/app/ops/profile-edits/actions.ts
+++ b/web/src/app/ops/profile-edits/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { sendStage1Status } from "@/lib/communications/stage1-status";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -24,6 +25,7 @@ export async function reviewProfileChangeAction(formData: FormData) {
   });
 
   if (error) redirect(`${detailPath}?error=decision`);
+  await sendStage1Status("profile_change", requestId);
 
   const vendorId = data?.[0]?.vendor_id;
   revalidatePath("/ops");

--- a/web/src/lib/communications/stage1-status.ts
+++ b/web/src/lib/communications/stage1-status.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { createAdminClient } from "@/utils/supabase/admin";
+import { runtimeEnv } from "@/lib/runtime-env";
+
+export async function sendStage1Status(entityType: "claim_request" | "profile_change", entityId: string) {
+  // This is deliberately hard-off until the public launch and this stage are
+  // explicitly accepted. Missing or any value other than true means no send.
+  if (runtimeEnv("TRANSACTIONAL_STATUS_EMAILS_ENABLED") !== "true") return { sent: false, reason: "disabled" as const };
+  const admin = createAdminClient();
+  const { data, error } = await admin.rpc("prepare_stage1_status_communication", { p_entity_type: entityType, p_entity_id: entityId });
+  if (error || !data?.[0]) return { sent: false, reason: "preparation_failed" as const };
+  const message = data[0] as { communication_delivery_id: string; recipient_email: string; request_status: string; business_name: string; message_type: string };
+  const apiKey = runtimeEnv("RESEND_API_KEY");
+  const from = runtimeEnv("TRANSACTIONAL_STATUS_FROM");
+  if (!apiKey || !from) return recordFailure(admin, message.communication_delivery_id, "Status email is enabled but sender configuration is missing.");
+  const title = message.message_type === "claim_status" ? "Your SuburbMates ownership request" : "Your SuburbMates profile update";
+  const response = await fetch("https://api.resend.com/emails", { method: "POST", headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" }, body: JSON.stringify({ from, to: [message.recipient_email], subject: title, text: `${message.business_name}: your request is ${message.request_status.replaceAll("_", " ")}. Sign in to SuburbMates to view the current status and next step.` }) });
+  const body = await response.json().catch(() => ({})) as { id?: string; message?: string };
+  if (!response.ok || !body.id) return recordFailure(admin, message.communication_delivery_id, body.message || "Status email provider rejected the message.");
+  await admin.rpc("record_communication_delivery", { p_communication_delivery_id: message.communication_delivery_id, p_provider_message_id: body.id, p_provider_error: null });
+  return { sent: true, reason: "sent" as const };
+}
+
+async function recordFailure(admin: ReturnType<typeof createAdminClient>, deliveryId: string, message: string) {
+  await admin.rpc("record_communication_delivery", { p_communication_delivery_id: deliveryId, p_provider_message_id: null, p_provider_error: message.slice(0, 1000) });
+  return { sent: false, reason: "failed" as const };
+}


### PR DESCRIPTION
## Outcome
Stages only the approved claim and profile-status email paths behind a hard-off feature gate.

## Safety
- `TRANSACTIONAL_STATUS_EMAILS_ENABLED` must equal `true`; absent/default is no send.
- No new sender is configured or activated.
- Only claim and profile-decision statuses are accepted.
- The application ledger stores metadata and provider outcome, never message bodies.
- No automatic retry, publication, ownership, ranking, tier, billing, or SEO effect.

## Verification
- `npm --prefix web run build`
- Remote migration aligned through `20260722030000`
- `supabase db push --linked --dry-run` before apply.