### PR TITLE
Harden candidate handoff recovery

### DIFF
--- a/scripts/submit-candidate-handoff.ts
+++ b/scripts/submit-candidate-handoff.ts
@@ -6,6 +6,7 @@ import { parse } from "csv-parse/sync";
 const endpoint = process.env.CANDIDATE_HANDOFF_URL;
 const token = process.env.AUTOMATION_INGEST_TOKEN;
 const csvPath = process.argv[2];
+const BATCH_SIZE = 10;
 if (!endpoint || !token || !csvPath) throw new Error("CANDIDATE_HANDOFF_URL, AUTOMATION_INGEST_TOKEN and a CSV path are required.");
 
 const rows = parse(fs.readFileSync(path.resolve(csvPath), "utf8"), { columns: true, skip_empty_lines: true }) as Array<Record<string, string>>;
@@ -13,15 +14,18 @@ const artifactUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITO
   ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
   : undefined;
 
-for (let index = 0; index < rows.length; index += 100) {
-  const candidates = rows.slice(index, index + 100).map((row) => ({
+for (let index = 0; index < rows.length; index += BATCH_SIZE) {
+  const candidates = rows.slice(index, index + BATCH_SIZE).map((row) => ({
     source: "openstreetmap", businessName: row.business_name, categorySlug: row.category_slug, suburbSlug: row.suburb_slug,
     streetAddress: row.address || undefined, contactEmail: row.contact_email || undefined, phone: row.phone || undefined,
     website: row.website || undefined, sourceUrl: row.source_url, sourceCheckedOn: row.source_checked_on || undefined, notes: row.notes || undefined,
   }));
   const artifactSha256 = createHash("sha256").update(JSON.stringify(candidates)).digest("hex");
   const response = await fetch(endpoint, { method: "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json" }, body: JSON.stringify({ source: "openstreetmap", artifactSha256, artifactUrl, candidates }) });
-  if (!response.ok) throw new Error(`Candidate handoff batch ${index / 100 + 1} failed with ${response.status}.`);
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 1000);
+    throw new Error(`Candidate handoff batch ${index / BATCH_SIZE + 1} failed with ${response.status}: ${detail || "No response body"}.`);
+  }
   const result = await response.json() as { qualifiedCount?: number; exceptionCount?: number; idempotent?: boolean };
-  console.log(`Candidate handoff batch ${index / 100 + 1}: ${result.idempotent ? "already received" : `${result.qualifiedCount ?? 0} qualified, ${result.exceptionCount ?? 0} exceptions`}.`);
+  console.log(`Candidate handoff batch ${index / BATCH_SIZE + 1}: ${result.idempotent ? "already received" : `${result.qualifiedCount ?? 0} qualified, ${result.exceptionCount ?? 0} exceptions`}.`);
 }

--- a/scripts/test-candidate-automation-ingest-boundary.ts
+++ b/scripts/test-candidate-automation-ingest-boundary.ts
@@ -13,10 +13,14 @@ assert.match(route, /listing_status: "published"/);
 assert.match(route, /ownership_status: "unclaimed"/);
 assert.match(route, /candidate_handoff_exception_created/);
 assert.match(route, /existingRun\.status === "failed"/);
-assert.match(route, /Could not resume the failed candidate handoff run/);
+assert.match(route, /STALE_PROCESSING_MS/);
+assert.match(route, /staleProcessing/);
+assert.match(route, /Could not resume the failed or stale candidate handoff run/);
 assert.match(route, /Could not recover the partially completed qualified listing/);
 assert.doesNotMatch(route, /stripe/i);
 assert.match(workflow, /candidate:handoff/);
 assert.match(workflow, /AUTOMATION_INGEST_TOKEN/);
+assert.match(fs.readFileSync("scripts\/submit-candidate-handoff.ts", "utf8"), /const BATCH_SIZE = 10/);
+assert.match(fs.readFileSync("scripts\/submit-candidate-handoff.ts", "utf8"), /await response\.text\(\)/);
 
 console.log("Candidate automation ingestion boundary checks passed.");

--- a/web/src/app/api/automation/candidates/route.ts
+++ b/web/src/app/api/automation/candidates/route.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from "@/utils/supabase/admin";
 
 const MAX_CANDIDATES = 100;
 const allowedSource = "openstreetmap";
+const STALE_PROCESSING_MS = 5 * 60 * 1000;
 
 type IncomingCandidate = CandidateInput & {
   sourceUrl: string;
@@ -39,16 +40,26 @@ export async function POST(request: NextRequest) {
       .single();
     if (runError?.code === "23505") {
       const { data: existingRun, error: existingRunError } = await admin.from("candidate_handoff_runs")
-        .select("id, correlation_id, status, qualified_count, exception_count")
+        .select("id, correlation_id, status, qualified_count, exception_count, received_at")
         .eq("source", source).eq("artifact_sha256", artifactSha256).maybeSingle();
       if (existingRunError || !existingRun) throw new Error("Could not read the existing candidate handoff run.");
       if (existingRun.status === "completed") return NextResponse.json({ received: true, idempotent: true, run: existingRun }, { status: 200 });
-      if (existingRun.status === "processing") return NextResponse.json({ received: true, processing: true, run: existingRun }, { status: 202 });
-      if (existingRun.status === "failed") {
+      const staleProcessing = existingRun.status === "processing"
+        && Date.now() - new Date(existingRun.received_at).getTime() >= STALE_PROCESSING_MS;
+      if (existingRun.status === "processing" && !staleProcessing) {
+        return NextResponse.json({ received: true, processing: true, run: existingRun }, { status: 202 });
+      }
+      if (existingRun.status === "failed" || staleProcessing) {
+        if (staleProcessing) {
+          const staleJobs = await admin.from("automation_jobs")
+            .update({ status: "failed", error_message: "Candidate handoff exceeded the processing window and was safely resumed.", completed_at: new Date().toISOString() })
+            .eq("correlation_id", existingRun.correlation_id).eq("status", "running");
+          if (staleJobs.error) throw new Error("Could not close the stale candidate handoff job.");
+        }
         const resumed = await admin.from("candidate_handoff_runs")
-          .update({ status: "processing", input_count: candidates.length, qualified_count: 0, exception_count: 0, error_message: null, completed_at: null })
+          .update({ status: "processing", input_count: candidates.length, qualified_count: 0, exception_count: 0, error_message: null, completed_at: null, received_at: new Date().toISOString() })
           .eq("id", existingRun.id).select("id, correlation_id").single();
-        if (resumed.error || !resumed.data) throw new Error("Could not resume the failed candidate handoff run.");
+        if (resumed.error || !resumed.data) throw new Error("Could not resume the failed or stale candidate handoff run.");
         run = resumed.data;
         runError = null;
       } else {


### PR DESCRIPTION
Summary: reduce production candidate batches to 10, retain response detail on failure, and safely recover stale processing runs while closing their abandoned job record. Verification: full repository checks and web build passed.