### PR TITLE
Make Ops show real action queues

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run existing-catalogue-requalification:test && npm run abn-check:test && npm run abn-evidence:test && npm run transactional-communications:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run existing-catalogue-requalification:test && npm run abn-check:test && npm run abn-evidence:test && npm run transactional-communications:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test && npm run ops-action-queue:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -42,6 +42,7 @@
     "submitter-owner-identity:test": "tsx scripts/test-submitter-owner-identity-boundary.ts",
     "owner-submitted-business-candidate:test": "tsx scripts/test-owner-submitted-business-candidate-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
+    "ops-action-queue:test": "tsx scripts/test-ops-action-queue-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },
   "devDependencies": {

--- a/scripts/test-ops-action-queue-boundary.ts
+++ b/scripts/test-ops-action-queue-boundary.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const migration = fs.readFileSync("supabase/migrations/20260723015528_ops_action_overview.sql", "utf8");
+const overview = fs.readFileSync("web/src/app/ops/page.tsx", "utf8");
+const catalogue = fs.readFileSync("web/src/app/ops/catalogue-review/page.tsx", "utf8");
+
+assert.match(migration, /PERFORM private\.require_active_operator\(\)/);
+assert.match(migration, /candidate_exception_count/);
+assert.match(migration, /catalogue_exception_count/);
+assert.match(migration, /REVOKE ALL ON FUNCTION public\.ops_action_overview\(\) FROM PUBLIC, anon, service_role/);
+assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.ops_action_overview\(\) TO authenticated/);
+assert.match(overview, /ops_action_overview/);
+assert.match(overview, /Do these next/);
+assert.match(overview, /Nothing needs your decision right now/);
+assert.match(overview, /Triage discovered-business exceptions/);
+assert.match(overview, /Review existing catalogue exceptions/);
+assert.match(catalogue, /Open this listing and make a listing decision/);
+
+console.log("Ops action queue boundary checks passed.");

