### PR TITLE
Mark requalification Ops reader volatile

### DIFF
--- a/supabase/migrations/20260722155953_fix_requalification_reader_volatility.sql
+++ b/supabase/migrations/20260722155953_fix_requalification_reader_volatility.sql
@@ -1,0 +1,3 @@
+-- The reader verifies the current operator, so PostgreSQL must not treat it
+-- as a stable function.
+ALTER FUNCTION public.ops_list_existing_catalogue_requalification_exceptions(TEXT, INTEGER, INTEGER) VOLATILE;


### PR DESCRIPTION
Removes the new Supabase lint warning by correctly marking the authenticated requalification-reader function as VOLATILE.