### PR TITLE
Separate bulk automation evidence from Ops actions

### DIFF
--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -115,6 +115,13 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Boundary:** This does not add a public account-registration screen, a new sender, marketing email, a general inbox, or application-managed authentication messages.
 - **Security rule:** Passwords must be at least 12 characters. The hosted plan does not include Supabase's optional breached-password check; the operator should use a unique password and may enable that provider feature only if the plan changes.
 - **Evidence required:** A real reset from the controlled email account, password sign-in in a separate browser/device, and confirmation that the fallback email-code path remains intact.
+
+### D-013 — Bulk automation evidence is not a manual Ops backlog
+
+- **Date:** 24 July 2026
+- **Decision:** Routine automated exclusions and repeated discovery events remain private audit evidence, not individual operator tasks. A person reviews only records that require genuine judgment, such as a possible duplicate with no separate automatic exclusion.
+- **Decision:** Existing-catalogue evidence gaps are a future batch data-improvement programme. They do not require the operator to process one listing at a time and do not change a listing's visibility by themselves.
+- **Boundary:** A confirmed duplicate, missing customer contact method, or unsupported category is safely held by automation. Automation does not merge uncertain duplicates, publish a held record, assign ownership, or delete evidence.
 - **Verified result:** Home, browse, a populated category route, a representative published profile and the sitemap return successfully. The sitemap contains 1,684 eligible public URLs; canonical and `www` redirect behaviour are correct; released pages no longer carry the holding-page `noindex` directive; `/ops` still redirects unauthenticated visitors to sign-in.
 - **Guardrail:** This authorisation does not enable Stripe, general outbound email, bulk ABN checks, AI publication, raw-candidate publication or automated ownership decisions.
 - **Outstanding evidence:** Complete real authenticated owner/submitter and operator walkthroughs, including the candidate-to-Ops, ABN evidence and owner-media paths. Any failure must be recorded and corrected; it is not a reason to publish additional listings.

--- a/scripts/test-ops-action-queue-boundary.ts
+++ b/scripts/test-ops-action-queue-boundary.ts
@@ -1,20 +1,26 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-const migration = fs.readFileSync("supabase/migrations/20260723015528_ops_action_overview.sql", "utf8");
+const migration = fs.readFileSync("supabase/migrations/20260723155744_distinguish_bulk_automation_from_operator_actions.sql", "utf8");
 const overview = fs.readFileSync("web/src/app/ops/page.tsx", "utf8");
 const catalogue = fs.readFileSync("web/src/app/ops/catalogue-review/page.tsx", "utf8");
+const candidateRoute = fs.readFileSync("web/src/app/api/automation/candidates/route.ts", "utf8");
 
 assert.match(migration, /PERFORM private\.require_active_operator\(\)/);
-assert.match(migration, /candidate_exception_count/);
-assert.match(migration, /catalogue_exception_count/);
+assert.match(migration, /candidate_manual_review_count/);
+assert.match(migration, /catalogue_manual_review_count/);
+assert.match(migration, /SELECT DISTINCT ON \(record\.source_record_key\)/);
+assert.match(migration, /Safely superseded by a resumed candidate handoff attempt/);
 assert.match(migration, /REVOKE ALL ON FUNCTION public\.ops_action_overview\(\) FROM PUBLIC, anon, service_role/);
 assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.ops_action_overview\(\) TO authenticated/);
 assert.match(overview, /ops_action_overview/);
 assert.match(overview, /Do these next/);
 assert.match(overview, /Nothing needs your decision right now/);
-assert.match(overview, /Triage discovered-business exceptions/);
-assert.match(overview, /Review existing catalogue exceptions/);
+assert.match(overview, /Review possible duplicate discoveries/);
+assert.match(overview, /Review possible duplicate listings/);
+assert.match(overview, /Background automation and evidence/);
 assert.match(catalogue, /Open this listing and make a listing decision/);
+assert.match(candidateRoute, /Safely superseded by a resumed candidate handoff attempt/);
+assert.match(candidateRoute, /recovered_by_job_id/);
 
 console.log("Ops action queue boundary checks passed.");

