### PR TITLE
Record catalogue requalification baseline

### DIFF
--- a/docs/AUTOMATION/EXISTING_CATALOGUE_REQUALIFICATION_AUDIT.md
+++ b/docs/AUTOMATION/EXISTING_CATALOGUE_REQUALIFICATION_AUDIT.md
@@ -1,0 +1,48 @@
+# Existing catalogue requalification audit
+
+**Date:** 23 July 2026 (Australia/Melbourne)  
+**Scope:** read-only inspection of the live published catalogue. No listing, publication, ownership, evidence or audit record was changed.
+
+## Why this audit exists
+
+The approved qualification policy applies to every directory listing: permitted provenance, valid Darebin/category scope, identifiable business, at least one customer contact method, no strong duplicate and no known safety or legitimacy concern. The pre-existing catalogue was published before the current candidate handoff was built, so it must not be assumed to have passed that same policy.
+
+## Live baseline
+
+| Check | Result |
+| --- | ---: |
+| Published listings inspected | 1,600 |
+| `approved_import` provenance | 1,598 |
+| `seeded_by_suburbmates` provenance | 2 |
+| Source URL present | 1,598 |
+| Source check date present | 1,598 |
+| Category and suburb present | 1,600 |
+| Street address present | 973 |
+| At least one usable email, phone or HTTPS website | 790 |
+| Non-HTTPS or malformed stored website | 0 |
+| Strong duplicate signal by website | 6 groups / 12 listings |
+| Strong duplicate signal by phone | 2 groups / 4 listings |
+| Strong duplicate signal by exact normalised name and address | 0 groups |
+
+The duplicate signal counts can overlap. They are review signals, not evidence that every paired listing is an erroneous duplicate.
+
+## Result
+
+The existing 1,600 listings are **not yet requalified** under the approved policy. In particular, 810 do not presently meet the stored-data version of the required reachable-contact rule. Provenance and scope are strong for most of the cohort, but this audit cannot prove a current website is safe, a business is still active, or that every duplicate signal is a duplicate without retained or fresh evidence.
+
+The public release remains an explicit owner-authorised release. This report does not retrospectively treat the existing cohort as qualified and does not authorise bulk unpublication.
+
+## Safe next implementation
+
+1. Create a private, idempotent requalification run and one evidence record per existing listing.
+2. Classify each row as `qualified` or `exception` using the same deterministic policy as new candidates, while preserving the listing's current publication state.
+3. Send missing-contact, duplicate, provenance and safety exceptions to a protected Ops queue with a plain-language reason.
+4. Require a separately authorised lifecycle decision before any exception is unpublished, corrected or otherwise changes public visibility.
+5. Verify the resulting evidence, queue counts, audit trail and public sitemap before describing the cohort as fully requalified.
+
+## Evidence used
+
+- Live `vendors` administrative inspection, paginated through all published rows.
+- Live candidate-handoff run and record counts.
+- `web/src/lib/automation/candidate-qualification.ts` and its boundary tests.
+- The approved lifecycle, target-state and Decision Log authorities.

--- a/docs/AUTOMATION/README.md
+++ b/docs/AUTOMATION/README.md
@@ -2,7 +2,7 @@
 
 This folder is the canonical operational map for SuburbMates automation. It explains what the implemented automations do, what triggers them, which services they use, and their current operating status.
 
-It does not override the locked product and Ops authorities in `docs/REFERENCE/` or the current-state record in `docs/HANDOVER.md`. It records implementation evidence as at 19 July 2026. A pending target-state decision must be reconciled with the locked authorities before it changes production behaviour.
+It does not override the locked product and Ops authorities in `docs/REFERENCE/` or the current-state record in `docs/HANDOVER.md`. It records implementation evidence as at 23 July 2026. A pending target-state decision must be reconciled with the locked authorities before it changes production behaviour.
 
 ## Read first
 
@@ -13,7 +13,7 @@ It does not override the locked product and Ops authorities in `docs/REFERENCE/`
 
 ## Automation boundary
 
-Automation may collect evidence, produce artefacts, and report exceptions. It must never publish a listing, approve or revoke ownership, decide a claim, change a listing's commercial state, or invent public business facts.
+Automation may collect evidence, produce artefacts, and report exceptions. The sole narrow publication path is the token-protected OpenStreetMap candidate handoff: a new candidate may become an unclaimed listing only after it passes the deterministic source, scope, contact, duplicate and safety policy and its evidence is persisted. Automation must never approve or revoke ownership, decide a claim, change a listing's commercial state, or invent public business facts.
 
 Database health updates and contact retention are narrow, audited **Ops** processes, not Automation-lane workflows. They may not affect listings, ownership, claims, payments, or publication. The health monitor must not be treated as proof that GitHub evidence workflows are fresh.
 
