### PR TITLE
Add password sign-in and recovery

### DIFF
--- a/docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md
+++ b/docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md
@@ -12,8 +12,9 @@ The product status screen is the source of a person's request outcome. A message
 
 | Capability | Status |
 | --- | --- |
-| Passwordless sign-in from `auth@suburbmates.com.au` | Active for authorised access. |
-| Cross-device passwordless access | Active through an eight-digit email code entered in the browser being used. |
+| Email-and-password sign-in | Active for existing authorised accounts; no public account-registration screen is provided. |
+| Password reset from `auth@suburbmates.com.au` | Active. It returns only to the real SuburbMates callback, where the person sets a new password. |
+| Email-code sign-in | Available as a fallback through an eight-digit code entered in the browser being used. |
 | Public contact/help/privacy form | Publicly reachable; it creates a private, moderated request and does not promise an email. |
 | Approved status messages | Enabled only for the approved claim, profile-change, submission and request-outcome paths. The first real successful delivery and deliberate failure evidence are still required. |
 | Contact dispatcher / general notification sender | Dormant; not enabled. |
@@ -25,7 +26,8 @@ No row below becomes enabled until its associated user journey and Ops workflow 
 
 | Stage | Message | Trigger | Recipient | In-product fallback | Ops evidence |
 | --- | --- | --- | --- | --- | --- |
-| Active | Email-code sign-in | Person requests authorised sign-in. | Requesting email. | Login page/retry guidance. | Auth provider result; no application message ledger required. |
+| Active | Password reset | An existing authorised account requests a reset. | Requesting email. | Reset page and login retry guidance. | Auth provider result; no application message ledger required. |
+| Active | Email-code sign-in | Person deliberately chooses the fallback code path. | Requesting email. | Login page/retry guidance. | Auth provider result; no application message ledger required. |
 | 1 | Claim status | Claim needs information, is approved, rejected or revoked. | Authenticated claimant's approved address. | Owner request-status feed. | Claim ID, status, template/version, delivery result. |
 | 1 | Profile-change status | Proposed change is approved or rejected. | Authenticated owner. | Owner request-status feed. | Change-request ID, status, template/version, delivery result. |
 | 2 | Missing-business outcome | Candidate is accepted, needs information or declined. | Submitter only when they supplied a valid contact basis. | Submitted reference/status path where offered. | Candidate ID, outcome, consent/contact basis, delivery result. |
@@ -49,7 +51,8 @@ The public form must classify the request before it reaches Ops: correction, cla
 
 ## Evidence required before review
 
-- authenticated email-code, expiry and recovery check;
+- authenticated password sign-in and password-reset recovery check;
+- fallback email-code, expiry and recovery check;
 - contact input validation/abuse-control and private-queue boundary check;
 - review of delivery-ledger access, audit and retention boundaries;
 - explicit confirmation that no dormant dispatcher became active; and

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -107,6 +107,14 @@ No branch, pull request, automation run or lane handover changes product policy 
 
 - **Date:** 23 July 2026
 - **Decision:** The owner explicitly authorised the first public directory release. The `NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED` gate is enabled in the production deployment.
+
+### D-012 — Password sign-in for existing authorised accounts
+
+- **Date:** 23 July 2026
+- **Decision:** Existing authorised accounts may use email and password as the primary sign-in path. Password reset is sent only from `auth@suburbmates.com.au` and returns only to the real SuburbMates callback. The eight-digit email code remains a fallback.
+- **Boundary:** This does not add a public account-registration screen, a new sender, marketing email, a general inbox, or application-managed authentication messages.
+- **Security rule:** Passwords must be at least 12 characters. The hosted plan does not include Supabase's optional breached-password check; the operator should use a unique password and may enable that provider feature only if the plan changes.
+- **Evidence required:** A real reset from the controlled email account, password sign-in in a separate browser/device, and confirmation that the fallback email-code path remains intact.
 - **Verified result:** Home, browse, a populated category route, a representative published profile and the sitemap return successfully. The sitemap contains 1,684 eligible public URLs; canonical and `www` redirect behaviour are correct; released pages no longer carry the holding-page `noindex` directive; `/ops` still redirects unauthenticated visitors to sign-in.
 - **Guardrail:** This authorisation does not enable Stripe, general outbound email, bulk ABN checks, AI publication, raw-candidate publication or automated ownership decisions.
 - **Outstanding evidence:** Complete real authenticated owner/submitter and operator walkthroughs, including the candidate-to-Ops, ABN evidence and owner-media paths. Any failure must be recorded and corrected; it is not a reason to publish additional listings.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "owner-request-withdrawal:test": "tsx scripts/test-owner-request-withdrawal-boundary.ts",
     "claim-evidence-handoff:test": "tsx scripts/test-claim-evidence-handoff-boundary.ts",
     "cross-device-email-code:test": "tsx scripts/test-cross-device-email-code-boundary.ts",