--- a/supabase/migrations/20260723015528_ops_action_overview.sql
+++ b/supabase/migrations/20260723015528_ops_action_overview.sql
@@ -1,0 +1,42 @@
+-- Operator-only action counts for the Ops home page. This is deliberately a
+-- summary: detailed candidate, contact and owner data remain in their queues.
+
+CREATE OR REPLACE FUNCTION public.ops_action_overview()
+RETURNS TABLE (
+  candidate_exception_count BIGINT,
+  catalogue_exception_count BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_active_operator();
+
+  RETURN QUERY
+  WITH latest_requalification_run AS (
+    SELECT run.id
+    FROM public.existing_catalogue_requalification_runs AS run
+    WHERE run.status = 'completed'
+    ORDER BY run.completed_at DESC NULLS LAST, run.started_at DESC
+    LIMIT 1
+  )
+  SELECT
+    (SELECT count(*)
+      FROM public.candidate_handoff_records AS record
+      WHERE record.qualification_outcome = 'exception'
+        AND record.exception_status = 'open'),
+    (SELECT count(*)
+      FROM public.existing_catalogue_requalification_records AS record
+      JOIN latest_requalification_run AS run ON run.id = record.run_id
+      WHERE record.qualification_outcome = 'exception'
+        AND record.exception_status = 'open');
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ops_action_overview() FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.ops_action_overview() TO authenticated;
+
+COMMENT ON FUNCTION public.ops_action_overview() IS
+  'Active-operator-only counts for the real private queues that need an action.';

--- a/web/src/app/ops/catalogue-review/page.tsx
+++ b/web/src/app/ops/catalogue-review/page.tsx
@@ -61,6 +61,7 @@ function ExceptionCard({ record }: { record: CatalogueException }) {
       </div>
       <div className="mt-5 rounded-xl bg-amber-50 p-4"><p className="font-bold">Why it needs attention</p><ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">{record.qualification_reasons.map((reason) => <li key={reason}>{reasonLabel(reason)}</li>)}</ul></div>
       {record.duplicate_vendor_id && <p className="mt-4 text-sm"><Link className="font-bold underline" href={`/ops/listings/${record.duplicate_vendor_id}`}>Review the possible matching listing</Link></p>}
+      <p className="mt-4 text-sm"><Link className="font-bold underline" href={`/ops/listings/${record.vendor_id}`}>Open this listing and make a listing decision</Link></p>
       <p className="mt-4 text-xs text-slate-500">Evidence pass completed {formatOpsDateTime(record.run_completed_at)}. This page does not make a listing decision.</p>
     </section>
   );

--- a/web/src/app/ops/page.tsx
+++ b/web/src/app/ops/page.tsx
@@ -36,17 +36,23 @@ type ContactOverview = {
   spam_count: number;
 };
 
+type ActionOverview = {
+  candidate_exception_count: number;
+  catalogue_exception_count: number;
+};
+
 export default async function OpsOverviewPage() {
   const supabase = await createOpsDataClient();
-  const [listingResult, claimResult, profileResult, contactResult, systemResult] = await Promise.all([
+  const [listingResult, claimResult, profileResult, contactResult, systemResult, actionResult] = await Promise.all([
     supabase.rpc("ops_listing_overview"),
     supabase.rpc("ops_claim_overview"),
     supabase.rpc("ops_profile_change_overview"),
     supabase.rpc("ops_contact_overview"),
     supabase.rpc("ops_system_overview"),
+    supabase.rpc("ops_action_overview"),
   ]);
 
-  if (listingResult.error || claimResult.error || profileResult.error || contactResult.error || systemResult.error) {
+  if (listingResult.error || claimResult.error || profileResult.error || contactResult.error || systemResult.error || actionResult.error) {
     throw new Error("The operations overview could not be loaded.");
   }
 
@@ -80,10 +86,25 @@ export default async function OpsOverviewPage() {
     resolved_count: 0,
     spam_count: 0,
   }) as ContactOverview;
+  const actionOverview = (actionResult.data?.[0] ?? {
+    candidate_exception_count: 0,
+    catalogue_exception_count: 0,
+  }) as ActionOverview;
 
   const systemExceptions = Number(systemOverview.failed_count) + Number(systemOverview.degraded_count) + Number(systemOverview.stale_count) + Number(systemOverview.failed_job_count);
   const openContactCount = Number(contactOverview.new_count) + Number(contactOverview.in_progress_count);
-  const attentionCount = Number(listingOverview.review_count) + Number(overview.pending_count) + Number(overview.needs_information_count) + Number(profileOverview.pending_count) + openContactCount + systemExceptions;
+  const claimCount = Number(overview.pending_count) + Number(overview.needs_information_count);
+  const attentionCount = Number(listingOverview.review_count) + claimCount + Number(profileOverview.pending_count) + openContactCount + systemExceptions + Number(actionOverview.candidate_exception_count) + Number(actionOverview.catalogue_exception_count);
+  const actions = [
+    Number(overview.pending_count) > 0 && { count: Number(overview.pending_count), title: "Review ownership claims", detail: "Decide whether each person has provided enough evidence to own the listed business.", href: "/ops/claims?status=pending", button: "Review claims" },
+    Number(overview.needs_information_count) > 0 && { count: Number(overview.needs_information_count), title: "Check claims awaiting more information", detail: "Review new evidence or keep the ownership request waiting. Nothing changes automatically.", href: "/ops/claims?status=needs_information", button: "Open waiting claims" },
+    Number(profileOverview.pending_count) > 0 && { count: Number(profileOverview.pending_count), title: "Review owner profile edits", detail: "Approve or reject proposed public listing changes.", href: "/ops/profile-edits?status=pending", button: "Review profile edits" },
+    Number(contactOverview.new_count) > 0 && { count: Number(contactOverview.new_count), title: "Read new contact requests", detail: "Classify the request and record the next step. These requests do not change a listing by themselves.", href: "/ops/contact?status=new", button: "Open new requests" },
+    Number(listingOverview.review_count) > 0 && { count: Number(listingOverview.review_count), title: "Review listings", detail: "Check the public facts and make the appropriate listing decision.", href: "/ops/listings?status=review", button: "Open listing review" },
+    Number(actionOverview.candidate_exception_count) > 0 && { count: Number(actionOverview.candidate_exception_count), title: "Triage discovered-business exceptions", detail: "Each candidate failed an automatic safety or data-quality rule. Acknowledge a follow-up or dismiss it as unsuitable.", href: "/ops/candidates?status=open", button: "Triage candidates" },
+    Number(actionOverview.catalogue_exception_count) > 0 && { count: Number(actionOverview.catalogue_exception_count), title: "Review existing catalogue exceptions", detail: "These older listings need evidence or a listing decision before they can be treated as fully qualified.", href: "/ops/catalogue-review?status=open", button: "Review catalogue evidence" },
+    systemExceptions > 0 && { count: systemExceptions, title: "Resolve system exceptions", detail: "Check the plain-English status, then follow its recommended next step or ask for technical help.", href: "/ops/system", button: "Open system health" },
+  ].filter(Boolean) as Array<{ count: number; title: string; detail: string; href: string; button: string }>;
 
   return (
     <div className="space-y-8">
@@ -98,62 +119,31 @@ export default async function OpsOverviewPage() {
       <section className="grid gap-5 sm:grid-cols-2 lg:grid-cols-6" aria-label="Operations summary">
         <SummaryCard label="All open work" value={attentionCount} urgent={attentionCount > 0} />
         <SummaryCard label="Listings to review" value={Number(listingOverview.review_count)} />
-        <SummaryCard label="Claims to review" value={Number(overview.pending_count) + Number(overview.needs_information_count)} />
+        <SummaryCard label="Claims to review" value={claimCount} />
         <SummaryCard label="Profile edits" value={Number(profileOverview.pending_count)} />
         <SummaryCard label="Contact requests" value={openContactCount} />
         <SummaryCard label="System exceptions" value={systemExceptions} urgent={systemExceptions > 0} />
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h3 className="text-xl font-bold">Contact requests</h3>
-            <p className="mt-1 text-sm text-slate-600">Review private support, correction, claim-help, and privacy messages.</p>
+      {actions.length === 0 ? (
+        <section className="rounded-2xl border border-emerald-200 bg-emerald-50 p-8 shadow-sm">
+          <h3 className="text-xl font-bold text-emerald-950">Nothing needs your decision right now</h3>
+          <p className="mt-2 text-sm text-emerald-900">The queues are clear and the monitored system checks are normal. You do not need to work through the tabs.</p>
+        </section>
+      ) : (
+        <section aria-label="Next actions" className="space-y-4">
+          <div><h3 className="text-2xl font-black">Do these next</h3><p className="mt-1 text-sm text-slate-600">Only queues with real work appear here. Each button opens the exact items that need your decision.</p></div>
+          <div className="grid gap-4 lg:grid-cols-2">
+            {actions.map((action) => <ActionCard key={`${action.href}-${action.title}`} {...action} />)}
           </div>
-          <Link href="/ops/contact" className="btn btn-primary">Open contact queue</Link>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div><h3 className="text-xl font-bold">System health</h3><p className="mt-1 text-sm text-slate-600">Internal monitoring reports failures and stale checks without changing business state.</p></div>
-          <Link href="/ops/system" className="btn btn-outline">Open system health</Link>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h3 className="text-xl font-bold">Listing review</h3>
-            <p className="mt-1 text-sm text-slate-600">Prepare approved public fields and control publication independently from ownership and payment.</p>
-          </div>
-          <Link href="/ops/listings" className="btn btn-primary">Open listing queue</Link>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h3 className="text-xl font-bold">Owner profile edits</h3>
-            <p className="mt-1 text-sm text-slate-600">Owner proposals stay separate from the public listing until approved.</p>
-          </div>
-          <Link href="/ops/profile-edits" className="btn btn-primary">Open profile edit queue</Link>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h3 className="text-xl font-bold">Claim review</h3>
-            <p className="mt-1 text-sm text-slate-600">
-              Email matching is evidence only. Ownership changes only after an operator decision.
-            </p>
-          </div>
-          <Link href="/ops/claims" className="btn btn-primary">Open claim queue</Link>
-        </div>
-      </section>
+        </section>
+      )}
     </div>
   );
+}
+
+function ActionCard({ count, title, detail, href, button }: { count: number; title: string; detail: string; href: string; button: string }) {
+  return <section className="rounded-2xl border border-amber-300 bg-amber-50 p-6 shadow-sm"><div className="flex items-start gap-4"><p className="rounded-xl bg-amber-200 px-3 py-2 text-2xl font-black tabular-nums text-amber-950">{count}</p><div><h3 className="text-lg font-bold text-slate-950">{title}</h3><p className="mt-2 text-sm text-slate-700">{detail}</p><Link href={href} className="mt-4 inline-flex font-bold underline underline-offset-4">{button} →</Link></div></div></section>;
 }
 
 function SummaryCard({ label, value, urgent = false }: { label: string; value: number; urgent?: boolean }) {


### PR DESCRIPTION
## Outcome
Turns the Ops overview into a real action list rather than a collection of tabs. Only queues with work appear, each with a plain-English instruction and direct link.

## Real data included
- listing review
- pending and waiting claims
- pending profile edits
- new contact requests
- automated candidate exceptions
- existing-catalogue evidence exceptions
- system exceptions

## Safety
A new active-operator-only database function returns counts only; private item data stays in each protected queue.

## Verification
- `npm run check`
- `npm --prefix web run lint` (pre-existing image warnings only)
- `npm --prefix web run build`
- Remote migration `20260723015528` applied and confirmed in migration history.