### PR TITLE
Stage submission and contact outcome messages

### DIFF
--- a/supabase/migrations/20260722031500_stage2_outcome_communications.sql
+++ b/supabase/migrations/20260722031500_stage2_outcome_communications.sql
@@ -1,0 +1,23 @@
+ALTER TABLE public.communication_deliveries DROP CONSTRAINT IF EXISTS communication_deliveries_message_type_check;
+ALTER TABLE public.communication_deliveries ADD CONSTRAINT communication_deliveries_message_type_check CHECK (message_type IN ('contact_receipt','operator_contact_alert','operator_stripe_exception','operator_abn_exception','claim_status','profile_change_status','submission_outcome','contact_outcome'));
+
+CREATE OR REPLACE FUNCTION public.prepare_stage2_outcome_communication(p_entity_type TEXT,p_entity_id UUID)
+RETURNS TABLE (communication_delivery_id UUID,message_type TEXT,recipient_email TEXT,request_status TEXT,business_name TEXT,template_version TEXT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE v_type TEXT:=lower(trim(coalesce(p_entity_type,''))); v_email TEXT; v_status TEXT; v_name TEXT; v_message_type TEXT; v_id UUID; v_template TEXT:='stage2-outcome-v1';
+BEGIN
+  IF v_type='business_submission' THEN
+    SELECT request.submitter_email,request.submission_status,vendor.business_name INTO v_email,v_status,v_name FROM public.business_submission_requests request JOIN public.vendors vendor ON vendor.id=request.vendor_id WHERE request.vendor_id=p_entity_id;
+    v_message_type:='submission_outcome';
+    IF v_status NOT IN ('needs_information','approved','declined') THEN RAISE EXCEPTION USING ERRCODE='22023',MESSAGE='This submission has no approved outcome message.'; END IF;
+  ELSIF v_type='contact_request' THEN
+    SELECT request.requester_email,request.contact_status,coalesce(request.business_name,'SuburbMates request') INTO v_email,v_status,v_name FROM public.contact_requests request WHERE request.id=p_entity_id;
+    v_message_type:='contact_outcome';
+    IF v_status<>'resolved' THEN RAISE EXCEPTION USING ERRCODE='22023',MESSAGE='Only a resolved contact request has an approved outcome message.'; END IF;
+  ELSE RAISE EXCEPTION USING ERRCODE='22023',MESSAGE='Unsupported communication entity.'; END IF;
+  INSERT INTO public.communication_deliveries(message_type,entity_type,entity_id,recipient_email,template_version) VALUES(v_message_type,v_type,p_entity_id::text,v_email,v_template) ON CONFLICT(message_type,entity_type,entity_id,recipient_email) DO NOTHING RETURNING id INTO v_id;
+  IF v_id IS NULL THEN SELECT id INTO v_id FROM public.communication_deliveries WHERE message_type=v_message_type AND entity_type=v_type AND entity_id=p_entity_id::text AND recipient_email=v_email; END IF;
+  RETURN QUERY SELECT v_id,v_message_type,v_email,v_status,v_name,v_template;
+END; $$;
+REVOKE ALL ON FUNCTION public.prepare_stage2_outcome_communication(TEXT,UUID) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.prepare_stage2_outcome_communication(TEXT,UUID) TO service_role;

--- a/web/src/app/ops/contact/actions.ts
+++ b/web/src/app/ops/contact/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { sendStage2Outcome } from "@/lib/communications/stage1-status";
 
 const allowedStatuses = new Set(["new", "in_progress", "resolved", "spam"]);
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -24,6 +25,7 @@ export async function reviewContactAction(formData: FormData) {
     p_reason: reason,
   });
   if (error) redirect(`${detailPath}?error=decision`);
+  if (status === "resolved") await sendStage2Outcome("contact_request", requestId);
 
   revalidatePath("/ops");
   revalidatePath("/ops/contact");

--- a/web/src/app/ops/listings/actions.ts
+++ b/web/src/app/ops/listings/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 import { checkAbn, normalizeAbn } from "@/lib/automation/abn-lookup";
+import { sendStage2Outcome } from "@/lib/communications/stage1-status";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const decisions = new Set(["publish", "approve_changes", "reject", "unpublish", "restore"]);
@@ -57,6 +58,7 @@ export async function setBusinessSubmissionStatusAction(formData: FormData) {
   if (!uuidPattern.test(vendorId) || !submissionOutcomes.has(outcome) || message.length < 1 || message.length > 2000) redirect(`${detailPath}?error=submission_status`);
   const { error } = await supabase.rpc("ops_set_business_submission_status", { p_vendor_id: vendorId, p_status: outcome, p_message: message });
   if (error) redirect(`${detailPath}?error=submission_status`);
+  await sendStage2Outcome("business_submission", vendorId);
   revalidatePath("/dashboard"); revalidatePath(detailPath);
   redirect(`${detailPath}?success=submission_status`);
 }

--- a/web/src/lib/communications/stage1-status.ts
+++ b/web/src/lib/communications/stage1-status.ts
@@ -22,6 +22,21 @@ export async function sendStage1Status(entityType: "claim_request" | "profile_ch
   return { sent: true, reason: "sent" as const };
 }
 
+export async function sendStage2Outcome(entityType: "business_submission" | "contact_request", entityId: string) {
+  if (runtimeEnv("TRANSACTIONAL_STATUS_EMAILS_ENABLED") !== "true") return { sent: false, reason: "disabled" as const };
+  const admin = createAdminClient();
+  const { data, error } = await admin.rpc("prepare_stage2_outcome_communication", { p_entity_type: entityType, p_entity_id: entityId });
+  if (error || !data?.[0]) return { sent: false, reason: "preparation_failed" as const };
+  const message = data[0] as { communication_delivery_id: string; recipient_email: string; request_status: string; business_name: string; message_type: string };
+  const apiKey = runtimeEnv("RESEND_API_KEY"); const from = runtimeEnv("TRANSACTIONAL_STATUS_FROM");
+  if (!apiKey || !from) return recordFailure(admin, message.communication_delivery_id, "Outcome email is enabled but sender configuration is missing.");
+  const response = await fetch("https://api.resend.com/emails", { method: "POST", headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" }, body: JSON.stringify({ from, to: [message.recipient_email], subject: "Your SuburbMates request update", text: `${message.business_name}: your request is ${message.request_status.replaceAll("_", " ")}. Check your private SuburbMates status for the current outcome.` }) });
+  const body = await response.json().catch(() => ({})) as { id?: string; message?: string };
+  if (!response.ok || !body.id) return recordFailure(admin, message.communication_delivery_id, body.message || "Outcome email provider rejected the message.");
+  await admin.rpc("record_communication_delivery", { p_communication_delivery_id: message.communication_delivery_id, p_provider_message_id: body.id, p_provider_error: null });
+  return { sent: true, reason: "sent" as const };
+}
+
 async function recordFailure(admin: ReturnType<typeof createAdminClient>, deliveryId: string, message: string) {
   await admin.rpc("record_communication_delivery", { p_communication_delivery_id: deliveryId, p_provider_message_id: null, p_provider_error: message.slice(0, 1000) });
   return { sent: false, reason: "failed" as const };


### PR DESCRIPTION
Stages only approved Stage 2 outcome messages behind the existing hard-off gate. No sender, retry loop, inbox, or public release is enabled.

Verification: production build passed; remote migration applied after dry-run.