@@ -23,13 +23,13 @@ Database health updates and contact retention are narrow, audited **Ops** proces
 - GitHub has four active workflows on `main`: Verify, Catalogue candidate discovery, Website safety evidence, and Production smoke.
 - Catalogue discovery and Production smoke fixes were merged in pull requests #4 and #5. Controlled manual runs then succeeded on `main`. Website safety completed evidence collection and raised one operator review issue.
 - Stripe billing, bulk ABR/ABN checks, AI publication, media/logo processing, and the legacy inactivity pruner are disabled.
-- Candidate artifacts remain evidence-only GitHub artefacts today. A future candidate-to-Ops handoff is required by the target product direction, but it has not yet been implemented or authorised to change production data.
+- Candidate-to-Ops handoff is implemented for approved OpenStreetMap batches. A controlled live proof created one private exception and zero listings; the first qualified live creation and the first full scheduled batch still require operator review evidence.
 - The database health monitor does not ingest GitHub workflow runs or artefacts. Its green automation-queue status means only that the local job table has no failed or overdue rows; it is not evidence that GitHub checks ran.
 
 ## Verified current gaps
 
 1. **Review website-safety evidence.** The controlled run checked 588 websites and flagged 86. The report is retained for 30 days in GitHub Actions and [issue #3](https://github.com/carlsuburbmates/suburbmates/issues/3) is the single review entry. No listing was changed.
-2. **Keep GitHub evidence distinct from the database health badge.** GitHub workflow-result ingestion is not implemented. Candidate-to-Ops import is not yet implemented. Neither omission is a reason to treat a database health row as proof of GitHub freshness.
+2. **Keep GitHub evidence distinct from the database health badge.** GitHub workflow-result ingestion is not implemented. The candidate handoff records its own database run and job state, but a health row is still not proof that every GitHub workflow ran.
 3. **Harden external acquisition.** The current robustness work adds bounded provider requests, response validation, fallback evidence and date-boundary tests. It remains an unmerged candidate until CI and review evidence are attached.
 4. **Cloudflare preview-build guard is enabled.** On 18 July, Cloudflare Workers Builds was verified with production branch `main` and non-production branch builds disabled. This prevents PR branches from producing automatic preview deployments.
 

--- a/docs/AUTOMATION/WORKFLOWS.md
+++ b/docs/AUTOMATION/WORKFLOWS.md
@@ -27,7 +27,7 @@ GitHub website-safety evidence (active on main)
   -> GitHub issue only when review is needed
   -> no database write; no listing change
 
-GitHub production smoke (active on main; controlled holding-posture run succeeded)
+GitHub production smoke (active on main; public-release route run succeeded)
   -> public site + Supabase safe projections
   -> route, sitemap, access-control, and catalogue consistency checks
   -> GitHub issue only on failure
@@ -47,7 +47,7 @@ Supabase internal health monitor (active Ops process; outside Automation lane)
 | Repository verification | GitHub pull request; push to `main` or `codex/**` | Check out code; install Node 22 dependencies; run root checks; lint, build, and Cloudflare build for `web/` | GitHub Actions, Node.js, npm, Next.js, OpenNext/Cloudflare build tooling | Pass/fail GitHub check | **Active** | No hosted data write or deployment command |
 | Catalogue candidate discovery | Monday schedule at `18:17` UTC; manual dispatch | Acquire City of Darebin commercial candidates from Overpass; audit; merge with curated candidates; audit again; retain CSVs; send OSM candidates in authenticated batches to the qualification handoff | GitHub Actions, Node.js, npm, OpenStreetMap/Overpass, Cloudflare, Supabase, repository CSV files, GitHub artifacts | Two CSV artifacts retained 30 days; private run and exception records in Ops | **Active on `main`; controlled private proof completed.** The first full scheduled discovery batch remains a separate release decision. | Only an approved-source candidate that passes deterministic source, scope, contact, duplicate and safety checks may create an unclaimed listing. Exceptions stay private in Ops. |
 | Website-safety evidence | Monday schedule at `08:41` UTC; manual dispatch | Read `published_vendors`; validate public DNS; make DNS-pinned HTTPS `HEAD` requests; follow at most three HTTPS redirects; write JSON report; fail when review is required; open/update one GitHub issue on failure | GitHub Actions, Supabase public projection, DNS, HTTPS, GitHub artifacts/issues | JSON report retained 30 days; one review issue if flagged | **Active on `main`; evidence run completed** — 588 checked, 86 flagged for review | No listing write; no automatic contact or publication decision |
-| Production smoke | Daily schedule at `19:23` Australia/Melbourne; manual dispatch | Check public routes; require unauthenticated Ops redirects; verify canonical redirects and invalid vendor 404; paginate safe Supabase projections; reconstruct and compare sitemap; sample a public vendor page; open/update one GitHub issue on failure | GitHub Actions, production Cloudflare site, Supabase public projections, GitHub issues | Pass/fail run; one failure issue if needed | **Active on `main`; controlled holding-posture run succeeded after the route-expectation fix** | No Supabase write; no deployment; no listing change |
+| Production smoke | Daily schedule at `19:23` Australia/Melbourne; manual dispatch | Check public routes; require unauthenticated Ops redirects; verify canonical redirects and invalid vendor 404; paginate safe Supabase projections; reconstruct and compare sitemap; sample a public vendor page; open/update one GitHub issue on failure | GitHub Actions, production Cloudflare site, Supabase public projections, GitHub issues | Pass/fail run; one failure issue if needed | **Active on `main`; public-release route verification is recorded** | No Supabase write; no deployment; no listing change |
 | Internal operations health | Supabase `pg_cron`, hourly at minute 5 | Count failed and overdue automation jobs; count listings needing review, pending claims, and pending profile changes; update integration-health rows; expose them through authenticated Ops RPCs | Supabase PostgreSQL, `pg_cron`, `automation_jobs`, operator workflow tables, `/ops/system` | `integration_health` status and queue counts | **Active Ops process; outside Automation lane** | Writes health records only; never changes listings, ownership, claims, payments, publication, billing, or tier |
 | Contact retention | Supabase `pg_cron`, daily at `03:17` UTC | Delete spam requests unchanged for 30 days and resolved requests unchanged for 12 months; append a retention audit event if content was deleted; update retention health | Supabase PostgreSQL, `pg_cron`, `contact_requests`, `audit_events`, `integration_health` | Retention health, deletion count, immutable audit evidence | **Active Ops process; outside Automation lane** | Deletes only eligible private contact-request content; never touches listings, ownership, claims, payments, or publication |
 | On-demand path revalidation | Authenticated `POST /api/webhook/revalidate` | Require bearer token; require a path/tag; call `revalidatePath`; return response | Next.js, Cloudflare runtime secret `REVALIDATION_TOKEN` | Cache revalidation response | **Available on demand** — no scheduled caller is evidenced | Does not write listing data; changes only rendered-path cache state |
@@ -91,7 +91,7 @@ For every published listing with a website, it retrieves only the safe `publishe
 
 Sources: `.github/workflows/production-smoke.yml` and `scripts/production-smoke.mjs`.
 
-It checks the public site and public database projections together: public routes, unauthenticated Ops redirects, canonical redirects, an invalid vendor route, public catalogue pagination, taxonomy eligibility, exact sitemap membership, category links, and one vendor page. A failure creates or updates one GitHub issue. It never writes to Supabase. Its holding-page expectation is merged and a controlled run succeeded on `main`.
+It checks the public site and public database projections together: public routes, unauthenticated Ops redirects, canonical redirects, an invalid vendor route, public catalogue pagination, taxonomy eligibility, exact sitemap membership, category links, and one vendor page. A failure creates or updates one GitHub issue. It never writes to Supabase. It supports both holding and released route expectations; live public-route verification is recorded in `SUB-14`.
 
 ### 5. Internal health and Ops display
 
@@ -121,7 +121,7 @@ This is intentionally narrower than general data pruning. It deletes only privat
 
 | Service | Automation role | Prohibited role |
 | --- | --- | --- |
-| GitHub Actions | Run checks, collect safe evidence, retain artifacts, and open one exception issue | Write to Supabase or publish a listing |
+| GitHub Actions | Run checks, collect safe evidence, retain artifacts, and call the token-protected approved-source candidate handoff | Bypass deterministic qualification, decide ownership or claims, or publish raw/exception candidates |
 | Supabase | Hold operational health, audit, and approved workflow data; run narrow internal schedules | Let automation bypass operator authorisation |
 | Cloudflare / Next.js | Serve protected event routes and the production site | Store server secrets in source or grant client authority |
 | OpenStreetMap / Overpass | Provide candidate-source data | Establish publication or ownership legitimacy on its own |
@@ -130,4 +130,4 @@ This is intentionally narrower than general data pruning. It deletes only privat
 
 ## Candidate handoff acceptance boundary
 
-The handoff is intentionally narrower than general automation. It must retain source provenance and exceptions, never ingest an unapproved source, and never make ownership or claim decisions. Holding mode remains independent: a qualified record can have a database publication state while the public directory remains intentionally unavailable. Before the first full scheduled batch is treated as accepted, an operator must review the private exception queue and confirm that the source, scope and duplicate outcomes are understandable.
+The handoff is intentionally narrower than general automation. It must retain source provenance and exceptions, never ingest an unapproved source, and never make ownership or claim decisions. Public release remains independent: a qualified record can be public only while the global launch gate is enabled. Before the first full scheduled batch is treated as accepted, an operator must review the private exception queue and confirm that the source, scope and duplicate outcomes are understandable.

--- a/docs/REFERENCE/SuburbMates — Listing Lifecycle and Release-State Contract.md
+++ b/docs/REFERENCE/SuburbMates — Listing Lifecycle and Release-State Contract.md
@@ -28,8 +28,8 @@ This contract turns the owner-approved directory policy into a buildable model. 
 ## Required corrections and boundaries
 
 1. **Commercial neutrality:** public directory ranking must not order by `tier` or another commercial field. Commercial presentation belongs to its own future approved model.
-2. **Qualified default publication:** the approved target is deterministic publication of qualifying approved-source candidates as unclaimed listings. The current importer keeps new records in `pending_review`; changing that path belongs to `SUB-6` after its auditable candidate handoff is designed and proven.
-3. **Holding remains separate:** a `published` listing stays non-public while the global holding gate is active. Releasing public routes is governed by `SUB-14`, not an import or claim.
+2. **Qualified default publication:** the token-protected OpenStreetMap candidate handoff now creates a published, unclaimed listing only when the deterministic source, scope, contact, duplicate and safety checks pass. It persists the handoff record, provenance, qualification evidence and audit event first. The legacy CSV importer still keeps ordinary new rows in `pending_review`; the pre-existing catalogue has not yet been requalified under the handoff policy.
+3. **Public release remains separate:** a `published` listing becomes publicly browseable only while the global launch gate is enabled. The owner authorised the first public release on 23 July 2026; future release or rollback remains governed by `SUB-14`, not an import or claim.
 4. **Claims remain independent:** the approved normal exact-email path and its future exception/revocation flow never publish a listing or change commercial/SEO state.
 5. **Evidence remains precise:** an ABN or website result is stored as supporting evidence. It is not a universal entry requirement.
 
@@ -39,18 +39,18 @@ This contract turns the owner-approved directory policy into a buildable model. 
 stateDiagram-v2
   [*] --> draft
   draft --> pending_review: candidate or operator prepares record
-  pending_review --> published: approved current control / future qualified policy
+  pending_review --> published: operator decision or deterministic qualified handoff
   pending_review --> rejected: insufficient, duplicate, unsafe or out of scope
   published --> unpublished: reasoned safety, accuracy, privacy or closure decision
   unpublished --> pending_review: restore for review
   rejected --> pending_review: new evidence or correction
 ```
 
-Every transition requires the permitted actor, reason, timestamp and audit evidence. The current operator-only transition path is retained until `SUB-6` delivers an approved deterministic qualification handoff.
+Every transition requires the permitted actor, reason, timestamp and audit evidence. The candidate handoff is the narrow exception: it can create only a new unclaimed published listing after retaining deterministic qualification evidence; it cannot change ownership, resolve a claim, or publish a raw or exceptional candidate.
 
 ## `SUB-8` delivery boundary
 
-`SUB-8` verifies and corrects the shared model: state separation, operator transition protection, public projection and non-commercial ranking. It does not enable automatic candidate publication, lift holding mode, implement claim exceptions, or activate billing.
+`SUB-8` verifies and corrects the shared model: state separation, operator transition protection, public projection and non-commercial ranking. It did not itself enable automatic candidate publication, public release, claim exceptions, or billing; the later `SUB-6` candidate handoff owns the narrow deterministic creation path.
 
 ## Evidence required before review
 


### PR DESCRIPTION
Adds a read-only live requalification audit for the 1,600 public listings and reconciles stale automation/lifecycle documentation with the implemented candidate handoff and public-release state. No production records are changed.