+    "password-login:test": "tsx scripts/test-password-login-boundary.ts",
     "private-business-submission-status:test": "tsx scripts/test-private-business-submission-status-boundary.ts",
     "submitter-owner-identity:test": "tsx scripts/test-submitter-owner-identity-boundary.ts",
     "owner-submitted-business-candidate:test": "tsx scripts/test-owner-submitted-business-candidate-boundary.ts",

--- a/scripts/test-password-login-boundary.ts
+++ b/scripts/test-password-login-boundary.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const login = fs.readFileSync("web/src/app/(directory)/login/page.tsx", "utf8");
+const reset = fs.readFileSync("web/src/app/(directory)/reset-password/page.tsx", "utf8");
+const communications = fs.readFileSync("docs/REFERENCE/SuburbMates — Communications and Account-Access Specification.md", "utf8");
+
+assert.match(login, /supabase\.auth\.signInWithPassword\(\{ email, password \}\)/);
+assert.match(login, /resetPasswordForEmail\(email, \{ redirectTo \}\)/);
+assert.match(login, /auth\/callback\?next=\/reset-password/);
+assert.match(login, /shouldCreateUser: false/);
+assert.match(reset, /auth\.updateUser\(\{ password \}\)/);
+assert.match(reset, /password\.length < 12/);
+assert.match(login, /minLength=\{12\}/);
+assert.match(communications, /Email-and-password sign-in/);
+assert.doesNotMatch(login, /signUp\(/);
+
+console.log("Password login boundary checks passed.");

--- a/web/src/app/(directory)/login/page.tsx
+++ b/web/src/app/(directory)/login/page.tsx
@@ -15,22 +15,36 @@ export default function LoginPage() {
 function LoginForm() {
   const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [codeSent, setCodeSent] = useState(false);
+  const [showEmailCode, setShowEmailCode] = useState(false);
   const [message, setMessage] = useState<{ kind: "error" | "success"; text: string } | null>(null);
 
   const next = safeNext(searchParams.get("next"));
 
-  const handleLogin = async (e: React.FormEvent) => {
+  const handlePasswordLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setMessage(null);
-    
     const supabase = createClient();
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-    });
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+
+    if (error || !data.session) {
+      setMessage({ kind: "error", text: "We could not sign you in with that email and password. Check both, or reset your password below." });
+    } else {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      window.location.assign(next);
+    }
+    setLoading(false);
+  };
+
+  const handleSendCode = async () => {
+    setLoading(true);
+    setMessage(null);
+    const supabase = createClient();
+    const { error } = await supabase.auth.signInWithOtp({ email, options: { shouldCreateUser: false } });
 
     if (error) {
       const text = error.message.toLowerCase().includes("rate")
@@ -40,6 +54,24 @@ function LoginForm() {
     } else {
       setCodeSent(true);
       setMessage({ kind: "success", text: "Check your email for the eight-digit sign-in code. Enter it here; the email can be opened on another device." });
+    }
+    setLoading(false);
+  };
+
+  const handlePasswordReset = async () => {
+    if (!email) {
+      setMessage({ kind: "error", text: "Enter your email address first, then choose password reset." });
+      return;
+    }
+    setLoading(true);
+    setMessage(null);
+    const supabase = createClient();
+    const redirectTo = `${window.location.origin}/auth/callback?next=/reset-password`;
+    const { error } = await supabase.auth.resetPasswordForEmail(email, { redirectTo });
+    if (error) {
+      setMessage({ kind: "error", text: "We could not send the password-reset email. Wait a little while if you recently requested an email, then try again." });
+    } else {
+      setMessage({ kind: "success", text: "Check your email for the password-reset link. You can open it on the device where you want to set your password." });
     }
     setLoading(false);
   };
@@ -71,14 +103,14 @@ function LoginForm() {
       <div className="w-full max-w-md space-y-8 bg-white text-[#121212] p-8 rounded-lg shadow-xl">
         <div className="text-center">
           <h1 className="text-3xl font-extrabold tracking-tight">Sign in to SuburbMates</h1>
-          <p className="mt-2 text-sm text-gray-600">Enter your email to receive a one-time sign-in code for your authorised area.</p>
+          <p className="mt-2 text-sm text-gray-600">Sign in with your email and password. Existing authorised accounts only.</p>
         </div>
         {searchParams.get("error") === "magic-link" && (
           <p role="alert" className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm font-medium text-amber-900">
             That older sign-in link could not be completed. Request a new email code below and enter it in this browser. Do not request another code until the email rate limit has cleared.
           </p>
         )}
-        <form className="mt-8 space-y-6" onSubmit={handleLogin}>
+        <form className="mt-8 space-y-4" onSubmit={handlePasswordLogin}>
           <div>
             <label htmlFor="email" className="sr-only">Email address</label>
             <input
@@ -93,12 +125,27 @@ function LoginForm() {
             />
           </div>
           <div>
+            <label htmlFor="password" className="sr-only">Password</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              minLength={12}
+              autoComplete="current-password"
+              className="appearance-none rounded-md relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-[#121212] focus:outline-none focus:ring-[#121212] focus:border-[#121212] focus:z-10 sm:text-sm"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <div>
             <button
               type="submit"
               disabled={loading}
               className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-[#121212] hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#121212] disabled:opacity-50"
             >
-              {loading ? "Sending code..." : codeSent ? "Send a new code" : "Send sign-in code"}
+              {loading ? "Signing in..." : "Sign in"}
             </button>
           </div>
           {message && (
@@ -110,7 +157,20 @@ function LoginForm() {
             </p>
           )}
         </form>
-        {codeSent && (
+        <div className="border-t border-gray-200 pt-5 text-center text-sm">
+          <button type="button" disabled={loading} onClick={handlePasswordReset} className="font-medium text-[#121212] underline hover:text-gray-700 disabled:opacity-50">Set or reset password</button>
+          <p className="mt-2 text-xs text-gray-500">Use a unique password of at least 12 characters.</p>
+        </div>
+        <div className="border-t border-gray-200 pt-5">
+          <button type="button" disabled={loading} onClick={() => setShowEmailCode((visible) => !visible)} className="w-full text-sm font-medium text-[#121212] underline hover:text-gray-700 disabled:opacity-50">{showEmailCode ? "Hide email-code sign-in" : "Use a one-time email code instead"}</button>
+        </div>
+        {showEmailCode && (
+          <div className="space-y-4">
+            <button type="button" disabled={loading || !email} onClick={handleSendCode} className="group relative flex w-full justify-center rounded-md border border-[#121212] bg-white px-4 py-2 text-sm font-medium text-[#121212] hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-[#121212] focus:ring-offset-2 disabled:opacity-50">{loading ? "Sending code..." : codeSent ? "Send a new code" : "Send sign-in code"}</button>
+            {!email && <p className="text-center text-xs text-gray-500">Enter your email address above before requesting a code.</p>}
+          </div>
+        )}
+        {showEmailCode && codeSent && (
           <form className="space-y-4 border-t border-gray-200 pt-6" onSubmit={handleCodeVerification}>
             <div>
               <label htmlFor="code" className="text-sm font-medium text-gray-700">Sign-in code</label>

--- a/web/src/app/(directory)/reset-password/page.tsx
+++ b/web/src/app/(directory)/reset-password/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { createClient } from "@/utils/supabase/client";
+
+export default function ResetPasswordPage() {
+  const [password, setPassword] = useState("");
+  const [confirmation, setConfirmation] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{ kind: "error" | "success"; text: string } | null>(null);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (password.length < 12) {
+      setMessage({ kind: "error", text: "Use a password with at least 12 characters." });
+      return;
+    }
+    if (password !== confirmation) {
+      setMessage({ kind: "error", text: "The two passwords do not match." });
+      return;
+    }
+    setLoading(true);
+    setMessage(null);
+    const { error } = await createClient().auth.updateUser({ password });
+    if (error) {
+      setMessage({ kind: "error", text: "This password-reset link could not be completed. Request a new reset email and open its newest link." });
+    } else {
+      setMessage({ kind: "success", text: "Your password is set. You can now sign in with it on any device." });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <main className="min-h-screen bg-[#121212] p-4 text-white flex items-center justify-center">
+      <section className="w-full max-w-md rounded-lg bg-white p-8 text-[#121212] shadow-xl">
+        <h1 className="text-3xl font-extrabold tracking-tight">Set your password</h1>
+        <p className="mt-2 text-sm text-gray-600">Choose a unique password with at least 12 characters.</p>
+        <form className="mt-8 space-y-4" onSubmit={handleSubmit}>
+          <input aria-label="New password" type="password" required minLength={12} autoComplete="new-password" className="block w-full rounded-md border border-gray-300 px-3 py-2 text-[#121212]" placeholder="New password" value={password} onChange={(event) => setPassword(event.target.value)} />
+          <input aria-label="Confirm new password" type="password" required minLength={12} autoComplete="new-password" className="block w-full rounded-md border border-gray-300 px-3 py-2 text-[#121212]" placeholder="Confirm new password" value={confirmation} onChange={(event) => setConfirmation(event.target.value)} />
+          <button type="submit" disabled={loading} className="flex w-full justify-center rounded-md bg-[#121212] px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50">{loading ? "Saving password..." : "Save password"}</button>
+        </form>
+        {message && <p role={message.kind === "error" ? "alert" : "status"} className={`mt-4 rounded-md border p-3 text-center text-sm font-medium ${message.kind === "error" ? "border-red-300 bg-red-50 text-red-800" : "border-green-300 bg-green-50 text-green-800"}`}>{message.text}</p>}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Outcome
Adds email-and-password sign-in for existing authorised accounts, plus a password-reset route that returns only to the production callback. Keeps the eight-digit email code as a fallback.

## Safety
- No public registration UI
- No new email sender or general notifications
- Password reset uses the existing auth sender
- Production Auth now requires at least 12 characters and permits only the real callback plus the existing review callback

## Verification
- `npm run password-login:test`
- `npm run cross-device-email-code:test`
- `npm run check`
- `npm --prefix web run lint` (existing image warnings only)
- `npm --prefix web run build`