--- a/supabase/migrations/20260723155744_distinguish_bulk_automation_from_operator_actions.sql
+++ b/supabase/migrations/20260723155744_distinguish_bulk_automation_from_operator_actions.sql
@@ -1,0 +1,89 @@
+-- Automation retains every qualification result for audit, but routine
+-- exclusions and repeated discoveries are not operator tasks. Only records
+-- requiring judgment are exposed as action counts.
+
+UPDATE public.automation_jobs AS job
+SET status = 'cancelled',
+    error_message = 'Safely superseded by a resumed candidate handoff attempt.',
+    result = coalesce(job.result, '{}'::jsonb) || jsonb_build_object('recovered', true),
+    completed_at = coalesce(job.completed_at, timezone('utc'::text, now()))
+WHERE job.job_type = 'candidate_handoff'
+  AND job.status = 'failed'
+  AND job.error_message = 'Candidate handoff exceeded the processing window and was safely resumed.';
+
+DROP FUNCTION IF EXISTS public.ops_action_overview();
+
+CREATE OR REPLACE FUNCTION public.ops_action_overview()
+RETURNS TABLE (
+  candidate_manual_review_count BIGINT,
+  catalogue_manual_review_count BIGINT,
+  candidate_background_unique_count BIGINT,
+  candidate_repeated_event_count BIGINT,
+  catalogue_background_count BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_active_operator();
+
+  RETURN QUERY
+  WITH latest_candidate_exception AS (
+    SELECT DISTINCT ON (record.source_record_key)
+      record.source_record_key, record.qualification_reasons
+    FROM public.candidate_handoff_records AS record
+    WHERE record.qualification_outcome = 'exception'
+      AND record.exception_status = 'open'
+    ORDER BY record.source_record_key, record.created_at DESC
+  ),
+  candidate_events AS (
+    SELECT count(*)::BIGINT AS open_event_count
+    FROM public.candidate_handoff_records AS record
+    WHERE record.qualification_outcome = 'exception'
+      AND record.exception_status = 'open'
+  ),
+  latest_requalification_run AS (
+    SELECT run.id
+    FROM public.existing_catalogue_requalification_runs AS run
+    WHERE run.status = 'completed'
+    ORDER BY run.completed_at DESC NULLS LAST, run.started_at DESC
+    LIMIT 1
+  ),
+  catalogue_exception AS (
+    SELECT record.qualification_reasons
+    FROM public.existing_catalogue_requalification_records AS record
+    JOIN latest_requalification_run AS run ON run.id = record.run_id
+    WHERE record.qualification_outcome = 'exception'
+      AND record.exception_status = 'open'
+  ),
+  candidate_counts AS (
+    SELECT
+      count(*) FILTER (WHERE qualification_reasons = '["possible_duplicate"]'::jsonb)::BIGINT AS manual_count,
+      count(*) FILTER (WHERE qualification_reasons <> '["possible_duplicate"]'::jsonb)::BIGINT AS background_count,
+      count(*)::BIGINT AS unique_count
+    FROM latest_candidate_exception
+  ),
+  catalogue_counts AS (
+    SELECT
+      count(*) FILTER (WHERE qualification_reasons = '["possible_duplicate"]'::jsonb)::BIGINT AS manual_count,
+      count(*) FILTER (WHERE qualification_reasons <> '["possible_duplicate"]'::jsonb)::BIGINT AS background_count
+    FROM catalogue_exception
+  )
+  SELECT
+    coalesce(candidate_counts.manual_count, 0),
+    coalesce(catalogue_counts.manual_count, 0),
+    coalesce(candidate_counts.background_count, 0),
+    greatest(coalesce(candidate_events.open_event_count, 0) - coalesce(candidate_counts.unique_count, 0), 0),
+    coalesce(catalogue_counts.background_count, 0)
+  FROM candidate_counts
+  CROSS JOIN candidate_events
+  CROSS JOIN catalogue_counts;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ops_action_overview() FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.ops_action_overview() TO authenticated;
+
+SELECT public.refresh_internal_operations_health();

--- a/web/src/app/api/automation/candidates/route.ts
+++ b/web/src/app/api/automation/candidates/route.ts
@@ -184,6 +184,11 @@ export async function POST(request: NextRequest) {
       const completedAt = new Date().toISOString();
       await admin.from("candidate_handoff_runs").update({ status: "completed", qualified_count: qualifiedCount, exception_count: exceptionCount, completed_at: completedAt }).eq("id", run.id);
       await admin.from("automation_jobs").update({ status: "succeeded", result: { qualified_count: qualifiedCount, exception_count: exceptionCount }, completed_at: completedAt }).eq("id", job.data.id);
+      await admin.from("automation_jobs")
+        .update({ status: "cancelled", error_message: "Safely superseded by a resumed candidate handoff attempt.", result: { recovered: true, recovered_by_job_id: job.data.id }, completed_at: completedAt })
+        .eq("correlation_id", run.correlation_id)
+        .eq("status", "failed")
+        .eq("error_message", "Candidate handoff exceeded the processing window and was safely resumed.");
       await admin.from("integration_health").upsert({ integration_name: "candidate_handoff", status: "healthy", last_success_at: completedAt, metadata: { last_run_id: run.id, qualified_count: qualifiedCount, exception_count: exceptionCount } }, { onConflict: "integration_name" });
       return NextResponse.json({ received: true, idempotent: false, runId: run.id, qualifiedCount, exceptionCount });
     } catch (error) {

--- a/web/src/app/ops/page.tsx
+++ b/web/src/app/ops/page.tsx
@@ -37,8 +37,11 @@ type ContactOverview = {
 };
 
 type ActionOverview = {
-  candidate_exception_count: number;
-  catalogue_exception_count: number;
+  candidate_manual_review_count: number;
+  catalogue_manual_review_count: number;
+  candidate_background_unique_count: number;
+  candidate_repeated_event_count: number;
+  catalogue_background_count: number;
 };
 
 export default async function OpsOverviewPage() {
@@ -87,22 +90,25 @@ export default async function OpsOverviewPage() {
     spam_count: 0,
   }) as ContactOverview;
   const actionOverview = (actionResult.data?.[0] ?? {
-    candidate_exception_count: 0,
-    catalogue_exception_count: 0,
+    candidate_manual_review_count: 0,
+    catalogue_manual_review_count: 0,
+    candidate_background_unique_count: 0,
+    candidate_repeated_event_count: 0,
+    catalogue_background_count: 0,
   }) as ActionOverview;
 
   const systemExceptions = Number(systemOverview.failed_count) + Number(systemOverview.degraded_count) + Number(systemOverview.stale_count) + Number(systemOverview.failed_job_count);
   const openContactCount = Number(contactOverview.new_count) + Number(contactOverview.in_progress_count);
   const claimCount = Number(overview.pending_count) + Number(overview.needs_information_count);
-  const attentionCount = Number(listingOverview.review_count) + claimCount + Number(profileOverview.pending_count) + openContactCount + systemExceptions + Number(actionOverview.candidate_exception_count) + Number(actionOverview.catalogue_exception_count);
+  const attentionCount = Number(listingOverview.review_count) + claimCount + Number(profileOverview.pending_count) + openContactCount + systemExceptions + Number(actionOverview.candidate_manual_review_count) + Number(actionOverview.catalogue_manual_review_count);
   const actions = [
     Number(overview.pending_count) > 0 && { count: Number(overview.pending_count), title: "Review ownership claims", detail: "Decide whether each person has provided enough evidence to own the listed business.", href: "/ops/claims?status=pending", button: "Review claims" },
     Number(overview.needs_information_count) > 0 && { count: Number(overview.needs_information_count), title: "Check claims awaiting more information", detail: "Review new evidence or keep the ownership request waiting. Nothing changes automatically.", href: "/ops/claims?status=needs_information", button: "Open waiting claims" },
     Number(profileOverview.pending_count) > 0 && { count: Number(profileOverview.pending_count), title: "Review owner profile edits", detail: "Approve or reject proposed public listing changes.", href: "/ops/profile-edits?status=pending", button: "Review profile edits" },
     Number(contactOverview.new_count) > 0 && { count: Number(contactOverview.new_count), title: "Read new contact requests", detail: "Classify the request and record the next step. These requests do not change a listing by themselves.", href: "/ops/contact?status=new", button: "Open new requests" },
     Number(listingOverview.review_count) > 0 && { count: Number(listingOverview.review_count), title: "Review listings", detail: "Check the public facts and make the appropriate listing decision.", href: "/ops/listings?status=review", button: "Open listing review" },
-    Number(actionOverview.candidate_exception_count) > 0 && { count: Number(actionOverview.candidate_exception_count), title: "Triage discovered-business exceptions", detail: "Each candidate failed an automatic safety or data-quality rule. Acknowledge a follow-up or dismiss it as unsuitable.", href: "/ops/candidates?status=open", button: "Triage candidates" },
-    Number(actionOverview.catalogue_exception_count) > 0 && { count: Number(actionOverview.catalogue_exception_count), title: "Review existing catalogue exceptions", detail: "These older listings need evidence or a listing decision before they can be treated as fully qualified.", href: "/ops/catalogue-review?status=open", button: "Review catalogue evidence" },
+    Number(actionOverview.candidate_manual_review_count) > 0 && { count: Number(actionOverview.candidate_manual_review_count), title: "Review possible duplicate discoveries", detail: "These are the only new discoveries without another automatic exclusion. Check whether each is already in the directory.", href: "/ops/candidates?status=open", button: "Review possible duplicates" },
+    Number(actionOverview.catalogue_manual_review_count) > 0 && { count: Number(actionOverview.catalogue_manual_review_count), title: "Review possible duplicate listings", detail: "These older listings may duplicate another listing and need a human merge or keep decision.", href: "/ops/catalogue-review?status=open", button: "Review possible duplicates" },
     systemExceptions > 0 && { count: systemExceptions, title: "Resolve system exceptions", detail: "Check the plain-English status, then follow its recommended next step or ask for technical help.", href: "/ops/system", button: "Open system health" },
   ].filter(Boolean) as Array<{ count: number; title: string; detail: string; href: string; button: string }>;
 
@@ -135,6 +141,17 @@ export default async function OpsOverviewPage() {
           <div><h3 className="text-2xl font-black">Do these next</h3><p className="mt-1 text-sm text-slate-600">Only queues with real work appear here. Each button opens the exact items that need your decision.</p></div>
           <div className="grid gap-4 lg:grid-cols-2">
             {actions.map((action) => <ActionCard key={`${action.href}-${action.title}`} {...action} />)}
+          </div>
+        </section>
+      )}
+
+      {(Number(actionOverview.candidate_background_unique_count) > 0 || Number(actionOverview.catalogue_background_count) > 0) && (
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 className="text-xl font-bold">Background automation and evidence</h3>
+          <p className="mt-1 text-sm text-slate-600">These are retained for audit and future batch improvement. They are not a manual to-do list and do not affect publication by themselves.</p>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            {Number(actionOverview.candidate_background_unique_count) > 0 && <article className="rounded-xl bg-slate-50 p-4"><p className="font-bold">{Number(actionOverview.candidate_background_unique_count).toLocaleString()} discoveries safely held</p><p className="mt-1 text-sm text-slate-600">They already have an automatic exclusion such as no customer contact method, a confirmed duplicate, or an unsupported category.</p>{Number(actionOverview.candidate_repeated_event_count) > 0 && <p className="mt-2 text-xs text-slate-500">{Number(actionOverview.candidate_repeated_event_count).toLocaleString()} repeat events were collapsed into this summary.</p>}</article>}
+            {Number(actionOverview.catalogue_background_count) > 0 && <article className="rounded-xl bg-slate-50 p-4"><p className="font-bold">{Number(actionOverview.catalogue_background_count).toLocaleString()} older listings need later evidence improvement</p><p className="mt-1 text-sm text-slate-600">Most lack a contact method, have an unsupported category, or need source evidence. This needs a future bulk data-improvement pass, not individual manual review.</p></article>}
           </div>
         </section>
       )}


### PR DESCRIPTION
## Outcome
Stops treating historical automated exclusions as thousands of manual jobs. Ops now presents only genuine human decisions and reports bulk evidence separately.

## Verified live outcome
- 1 new possible duplicate for review
- 34 legacy possible duplicates for review
- 1 listing review
- 1,543 automatically held discoveries and 617 repeat events retained as background evidence
- 982 legacy evidence gaps retained for a future bulk-improvement pass
- 11 safely resumed candidate jobs marked resolved; automation health now healthy

## Safety
No listings, ownership, claims, or public visibility changed. Automation still never merges uncertain duplicates automatically.

## Verification
- Remote migration `20260723155744` applied
- Direct database count verification
- `npm run check`
- Production build and lint completed earlier in this branch context.