### PR TITLE
Resume interrupted candidate batches sooner

### DIFF
--- a/scripts/test-candidate-automation-ingest-boundary.ts
+++ b/scripts/test-candidate-automation-ingest-boundary.ts
@@ -14,7 +14,7 @@ assert.match(route, /ownership_status: "unclaimed"/);
 assert.match(route, /candidate_handoff_exception_created/);
 assert.match(route, /existingRun\.status === "failed"/);
 assert.match(route, /STALE_PROCESSING_MS/);
-assert.match(route, /STALE_PROCESSING_MS = 60 \* 1000/);
+assert.match(route, /STALE_PROCESSING_MS = 30 \* 1000/);
 assert.match(route, /staleProcessing/);
 assert.match(route, /Could not resume the failed or stale candidate handoff run/);
 assert.match(route, /Could not recover the partially completed qualified listing/);

--- a/web/src/app/api/automation/candidates/route.ts
+++ b/web/src/app/api/automation/candidates/route.ts
@@ -5,9 +5,9 @@ import { createAdminClient } from "@/utils/supabase/admin";
 
 const MAX_CANDIDATES = 100;
 const allowedSource = "openstreetmap";
-// A Worker request is bounded well below this window. Treat a processing record
-// older than one minute as interrupted, close its job and resume idempotently.
-const STALE_PROCESSING_MS = 60 * 1000;
+// The Worker request cannot legitimately outlive this window. Treat a longer
+// processing record as interrupted, close its job and resume idempotently.
+const STALE_PROCESSING_MS = 30 * 1000;
 
 type IncomingCandidate = CandidateInput & {
   sourceUrl: string;


### PR DESCRIPTION
A processing candidate batch older than 30 seconds is beyond the Worker request lifetime and can be closed and safely resumed.\n\nVerification: candidate automation boundary tests; candidate handoff boundary tests; web production build.