### PR TITLE
Add existing catalogue requalification controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run abn-check:test && npm run abn-evidence:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run existing-catalogue-requalification:test && npm run abn-check:test && npm run abn-evidence:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -12,6 +12,8 @@
     "candidate-handoff:test": "tsx scripts/test-candidate-handoff-boundary.ts",
     "candidate:handoff": "tsx --env-file-if-exists=.env.local scripts/submit-candidate-handoff.ts",
     "candidate-automation-ingest:test": "tsx scripts/test-candidate-automation-ingest-boundary.ts",
+    "existing-catalogue-requalification:test": "tsx scripts/test-existing-catalogue-requalification.ts",
+    "catalogue:requalify": "tsx --env-file=.env.local scripts/requalify-existing-catalogue.ts",
     "abn-check:test": "tsx scripts/test-abn-lookup.ts",
     "abn-evidence:test": "tsx scripts/test-abn-evidence-boundary.ts",
     "owner-media:test": "tsx scripts/test-owner-media-boundary.ts",

--- a/scripts/requalify-existing-catalogue.ts
+++ b/scripts/requalify-existing-catalogue.ts
@@ -1,0 +1,130 @@
+import { createHash } from "node:crypto";
+import { createClient } from "@supabase/supabase-js";
+import { qualifyExistingCatalogueListing, type ExistingCatalogueListing } from "../web/src/lib/automation/existing-catalogue-requalification";
+
+const policyVersion = "existing-catalogue-v1";
+const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const secret = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !secret) throw new Error("Missing server-side Supabase credentials.");
+if (process.env.ALLOW_CATALOGUE_REQUALIFICATION !== "true") {
+  throw new Error("Refusing to write requalification evidence. Set ALLOW_CATALOGUE_REQUALIFICATION=true after reviewing the run scope.");
+}
+
+const supabase = createClient(url, secret, { auth: { persistSession: false, autoRefreshToken: false } });
+
+type VendorRow = {
+  id: string;
+  business_name: string;
+  street_address: string | null;
+  contact_email: string | null;
+  phone: string | null;
+  website: string | null;
+  listing_source: string | null;
+  source_url: string | null;
+  source_checked_on: string | null;
+  category_slug: string | null;
+  suburb_slug: string | null;
+  updated_at: string;
+};
+
+async function main() {
+  const [vendors, categories, suburbs] = await Promise.all([loadPublishedVendors(), loadSlugs("categories"), loadSlugs("suburbs")]);
+  const fingerprint = createHash("sha256").update(JSON.stringify(vendors.map((vendor) => [vendor.id, vendor.updated_at]))).digest("hex");
+  const { data: existing, error: existingError } = await supabase
+    .from("existing_catalogue_requalification_runs")
+    .select("id, status, qualified_count, exception_count")
+    .eq("policy_version", policyVersion)
+    .eq("catalogue_fingerprint", fingerprint)
+    .maybeSingle();
+  if (existingError) throw existingError;
+  if (existing?.status === "completed") {
+    console.log(`Existing catalogue already requalified: ${existing.qualified_count} qualified, ${existing.exception_count} exceptions.`);
+    return;
+  }
+
+  const run = existing ?? await createRun(fingerprint, vendors.length);
+  const existingListings = vendors.map(toExistingListing);
+  const records = vendors.map((vendor) => {
+    const qualification = qualifyExistingCatalogueListing(toQualificationInput(vendor), { allowedSuburbs: suburbs, allowedCategories: categories, existingListings });
+    return {
+      run_id: run.id,
+      vendor_id: vendor.id,
+      qualification_outcome: qualification.outcome,
+      qualification_reasons: qualification.reasons,
+      normalized_data: qualification.normalized,
+      duplicate_vendor_id: qualification.duplicateVendorId,
+      exception_status: "open",
+    };
+  });
+
+  try {
+    for (let index = 0; index < records.length; index += 100) {
+      const { error } = await supabase.from("existing_catalogue_requalification_records")
+        .upsert(records.slice(index, index + 100), { onConflict: "run_id,vendor_id", ignoreDuplicates: true });
+      if (error) throw error;
+    }
+    const qualifiedCount = records.filter((record) => record.qualification_outcome === "qualified").length;
+    const exceptionCount = records.length - qualifiedCount;
+    const completedAt = new Date().toISOString();
+    const { error: updateError } = await supabase.from("existing_catalogue_requalification_runs")
+      .update({ status: "completed", qualified_count: qualifiedCount, exception_count: exceptionCount, completed_at: completedAt, error_message: null })
+      .eq("id", run.id);
+    if (updateError) throw updateError;
+    const { error: auditError } = await supabase.from("audit_events").insert({
+      actor_type: "service",
+      action: "existing_catalogue_requalification_completed",
+      entity_type: "existing_catalogue_requalification_run",
+      entity_id: run.id,
+      reason: "Private deterministic evidence pass completed; listing visibility and lifecycle were unchanged.",
+      after_data: { policy_version: policyVersion, input_count: records.length, qualified_count: qualifiedCount, exception_count: exceptionCount, publication_unchanged: true },
+      correlation_id: run.correlation_id,
+    });
+    if (auditError) throw auditError;
+    console.log(`Existing catalogue requalification completed: ${qualifiedCount} qualified, ${exceptionCount} exceptions. No listing state changed.`);
+  } catch (error) {
+    await supabase.from("existing_catalogue_requalification_runs")
+      .update({ status: "failed", error_message: error instanceof Error ? error.message : "Catalogue requalification failed.", completed_at: new Date().toISOString() })
+      .eq("id", run.id);
+    throw error;
+  }
+}
+
+async function loadPublishedVendors(): Promise<VendorRow[]> {
+  const vendors: VendorRow[] = [];
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await supabase.from("vendors")
+      .select("id, business_name, street_address, contact_email, phone, website, listing_source, source_url, source_checked_on, category_slug, suburb_slug, updated_at")
+      .eq("is_published", true).order("id").range(from, from + 999);
+    if (error) throw error;
+    vendors.push(...(data as VendorRow[]));
+    if (data.length < 1000) return vendors;
+  }
+}
+
+async function loadSlugs(table: "categories" | "suburbs") {
+  const { data, error } = await supabase.from(table).select("slug");
+  if (error) throw error;
+  return new Set(data.map((row) => row.slug));
+}
+
+async function createRun(fingerprint: string, inputCount: number) {
+  const { data, error } = await supabase.from("existing_catalogue_requalification_runs")
+    .insert({ policy_version: policyVersion, catalogue_fingerprint: fingerprint, input_count: inputCount, status: "processing" })
+    .select("id, correlation_id").single();
+  if (error || !data) throw error ?? new Error("Could not start existing catalogue requalification.");
+  return data;
+}
+
+function toExistingListing(vendor: VendorRow) {
+  return { id: vendor.id, businessName: vendor.business_name, streetAddress: vendor.street_address, phone: vendor.phone, website: vendor.website };
+}
+
+function toQualificationInput(vendor: VendorRow): ExistingCatalogueListing {
+  return { ...toExistingListing(vendor), listingSource: vendor.listing_source, sourceUrl: vendor.source_url, sourceCheckedOn: vendor.source_checked_on, categorySlug: vendor.category_slug, suburbSlug: vendor.suburb_slug, contactEmail: vendor.contact_email };
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/scripts/test-existing-catalogue-requalification.ts
+++ b/scripts/test-existing-catalogue-requalification.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { qualifyExistingCatalogueListing } from "../web/src/lib/automation/existing-catalogue-requalification";
+
+const options = {
+  allowedSuburbs: new Set(["northcote"]),
+  allowedCategories: new Set(["plumber"]),
+  existingListings: [
+    { id: "other", businessName: "Other Plumbing", streetAddress: "2 Main Street", phone: "03 9000 0000", website: "https://other.example" },
+  ],
+};
+const valid = {
+  id: "self",
+  businessName: "Acme Plumbing",
+  streetAddress: "1 Main Street",
+  phone: "03 8111 2222",
+  website: null,
+  contactEmail: null,
+  listingSource: "approved_import",
+  sourceUrl: "https://www.openstreetmap.org/node/1",
+  sourceCheckedOn: "2026-07-23",
+  categorySlug: "plumber",
+  suburbSlug: "northcote",
+};
+
+assert.equal(qualifyExistingCatalogueListing(valid, options).outcome, "qualified");
+assert(qualifyExistingCatalogueListing({ ...valid, phone: null, website: null, contactEmail: null }, options).reasons.includes("missing_reachable_contact"));
+assert(qualifyExistingCatalogueListing({ ...valid, listingSource: "seeded_by_suburbmates", sourceUrl: null, sourceCheckedOn: null }, options).reasons.includes("unproven_existing_provenance"));
+assert(qualifyExistingCatalogueListing({ ...valid, phone: "03 9000 0000" }, options).reasons.includes("strong_duplicate"));
+assert(!qualifyExistingCatalogueListing(valid, { ...options, existingListings: [{ ...valid }] }).reasons.includes("strong_duplicate"));
+
+const migration = fs.readFileSync("supabase/migrations/20260722155335_existing_catalogue_requalification.sql", "utf8");
+assert.match(migration, /UNIQUE \(policy_version, catalogue_fingerprint\)/);
+assert.match(migration, /UNIQUE \(run_id, vendor_id\)/);
+assert.match(migration, /never changes listing lifecycle or visibility/i);
+assert.match(migration, /PERFORM private\.require_active_operator\(\)/);
+
+console.log("Existing catalogue requalification policy tests passed.");

--- a/supabase/migrations/20260722155335_existing_catalogue_requalification.sql
+++ b/supabase/migrations/20260722155335_existing_catalogue_requalification.sql
@@ -1,0 +1,102 @@
+-- Private, repeatable requalification evidence for listings that predate the
+-- deterministic candidate handoff. Classification alone never changes a
+-- listing's public, ownership, commercial or lifecycle state.
+
+CREATE TABLE public.existing_catalogue_requalification_runs (
+  id UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  policy_version TEXT NOT NULL,
+  catalogue_fingerprint TEXT NOT NULL CHECK (catalogue_fingerprint ~ '^[0-9a-f]{64}$'),
+  status TEXT NOT NULL DEFAULT 'processing' CHECK (status IN ('processing', 'completed', 'failed')),
+  input_count INTEGER NOT NULL DEFAULT 0 CHECK (input_count >= 0),
+  qualified_count INTEGER NOT NULL DEFAULT 0 CHECK (qualified_count >= 0),
+  exception_count INTEGER NOT NULL DEFAULT 0 CHECK (exception_count >= 0),
+  correlation_id UUID NOT NULL DEFAULT extensions.uuid_generate_v4(),
+  error_message TEXT,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
+  completed_at TIMESTAMPTZ,
+  UNIQUE (policy_version, catalogue_fingerprint)
+);
+
+CREATE TABLE public.existing_catalogue_requalification_records (
+  id UUID PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  run_id UUID NOT NULL REFERENCES public.existing_catalogue_requalification_runs(id) ON DELETE RESTRICT,
+  vendor_id UUID NOT NULL REFERENCES public.vendors(id) ON DELETE RESTRICT,
+  qualification_outcome TEXT NOT NULL CHECK (qualification_outcome IN ('qualified', 'exception')),
+  qualification_reasons JSONB NOT NULL DEFAULT '[]'::jsonb,
+  normalized_data JSONB NOT NULL,
+  duplicate_vendor_id UUID REFERENCES public.vendors(id) ON DELETE RESTRICT,
+  exception_status TEXT NOT NULL DEFAULT 'open' CHECK (exception_status IN ('open', 'acknowledged')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
+  UNIQUE (run_id, vendor_id)
+);
+
+ALTER TABLE public.existing_catalogue_requalification_runs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.existing_catalogue_requalification_records ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.existing_catalogue_requalification_runs, public.existing_catalogue_requalification_records FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.existing_catalogue_requalification_runs, public.existing_catalogue_requalification_records TO service_role;
+
+CREATE INDEX existing_catalogue_requalification_records_run_outcome_idx
+  ON public.existing_catalogue_requalification_records (run_id, qualification_outcome, created_at DESC);
+CREATE INDEX existing_catalogue_requalification_records_exception_idx
+  ON public.existing_catalogue_requalification_records (exception_status, created_at DESC)
+  WHERE qualification_outcome = 'exception';
+
+CREATE OR REPLACE FUNCTION public.ops_list_existing_catalogue_requalification_exceptions(
+  p_status TEXT DEFAULT 'open',
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+  run_id UUID,
+  run_completed_at TIMESTAMPTZ,
+  record_id UUID,
+  vendor_id UUID,
+  business_name TEXT,
+  category_slug TEXT,
+  suburb_slug TEXT,
+  qualification_reasons JSONB,
+  duplicate_vendor_id UUID,
+  exception_status TEXT,
+  created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_status TEXT := lower(trim(coalesce(p_status, 'open')));
+BEGIN
+  PERFORM private.require_active_operator();
+  IF v_status NOT IN ('open', 'acknowledged', 'all') OR p_limit < 1 OR p_limit > 200 OR p_offset < 0 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invalid catalogue requalification filter or pagination values.';
+  END IF;
+
+  RETURN QUERY
+  WITH latest_run AS (
+    SELECT run.id, run.completed_at
+    FROM public.existing_catalogue_requalification_runs AS run
+    WHERE run.status = 'completed'
+    ORDER BY run.completed_at DESC NULLS LAST, run.started_at DESC
+    LIMIT 1
+  )
+  SELECT run.id, run.completed_at, record.id, vendor.id, vendor.business_name,
+    vendor.category_slug, vendor.suburb_slug, record.qualification_reasons,
+    record.duplicate_vendor_id, record.exception_status, record.created_at
+  FROM latest_run AS run
+  JOIN public.existing_catalogue_requalification_records AS record ON record.run_id = run.id
+  JOIN public.vendors AS vendor ON vendor.id = record.vendor_id
+  WHERE record.qualification_outcome = 'exception'
+    AND (v_status = 'all' OR record.exception_status = v_status)
+  ORDER BY record.created_at DESC
+  LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ops_list_existing_catalogue_requalification_exceptions(TEXT, INTEGER, INTEGER) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.ops_list_existing_catalogue_requalification_exceptions(TEXT, INTEGER, INTEGER) TO authenticated;
+
+COMMENT ON TABLE public.existing_catalogue_requalification_runs IS
+  'Private, idempotent evidence pass over existing listings. It never changes listing lifecycle or visibility.';
+COMMENT ON TABLE public.existing_catalogue_requalification_records IS
+  'Private per-listing deterministic requalification result for a specific existing-catalogue run.';

--- a/supabase/migrations/20260722155653_fix_staged_communication_conflicts.sql
+++ b/supabase/migrations/20260722155653_fix_staged_communication_conflicts.sql
@@ -1,0 +1,117 @@
+-- The Stage 1 and 2 functions return a column named message_type. Using the
+-- column-list form of ON CONFLICT makes that output variable ambiguous in
+-- PL/pgSQL, so target the existing unique constraint by name instead.
+
+CREATE OR REPLACE FUNCTION public.prepare_stage1_status_communication(
+  p_entity_type TEXT,
+  p_entity_id UUID
+)
+RETURNS TABLE (
+  communication_delivery_id UUID,
+  message_type TEXT,
+  recipient_email TEXT,
+  request_status TEXT,
+  business_name TEXT,
+  template_version TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_type TEXT := lower(trim(coalesce(p_entity_type, '')));
+  v_email TEXT;
+  v_status TEXT;
+  v_business_name TEXT;
+  v_message_type TEXT;
+  v_delivery_id UUID;
+  v_template TEXT := 'stage1-status-v1';
+BEGIN
+  IF v_type = 'claim_request' THEN
+    SELECT claim.claimant_email, claim.claim_status, vendor.business_name
+    INTO v_email, v_status, v_business_name
+    FROM public.claim_requests AS claim JOIN public.vendors AS vendor ON vendor.id = claim.vendor_id
+    WHERE claim.id = p_entity_id;
+    v_message_type := 'claim_status';
+  ELSIF v_type = 'profile_change' THEN
+    SELECT lower(user_record.email), change_request.change_status, vendor.business_name
+    INTO v_email, v_status, v_business_name
+    FROM public.listing_change_requests AS change_request
+    JOIN public.vendors AS vendor ON vendor.id = change_request.vendor_id
+    JOIN auth.users AS user_record ON user_record.id = change_request.submitted_by
+    WHERE change_request.id = p_entity_id;
+    v_message_type := 'profile_change_status';
+  ELSE
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Unsupported communication entity.';
+  END IF;
+  IF v_email IS NULL OR v_status NOT IN ('needs_information', 'approved', 'rejected', 'revoked') THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'This request does not have an approved Stage 1 status message.';
+  END IF;
+  INSERT INTO public.communication_deliveries (message_type, entity_type, entity_id, recipient_email, template_version)
+  VALUES (v_message_type, v_type, p_entity_id::text, v_email, v_template)
+  ON CONFLICT ON CONSTRAINT communication_deliveries_unique_message DO NOTHING
+  RETURNING id INTO v_delivery_id;
+  IF v_delivery_id IS NULL THEN
+    SELECT delivery.id INTO v_delivery_id FROM public.communication_deliveries AS delivery
+    WHERE delivery.message_type = v_message_type AND delivery.entity_type = v_type AND delivery.entity_id = p_entity_id::text AND delivery.recipient_email = v_email;
+  END IF;
+  RETURN QUERY SELECT v_delivery_id, v_message_type, v_email, v_status, v_business_name, v_template;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.prepare_stage2_outcome_communication(
+  p_entity_type TEXT,
+  p_entity_id UUID
+)
+RETURNS TABLE (
+  communication_delivery_id UUID,
+  message_type TEXT,
+  recipient_email TEXT,
+  request_status TEXT,
+  business_name TEXT,
+  template_version TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_type TEXT := lower(trim(coalesce(p_entity_type, '')));
+  v_email TEXT;
+  v_status TEXT;
+  v_name TEXT;
+  v_message_type TEXT;
+  v_id UUID;
+  v_template TEXT := 'stage2-outcome-v1';
+BEGIN
+  IF v_type = 'business_submission' THEN
+    SELECT request.submitter_email, request.submission_status, vendor.business_name
+    INTO v_email, v_status, v_name
+    FROM public.business_submission_requests AS request JOIN public.vendors AS vendor ON vendor.id = request.vendor_id
+    WHERE request.vendor_id = p_entity_id;
+    v_message_type := 'submission_outcome';
+    IF v_status NOT IN ('needs_information', 'approved', 'declined') THEN
+      RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'This submission has no approved outcome message.';
+    END IF;
+  ELSIF v_type = 'contact_request' THEN
+    SELECT request.requester_email, request.contact_status, coalesce(request.business_name, 'SuburbMates request')
+    INTO v_email, v_status, v_name
+    FROM public.contact_requests AS request WHERE request.id = p_entity_id;
+    v_message_type := 'contact_outcome';
+    IF v_status <> 'resolved' THEN
+      RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Only a resolved contact request has an approved outcome message.';
+    END IF;
+  ELSE
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Unsupported communication entity.';
+  END IF;
+  INSERT INTO public.communication_deliveries (message_type, entity_type, entity_id, recipient_email, template_version)
+  VALUES (v_message_type, v_type, p_entity_id::text, v_email, v_template)
+  ON CONFLICT ON CONSTRAINT communication_deliveries_unique_message DO NOTHING
+  RETURNING id INTO v_id;
+  IF v_id IS NULL THEN
+    SELECT delivery.id INTO v_id FROM public.communication_deliveries AS delivery
+    WHERE delivery.message_type = v_message_type AND delivery.entity_type = v_type AND delivery.entity_id = p_entity_id::text AND delivery.recipient_email = v_email;
+  END IF;
+  RETURN QUERY SELECT v_id, v_message_type, v_email, v_status, v_name, v_template;
+END;
+$$;

--- a/web/src/app/ops/catalogue-review/page.tsx
+++ b/web/src/app/ops/catalogue-review/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+import { createOpsDataClient } from "@/lib/ops/auth";
+import { formatOpsDateTime } from "@/lib/ops/date";
+
+const statuses = ["open", "acknowledged", "all"] as const;
+type Status = (typeof statuses)[number];
+
+type CatalogueException = {
+  run_id: string;
+  run_completed_at: string;
+  record_id: string;
+  vendor_id: string;
+  business_name: string;
+  category_slug: string;
+  suburb_slug: string;
+  qualification_reasons: string[];
+  duplicate_vendor_id: string | null;
+  exception_status: string;
+  created_at: string;
+};
+
+export default async function CatalogueReviewPage({ searchParams }: { searchParams: Promise<{ status?: string }> }) {
+  const params = await searchParams;
+  const status = statuses.includes(params.status as Status) ? (params.status as Status) : "open";
+  const supabase = await createOpsDataClient();
+  const { data, error } = await supabase.rpc("ops_list_existing_catalogue_requalification_exceptions", {
+    p_status: status,
+    p_limit: 100,
+    p_offset: 0,
+  });
+  if (error) throw new Error("The catalogue requalification exceptions could not be loaded.");
+  const records = (data ?? []) as CatalogueException[];
+
+  return (
+    <div className="space-y-7">
+      <div>
+        <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">Existing catalogue</p>
+        <h2 className="mt-2 text-4xl font-black tracking-tight">Records needing evidence or a decision</h2>
+        <p className="mt-3 max-w-3xl text-slate-600">This is a private evidence review of listings that existed before the current qualification handoff. Seeing a record here does not change its public visibility.</p>
+      </div>
+
+      <nav className="flex flex-wrap gap-2" aria-label="Catalogue requalification status filters">
+        {statuses.map((item) => <Link key={item} href={`/ops/catalogue-review?status=${item}`} aria-current={item === status ? "page" : undefined} className={`rounded-full border px-4 py-2 text-sm font-bold ${item === status ? "border-slate-950 bg-slate-950 text-white" : "border-slate-300 bg-white"}`}>{label(item)}</Link>)}
+      </nav>
+
+      {records.length === 0 ? (
+        <section className="rounded-2xl border border-slate-200 bg-white p-8 text-slate-600 shadow-sm">No completed requalification exceptions match this view yet. Running the private evidence pass does not publish, unpublish, claim or edit any business.</section>
+      ) : (
+        <div className="space-y-5">{records.map((record) => <ExceptionCard key={record.record_id} record={record} />)}</div>
+      )}
+    </div>
+  );
+}
+
+function ExceptionCard({ record }: { record: CatalogueException }) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div><h3 className="text-xl font-bold">{record.business_name}</h3><p className="mt-1 text-sm text-slate-600">{record.category_slug} · {record.suburb_slug}</p></div>
+        <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-950">Evidence review</span>
+      </div>
+      <div className="mt-5 rounded-xl bg-amber-50 p-4"><p className="font-bold">Why it needs attention</p><ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">{record.qualification_reasons.map((reason) => <li key={reason}>{reasonLabel(reason)}</li>)}</ul></div>
+      {record.duplicate_vendor_id && <p className="mt-4 text-sm"><Link className="font-bold underline" href={`/ops/listings/${record.duplicate_vendor_id}`}>Review the possible matching listing</Link></p>}
+      <p className="mt-4 text-xs text-slate-500">Evidence pass completed {formatOpsDateTime(record.run_completed_at)}. This page does not make a listing decision.</p>
+    </section>
+  );
+}
+
+function label(value: string) { return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase()); }
+function reasonLabel(reason: string) {
+  return ({
+    missing_reachable_contact: "There is no usable way for customers to contact the business.",
+    unproven_existing_provenance: "The original source evidence is incomplete.",
+    unsafe_or_invalid_website: "The stored website address is unsafe or invalid.",
+    strong_duplicate: "It matches another listing strongly.",
+    possible_duplicate: "It may match another listing and needs a human check.",
+    outside_geographic_scope: "It is outside the directory area.",
+    unsupported_category: "Its category is not supported.",
+    invalid_business_name: "The business name is not usable.",
+  } as Record<string, string>)[reason] ?? label(reason);
+}

--- a/web/src/app/ops/layout.tsx
+++ b/web/src/app/ops/layout.tsx
@@ -24,6 +24,7 @@ export default async function OpsLayout({ children }: { children: React.ReactNod
             <Link href="/ops">Overview</Link>
             <Link href="/ops/listings">Listings</Link>
             <Link href="/ops/candidates">Candidates</Link>
+            <Link href="/ops/catalogue-review">Catalogue review</Link>
             <Link href="/ops/claims">Claims</Link>
             <Link href="/ops/profile-edits">Profile edits</Link>
             <Link href="/ops/contact">Contact</Link>

--- a/web/src/lib/automation/existing-catalogue-requalification.ts
+++ b/web/src/lib/automation/existing-catalogue-requalification.ts
@@ -1,0 +1,49 @@
+import { qualifyCandidate, type ExistingListing, type Qualification } from "./candidate-qualification";
+
+export type ExistingCatalogueListing = ExistingListing & {
+  listingSource: string | null;
+  sourceUrl: string | null;
+  sourceCheckedOn: string | null;
+  categorySlug: string | null;
+  suburbSlug: string | null;
+  contactEmail: string | null;
+};
+
+export type ExistingCatalogueQualification = Qualification & {
+  reasons: string[];
+};
+
+export function qualifyExistingCatalogueListing(
+  listing: ExistingCatalogueListing,
+  options: { allowedSuburbs: ReadonlySet<string>; allowedCategories: ReadonlySet<string>; existingListings: readonly ExistingListing[] },
+): ExistingCatalogueQualification {
+  const base = qualifyCandidate(
+    {
+      source: "openstreetmap",
+      businessName: listing.businessName,
+      categorySlug: listing.categorySlug ?? "",
+      suburbSlug: listing.suburbSlug ?? "",
+      streetAddress: listing.streetAddress,
+      contactEmail: listing.contactEmail,
+      phone: listing.phone,
+      website: listing.website,
+      websiteSafety: "unknown",
+    },
+    {
+      allowedSources: new Set(["openstreetmap"]),
+      allowedSuburbs: options.allowedSuburbs,
+      allowedCategories: options.allowedCategories,
+      existingListings: options.existingListings.filter((candidate) => candidate.id !== listing.id),
+    },
+  );
+
+  const reasons = [...base.reasons];
+  if (listing.listingSource !== "approved_import" || !listing.sourceUrl || !listing.sourceCheckedOn) {
+    reasons.push("unproven_existing_provenance");
+  }
+  return {
+    ...base,
+    outcome: reasons.length === 0 ? "qualified" : "exception",
+    reasons,
+  };
+}


### PR DESCRIPTION
Adds a private idempotent requalification evidence pass for the existing catalogue, a protected Ops review surface, and fixes dormant staged-communication conflict handling. The requalification run cannot change listing visibility or lifecycle; it requires explicit local opt-in to execute.