### PR TITLE
Recompose protected Ops workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "submitter-owner-identity:test": "tsx scripts/test-submitter-owner-identity-boundary.ts",
     "owner-submitted-business-candidate:test": "tsx scripts/test-owner-submitted-business-candidate-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
-    "ops-action-queue:test": "tsx scripts/test-ops-action-queue-boundary.ts",
+    "ops-action-queue:test": "tsx scripts/test-ops-action-queue-boundary.ts && npm run ops-workspace:test",
+    "ops-workspace:test": "tsx scripts/test-ops-workspace-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },
   "devDependencies": {

--- a/scripts/test-ops-action-queue-boundary.ts
+++ b/scripts/test-ops-action-queue-boundary.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const migration = fs.readFileSync("supabase/migrations/20260723155744_distinguish_bulk_automation_from_operator_actions.sql", "utf8");
-const overview = fs.readFileSync("web/src/app/ops/page.tsx", "utf8");
+const work = fs.readFileSync("web/src/lib/ops/work.ts", "utf8");
 const catalogue = fs.readFileSync("web/src/app/ops/catalogue-review/page.tsx", "utf8");
 const candidateRoute = fs.readFileSync("web/src/app/api/automation/candidates/route.ts", "utf8");
 
@@ -13,12 +13,10 @@ assert.match(migration, /SELECT DISTINCT ON \(record\.source_record_key\)/);
 assert.match(migration, /Safely superseded by a resumed candidate handoff attempt/);
 assert.match(migration, /REVOKE ALL ON FUNCTION public\.ops_action_overview\(\) FROM PUBLIC, anon, service_role/);
 assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.ops_action_overview\(\) TO authenticated/);
-assert.match(overview, /ops_action_overview/);
-assert.match(overview, /Do these next/);
-assert.match(overview, /Nothing needs your decision right now/);
-assert.match(overview, /Review possible duplicate discoveries/);
-assert.match(overview, /Review possible duplicate listings/);
-assert.match(overview, /Background automation and evidence/);
+assert.match(work, /qualification_reasons\.length === 1/);
+assert.match(work, /possible_duplicate/);
+assert.match(work, /not a Business/);
+assert.match(work, /later_review/);
 assert.match(catalogue, /Open this listing and make a listing decision/);
 assert.match(candidateRoute, /Safely superseded by a resumed candidate handoff attempt/);
 assert.match(candidateRoute, /recovered_by_job_id/);

--- a/scripts/test-ops-workspace-boundary.ts
+++ b/scripts/test-ops-workspace-boundary.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const work = fs.readFileSync("web/src/lib/ops/work.ts", "utf8");
+const layout = fs.readFileSync("web/src/app/ops/layout.tsx", "utf8");
+const page = fs.readFileSync("web/src/app/ops/page.tsx", "utf8");
+const businesses = fs.readFileSync("web/src/app/ops/listings/page.tsx", "utf8");
+const system = fs.readFileSync("web/src/app/ops/system/page.tsx", "utf8");
+const registerMigration = fs.readFileSync("supabase/migrations/20260725120000_alphabetical_ops_business_register.sql", "utf8");
+
+assert.match(layout, /Work/);
+assert.match(layout, /Businesses/);
+assert.match(layout, /System/);
+assert.doesNotMatch(layout, />Candidates</);
+assert.doesNotMatch(layout, />Catalogue review</);
+assert.match(page, /All open work/);
+assert.match(page, /Open work list/);
+assert.match(page, /Act now/);
+assert.match(page, /Needs a decision/);
+assert.match(page, /Later review/);
+assert.match(work, /possible_duplicate/);
+assert.match(work, /qualification_reasons\.length === 1/);
+assert.match(work, /"act_now"/);
+assert.match(work, /"needs_decision"/);
+assert.match(work, /"later_review"/);
+assert.match(page, /ops_list_candidate_handoff_records/);
+assert.match(page, /ops_list_existing_catalogue_requalification_exceptions/);
+assert.match(businesses, /Business register/);
+assert.match(businesses, /"all"/);
+assert.doesNotMatch(businesses, /Tier: \{listing\.tier\}/);
+assert.match(registerMigration, /PERFORM private\.require_active_operator\(\)/);
+assert.match(registerMigration, /CASE WHEN v_status = 'all' THEN vendor\.business_name END ASC/);
+assert.match(system, /Commercial readiness/);
+assert.match(system, /Billing is off/);
+for (const forbidden of ["work_items", "realtime", "Stripe checkout", "subscription", "invoice", "ABN request"]) {
+  assert(!page.includes(forbidden) && !work.includes(forbidden), `Ops Work must not introduce ${forbidden}`);
+}
+console.log("Ops workspace boundary checks passed.");

--- a/supabase/migrations/20260725120000_alphabetical_ops_business_register.sql
+++ b/supabase/migrations/20260725120000_alphabetical_ops_business_register.sql
@@ -1,0 +1,70 @@
+-- The protected Business register is an operator browse surface, not a review
+-- queue. Keep review views prioritised, but make the explicit `all` view a
+-- stable alphabetical register without adding tables, policies or new reads.
+
+CREATE OR REPLACE FUNCTION public.ops_list_listings(
+  p_status TEXT DEFAULT 'review',
+  p_query TEXT DEFAULT NULL,
+  p_vendor_id UUID DEFAULT NULL,
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+  vendor_id UUID, business_name TEXT, category_slug TEXT, suburb_slug TEXT,
+  street_address TEXT, contact_email TEXT, phone TEXT, website TEXT, description TEXT,
+  listing_status TEXT, listing_source TEXT, ownership_status TEXT, is_published BOOLEAN,
+  is_claimed BOOLEAN, tier TEXT, moderation_reason TEXT, reviewed_at TIMESTAMPTZ,
+  published_at TIMESTAMPTZ, rejected_at TIMESTAMPTZ, unpublished_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ, active_draft_id UUID,
+  draft_base_values JSONB, draft_values JSONB
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_status TEXT := lower(trim(coalesce(p_status, 'review')));
+  v_query TEXT := nullif(trim(coalesce(p_query, '')), '');
+BEGIN
+  PERFORM private.require_active_operator();
+  IF v_status NOT IN ('review', 'unclassified', 'draft', 'pending_review', 'published', 'rejected', 'unpublished', 'all') THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invalid listing status filter.';
+  END IF;
+  IF p_limit < 1 OR p_limit > 200 OR p_offset < 0 OR length(coalesce(v_query, '')) > 200 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invalid listing search or pagination values.';
+  END IF;
+
+  RETURN QUERY
+  SELECT vendor.id, vendor.business_name, vendor.category_slug, vendor.suburb_slug,
+    vendor.street_address, vendor.contact_email, vendor.phone, vendor.website, vendor.description,
+    vendor.listing_status, vendor.listing_source, vendor.ownership_status,
+    vendor.is_published, vendor.is_claimed, vendor.tier, vendor.moderation_reason,
+    vendor.reviewed_at, vendor.published_at, vendor.rejected_at, vendor.unpublished_at,
+    vendor.created_at, vendor.updated_at, active_draft.id, active_draft.base_values, active_draft.draft_values
+  FROM public.vendors AS vendor
+  LEFT JOIN LATERAL (
+    SELECT draft.id, draft.base_values, draft.draft_values
+    FROM public.operator_listing_drafts AS draft
+    WHERE draft.vendor_id = vendor.id AND draft.draft_status = 'active'
+    LIMIT 1
+  ) AS active_draft ON true
+  WHERE (p_vendor_id IS NULL OR vendor.id = p_vendor_id)
+    AND (v_query IS NULL OR vendor.business_name ILIKE '%' || replace(replace(replace(v_query, '\\', '\\\\'), '%', '\\%'), '_', '\\_') || '%' ESCAPE '\\')
+    AND (
+      v_status = 'all'
+      OR (v_status = 'review' AND (vendor.listing_status IS NULL OR vendor.listing_status IN ('draft', 'pending_review')))
+      OR (v_status = 'unclassified' AND vendor.listing_status IS NULL)
+      OR vendor.listing_status = v_status
+    )
+  ORDER BY
+    CASE WHEN v_status = 'all' THEN 0 WHEN vendor.listing_status IS NULL OR vendor.listing_status IN ('draft', 'pending_review') THEN 0 ELSE 1 END,
+    CASE WHEN v_status = 'all' THEN vendor.business_name END ASC NULLS LAST,
+    CASE WHEN v_status <> 'all' THEN vendor.updated_at END DESC NULLS LAST,
+    vendor.business_name
+  LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+COMMENT ON FUNCTION public.ops_list_listings(TEXT, TEXT, UUID, INTEGER, INTEGER) IS
+  'Operator-only listing reader. The all-businesses register is alphabetical; lifecycle review views preserve their existing review-first ordering.';

--- a/web/src/app/ops/layout.tsx
+++ b/web/src/app/ops/layout.tsx
@@ -20,20 +20,12 @@ export default async function OpsLayout({ children }: { children: React.ReactNod
             <p className="text-xs font-bold uppercase tracking-[0.22em] text-slate-400">SuburbMates</p>
             <h1 className="text-xl font-black">Operations</h1>
           </div>
-          <nav aria-label="Operations" className="flex items-center gap-5 text-sm font-semibold">
-            <Link href="/ops">Overview</Link>
-            <Link href="/ops/listings">Listings</Link>
-            <Link href="/ops/candidates">Candidates</Link>
-            <Link href="/ops/catalogue-review">Catalogue review</Link>
-            <Link href="/ops/claims">Claims</Link>
-            <Link href="/ops/profile-edits">Profile edits</Link>
-            <Link href="/ops/contact">Contact</Link>
+          <nav aria-label="Operations" className="flex items-center gap-4 text-sm font-semibold">
+            <Link href="/ops">Work</Link>
+            <Link href="/ops/listings?status=all">Businesses</Link>
             <Link href="/ops/system">System</Link>
-            <form action="/auth/signout" method="post">
-              <button className="underline decoration-slate-500 underline-offset-4">Sign out</button>
-            </form>
           </nav>
-          <p className="w-full text-xs text-slate-400 sm:w-auto">Signed in as {user.email ?? "operator"}</p>
+          <div className="flex w-full items-center gap-3 text-xs text-slate-400 sm:w-auto"><span>Signed in as {user.email ?? "operator"}</span><form action="/auth/signout" method="post"><button className="underline decoration-slate-500 underline-offset-4">Sign out</button></form></div>
         </div>
       </header>
       <main className="mx-auto max-w-7xl px-6 py-10">{children}</main>

--- a/web/src/app/ops/listings/page.tsx
+++ b/web/src/app/ops/listings/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { QueuePagination } from "@/components/ops/QueuePagination";
 import { createOpsDataClient } from "@/lib/ops/auth";
 
-const statuses = ["review", "unclassified", "draft", "pending_review", "published", "rejected", "unpublished"] as const;
+const statuses = ["all", "review", "unclassified", "draft", "pending_review", "published", "rejected", "unpublished"] as const;
 type Status = (typeof statuses)[number];
 
 type OpsListing = {
@@ -20,7 +20,7 @@ type OpsListing = {
 
 export default async function OpsListingsPage({ searchParams }: { searchParams: Promise<{ status?: string; q?: string; page?: string }> }) {
   const params = await searchParams;
-  const status = statuses.includes(params.status as Status) ? (params.status as Status) : "review";
+  const status = statuses.includes(params.status as Status) ? (params.status as Status) : "all";
   const q = typeof params.q === "string" ? params.q.slice(0, 200) : "";
   const page = pageNumber(params.page);
   const supabase = await createOpsDataClient();
@@ -40,9 +40,9 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
   return (
     <div className="space-y-7">
       <div>
-        <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">Listings</p>
-        <h2 className="mt-2 text-4xl font-black tracking-tight">Listing review queue</h2>
-        <p className="mt-3 max-w-3xl text-slate-600">Review source facts, prepare approved public fields and control publication without changing ownership, ABN, payment or tier state.</p>
+        <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">Businesses</p>
+        <h2 className="mt-2 text-4xl font-black tracking-tight">Business register</h2>
+        <p className="mt-3 max-w-3xl text-slate-600">Search real directory records and open one business to see its authorised evidence, requests and safe actions. Private candidate records are not businesses.</p>
       </div>
 
       <form className="flex max-w-xl gap-3" action="/ops/listings">
@@ -72,7 +72,7 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
                     {listing.active_draft_id && <Badge>Draft saved</Badge>}
                   </div>
                   <p className="mt-2 text-sm text-slate-600">{listing.category_slug ?? "No category"} · {listing.suburb_slug ?? "No location"}</p>
-                  <p className="mt-1 text-xs text-slate-500">Source: {listing.listing_source ?? "Unrecorded"} · Ownership: {statusLabel(listing.ownership_status)} · Tier: {listing.tier}</p>
+                  <p className="mt-1 text-xs text-slate-500">Source: {listing.listing_source ?? "Unrecorded"} · Ownership: {statusLabel(listing.ownership_status)}</p>
                 </div>
                 <Link href={`/ops/listings/${listing.vendor_id}`} className="font-bold underline underline-offset-4">Review</Link>
               </div>
@@ -90,6 +90,7 @@ function Badge({ children }: { children: React.ReactNode }) {
 }
 
 function statusLabel(value: string) {
+  if (value === "all") return "All businesses";
   if (value === "review") return "Attention";
   if (value === "unclassified") return "Needs classification";
   return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());

--- a/web/src/app/ops/loading.tsx
+++ b/web/src/app/ops/loading.tsx
@@ -1,0 +1,3 @@
+export default function OpsLoading() {
+  return <div className="animate-pulse space-y-5" role="status" aria-live="polite"><p className="text-sm font-semibold text-slate-600">Loading Operations…</p><div className="h-24 rounded-3xl bg-slate-200" /><div className="h-32 rounded-3xl bg-slate-200" /><span className="sr-only">Loading Operations</span></div>;
+}

--- a/web/src/app/ops/page.tsx
+++ b/web/src/app/ops/page.tsx
@@ -1,173 +1,67 @@
 import Link from "next/link";
+import { formatOpsDate } from "@/lib/ops/date";
 import { createOpsDataClient } from "@/lib/ops/auth";
+import { composeWorkItems, workPriorityOrder, type WorkItem, type WorkPriority, type WorkSource } from "@/lib/ops/work";
 
-type ClaimOverview = {
-  pending_count: number;
-  needs_information_count: number;
-  approved_count: number;
-  rejected_count: number;
-  revoked_count: number;
-};
+const pageSize = 200;
 
-type ProfileChangeOverview = {
-  pending_count: number;
-  approved_count: number;
-  rejected_count: number;
-};
-
-type ListingOverview = {
-  review_count: number;
-  published_count: number;
-  rejected_count: number;
-  unpublished_count: number;
-};
-
-type SystemOverview = {
-  failed_count: number;
-  degraded_count: number;
-  stale_count: number;
-  failed_job_count: number;
-};
-
-type ContactOverview = {
-  new_count: number;
-  in_progress_count: number;
-  resolved_count: number;
-  spam_count: number;
-};
-
-type ActionOverview = {
-  candidate_manual_review_count: number;
-  catalogue_manual_review_count: number;
-  candidate_background_unique_count: number;
-  candidate_repeated_event_count: number;
-  catalogue_background_count: number;
-};
-
-export default async function OpsOverviewPage() {
+export default async function OpsWorkPage() {
   const supabase = await createOpsDataClient();
-  const [listingResult, claimResult, profileResult, contactResult, systemResult, actionResult] = await Promise.all([
-    supabase.rpc("ops_listing_overview"),
-    supabase.rpc("ops_claim_overview"),
-    supabase.rpc("ops_profile_change_overview"),
-    supabase.rpc("ops_contact_overview"),
-    supabase.rpc("ops_system_overview"),
-    supabase.rpc("ops_action_overview"),
+  const [listings, pendingClaims, waitingClaims, profiles, newContacts, activeContacts, candidates, catalogue, health, jobs] = await Promise.all([
+    loadAll((offset) => supabase.rpc("ops_list_listings", { p_status: "review", p_query: null, p_vendor_id: null, p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_claim_requests", { p_status: "pending", p_claim_request_id: null, p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_claim_requests", { p_status: "needs_information", p_claim_request_id: null, p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_profile_changes", { p_status: "pending", p_change_request_id: null, p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_contact_requests", { p_status: "new", p_contact_request_id: null, p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_contact_requests", { p_status: "in_progress", p_contact_request_id: null, p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_candidate_handoff_records", { p_status: "open", p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_existing_catalogue_requalification_exceptions", { p_status: "open", p_limit: pageSize, p_offset: offset })),
+    onePage(() => supabase.rpc("ops_list_integration_health")),
+    onePage(() => supabase.rpc("ops_list_automation_jobs", { p_limit: pageSize })),
   ]);
 
-  if (listingResult.error || claimResult.error || profileResult.error || contactResult.error || systemResult.error || actionResult.error) {
-    throw new Error("The operations overview could not be loaded.");
+  const items = composeWorkItems({
+    listings: listings as WorkSource["listings"],
+    claims: [...pendingClaims, ...waitingClaims] as WorkSource["claims"],
+    profiles: profiles as WorkSource["profiles"],
+    contacts: [...newContacts, ...activeContacts] as WorkSource["contacts"],
+    candidates: candidates as WorkSource["candidates"],
+    catalogue: catalogue as WorkSource["catalogue"],
+    health: health as WorkSource["health"],
+    jobs: jobs as WorkSource["jobs"],
+  });
+  const grouped = new Map(workPriorityOrder.map((priority) => [priority, items.filter((item) => item.priority === priority)]));
+
+  return <div className="space-y-8">
+    <header className="max-w-3xl"><p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">Work</p><h2 className="mt-2 text-4xl font-black tracking-tight">What needs your judgment?</h2><p className="mt-3 text-slate-600">Only real decisions appear here. Background automation is kept out of your way.</p></header>
+    <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"><div className="flex flex-wrap items-center justify-between gap-5"><div><p className="text-sm font-semibold text-slate-600">All open work</p><p className="mt-1 text-4xl font-black tabular-nums">{items.length}</p></div><Link href="#all-work" className="rounded-full bg-slate-950 px-5 py-3 text-sm font-bold text-white">Open work list</Link></div></section>
+    {items.length === 0 ? <section className="rounded-3xl border border-emerald-200 bg-emerald-50 p-7"><h3 className="text-xl font-bold text-emerald-950">Nothing needs your decision right now</h3><p className="mt-2 text-sm text-emerald-900">The monitored queues are clear. Background evidence remains available in System if it is ever needed.</p></section> : <section id="all-work" className="space-y-8" aria-label="All open work">{workPriorityOrder.map((priority) => <WorkGroup key={priority} priority={priority} items={grouped.get(priority) ?? []} />)}</section>}
+    <section className="rounded-2xl border border-slate-200 bg-slate-50 p-5 text-sm text-slate-600"><p className="font-semibold text-slate-800">Quiet background context</p><p className="mt-1">Automatic exclusions, repeat discoveries and historic evidence gaps are retained for audit and future batch improvement. They are not work for you to process one by one.</p><Link href="/ops/system" className="mt-3 inline-block font-bold underline underline-offset-4">Open System</Link></section>
+  </div>;
+}
+
+function WorkGroup({ priority, items }: { priority: WorkPriority; items: WorkItem[] }) {
+  const copy: Record<WorkPriority, [string, string]> = { act_now: ["Act now", "A real technical, safety, privacy or security issue needs attention."], needs_decision: ["Needs a decision", "Open an item to see its evidence and the safe choices already available."], later_review: ["Later review", "Older possible duplicates are worth reviewing, but they are not urgent."] };
+  const [title, detail] = copy[priority];
+  if (!items.length) return null;
+  return <section><div className="mb-3 flex items-baseline justify-between gap-4"><div><h3 className="text-2xl font-black tracking-tight">{title}</h3><p className="mt-1 text-sm text-slate-600">{detail}</p></div><span className="rounded-full bg-slate-200 px-3 py-1 text-sm font-bold tabular-nums">{items.length}</span></div><div className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">{items.map((item) => <WorkRow key={item.id} item={item} />)}</div></section>;
+}
+
+function WorkRow({ item }: { item: WorkItem }) {
+  return <Link href={item.href} className="group flex min-h-28 items-center justify-between gap-4 border-b border-slate-100 px-5 py-4 last:border-b-0 focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-[-4px] focus-visible:outline-indigo-600 hover:bg-slate-50"><div className="min-w-0"><p className="font-bold text-slate-950">{item.title}</p><p className="mt-1 text-sm font-semibold text-slate-700">{item.decision}</p><p className="mt-1 text-sm text-slate-600">{item.evidence}</p>{item.createdAt && <p className="mt-2 text-xs text-slate-500">Recorded {formatOpsDate(item.createdAt)}</p>}</div><span aria-hidden="true" className="text-xl font-bold text-slate-400 transition-transform motion-reduce:transition-none group-hover:translate-x-0.5">›</span></Link>;
+}
+
+async function onePage<T>(request: () => PromiseLike<{ data: T[] | null; error: { message: string } | null }>) {
+  const result = await request();
+  if (result.error) throw new Error("The Work list could not be loaded.");
+  return result.data ?? [];
+}
+
+async function loadAll<T>(request: (offset: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>) {
+  const results: T[] = [];
+  for (let offset = 0; ; offset += pageSize) {
+    const page = await onePage(() => request(offset));
+    results.push(...page);
+    if (page.length < pageSize) return results;
   }
-
-  const overview = (claimResult.data?.[0] ?? {
-    pending_count: 0,
-    needs_information_count: 0,
-    approved_count: 0,
-    rejected_count: 0,
-    revoked_count: 0,
-  }) as ClaimOverview;
-  const profileOverview = (profileResult.data?.[0] ?? {
-    pending_count: 0,
-    approved_count: 0,
-    rejected_count: 0,
-  }) as ProfileChangeOverview;
-  const listingOverview = (listingResult.data?.[0] ?? {
-    review_count: 0,
-    published_count: 0,
-    rejected_count: 0,
-    unpublished_count: 0,
-  }) as ListingOverview;
-  const systemOverview = (systemResult.data?.[0] ?? {
-    failed_count: 0,
-    degraded_count: 0,
-    stale_count: 0,
-    failed_job_count: 0,
-  }) as SystemOverview;
-  const contactOverview = (contactResult.data?.[0] ?? {
-    new_count: 0,
-    in_progress_count: 0,
-    resolved_count: 0,
-    spam_count: 0,
-  }) as ContactOverview;
-  const actionOverview = (actionResult.data?.[0] ?? {
-    candidate_manual_review_count: 0,
-    catalogue_manual_review_count: 0,
-    candidate_background_unique_count: 0,
-    candidate_repeated_event_count: 0,
-    catalogue_background_count: 0,
-  }) as ActionOverview;
-
-  const systemExceptions = Number(systemOverview.failed_count) + Number(systemOverview.degraded_count) + Number(systemOverview.stale_count) + Number(systemOverview.failed_job_count);
-  const openContactCount = Number(contactOverview.new_count) + Number(contactOverview.in_progress_count);
-  const claimCount = Number(overview.pending_count) + Number(overview.needs_information_count);
-  const attentionCount = Number(listingOverview.review_count) + claimCount + Number(profileOverview.pending_count) + openContactCount + systemExceptions + Number(actionOverview.candidate_manual_review_count) + Number(actionOverview.catalogue_manual_review_count);
-  const actions = [
-    Number(overview.pending_count) > 0 && { count: Number(overview.pending_count), title: "Review ownership claims", detail: "Decide whether each person has provided enough evidence to own the listed business.", href: "/ops/claims?status=pending", button: "Review claims" },
-    Number(overview.needs_information_count) > 0 && { count: Number(overview.needs_information_count), title: "Check claims awaiting more information", detail: "Review new evidence or keep the ownership request waiting. Nothing changes automatically.", href: "/ops/claims?status=needs_information", button: "Open waiting claims" },
-    Number(profileOverview.pending_count) > 0 && { count: Number(profileOverview.pending_count), title: "Review owner profile edits", detail: "Approve or reject proposed public listing changes.", href: "/ops/profile-edits?status=pending", button: "Review profile edits" },
-    Number(contactOverview.new_count) > 0 && { count: Number(contactOverview.new_count), title: "Read new contact requests", detail: "Classify the request and record the next step. These requests do not change a listing by themselves.", href: "/ops/contact?status=new", button: "Open new requests" },
-    Number(listingOverview.review_count) > 0 && { count: Number(listingOverview.review_count), title: "Review listings", detail: "Check the public facts and make the appropriate listing decision.", href: "/ops/listings?status=review", button: "Open listing review" },
-    Number(actionOverview.candidate_manual_review_count) > 0 && { count: Number(actionOverview.candidate_manual_review_count), title: "Review possible duplicate discoveries", detail: "These are the only new discoveries without another automatic exclusion. Check whether each is already in the directory.", href: "/ops/candidates?status=open", button: "Review possible duplicates" },
-    Number(actionOverview.catalogue_manual_review_count) > 0 && { count: Number(actionOverview.catalogue_manual_review_count), title: "Review possible duplicate listings", detail: "These older listings may duplicate another listing and need a human merge or keep decision.", href: "/ops/catalogue-review?status=open", button: "Review possible duplicates" },
-    systemExceptions > 0 && { count: systemExceptions, title: "Resolve system exceptions", detail: "Check the plain-English status, then follow its recommended next step or ask for technical help.", href: "/ops/system", button: "Open system health" },
-  ].filter(Boolean) as Array<{ count: number; title: string; detail: string; href: string; button: string }>;
-
-  return (
-    <div className="space-y-8">
-      <div>
-        <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">Overview</p>
-        <h2 className="mt-2 text-4xl font-black tracking-tight">Items needing attention</h2>
-        <p className="mt-3 max-w-2xl text-slate-600">
-          Routine review stays here. External dashboards are only needed for account setup or exceptional incidents.
-        </p>
-      </div>
-
-      <section className="grid gap-5 sm:grid-cols-2 lg:grid-cols-6" aria-label="Operations summary">
-        <SummaryCard label="All open work" value={attentionCount} urgent={attentionCount > 0} />
-        <SummaryCard label="Listings to review" value={Number(listingOverview.review_count)} />
-        <SummaryCard label="Claims to review" value={claimCount} />
-        <SummaryCard label="Profile edits" value={Number(profileOverview.pending_count)} />
-        <SummaryCard label="Contact requests" value={openContactCount} />
-        <SummaryCard label="System exceptions" value={systemExceptions} urgent={systemExceptions > 0} />
-      </section>
-
-      {actions.length === 0 ? (
-        <section className="rounded-2xl border border-emerald-200 bg-emerald-50 p-8 shadow-sm">
-          <h3 className="text-xl font-bold text-emerald-950">Nothing needs your decision right now</h3>
-          <p className="mt-2 text-sm text-emerald-900">The queues are clear and the monitored system checks are normal. You do not need to work through the tabs.</p>
-        </section>
-      ) : (
-        <section aria-label="Next actions" className="space-y-4">
-          <div><h3 className="text-2xl font-black">Do these next</h3><p className="mt-1 text-sm text-slate-600">Only queues with real work appear here. Each button opens the exact items that need your decision.</p></div>
-          <div className="grid gap-4 lg:grid-cols-2">
-            {actions.map((action) => <ActionCard key={`${action.href}-${action.title}`} {...action} />)}
-          </div>
-        </section>
-      )}
-
-      {(Number(actionOverview.candidate_background_unique_count) > 0 || Number(actionOverview.catalogue_background_count) > 0) && (
-        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 className="text-xl font-bold">Background automation and evidence</h3>
-          <p className="mt-1 text-sm text-slate-600">These are retained for audit and future batch improvement. They are not a manual to-do list and do not affect publication by themselves.</p>
-          <div className="mt-4 grid gap-4 md:grid-cols-2">
-            {Number(actionOverview.candidate_background_unique_count) > 0 && <article className="rounded-xl bg-slate-50 p-4"><p className="font-bold">{Number(actionOverview.candidate_background_unique_count).toLocaleString()} discoveries safely held</p><p className="mt-1 text-sm text-slate-600">They already have an automatic exclusion such as no customer contact method, a confirmed duplicate, or an unsupported category.</p>{Number(actionOverview.candidate_repeated_event_count) > 0 && <p className="mt-2 text-xs text-slate-500">{Number(actionOverview.candidate_repeated_event_count).toLocaleString()} repeat events were collapsed into this summary.</p>}</article>}
-            {Number(actionOverview.catalogue_background_count) > 0 && <article className="rounded-xl bg-slate-50 p-4"><p className="font-bold">{Number(actionOverview.catalogue_background_count).toLocaleString()} older listings need later evidence improvement</p><p className="mt-1 text-sm text-slate-600">Most lack a contact method, have an unsupported category, or need source evidence. This needs a future bulk data-improvement pass, not individual manual review.</p></article>}
-          </div>
-        </section>
-      )}
-    </div>
-  );
-}
-
-function ActionCard({ count, title, detail, href, button }: { count: number; title: string; detail: string; href: string; button: string }) {
-  return <section className="rounded-2xl border border-amber-300 bg-amber-50 p-6 shadow-sm"><div className="flex items-start gap-4"><p className="rounded-xl bg-amber-200 px-3 py-2 text-2xl font-black tabular-nums text-amber-950">{count}</p><div><h3 className="text-lg font-bold text-slate-950">{title}</h3><p className="mt-2 text-sm text-slate-700">{detail}</p><Link href={href} className="mt-4 inline-flex font-bold underline underline-offset-4">{button} →</Link></div></div></section>;
-}
-
-function SummaryCard({ label, value, urgent = false }: { label: string; value: number; urgent?: boolean }) {
-  return (
-    <div className={`rounded-2xl border p-6 shadow-sm ${urgent ? "border-amber-300 bg-amber-50" : "border-slate-200 bg-white"}`}>
-      <p className="text-sm font-semibold text-slate-600">{label}</p>
-      <p className="mt-3 text-4xl font-black tabular-nums">{value}</p>
-    </div>
-  );
 }

--- a/web/src/app/ops/system/page.tsx
+++ b/web/src/app/ops/system/page.tsx
@@ -39,13 +39,19 @@ export default async function OpsSystemPage() {
 
       <section className={`rounded-2xl border p-6 shadow-sm ${attention.length === 0 ? "border-green-200 bg-green-50" : "border-amber-300 bg-amber-50"}`}>
         <h3 className="text-xl font-bold">{attention.length === 0 ? "All clear" : `${attention.length} item${attention.length === 1 ? "" : "s"} need attention`}</h3>
-        {attention.length === 0 ? <p className="mt-2 text-slate-700">Everything currently monitored is operating normally. You do not need to do anything.</p> : <div className="mt-4 space-y-3">{attention.map((item) => <article key={item.reference} className="rounded-xl border border-amber-200 bg-white p-4"><p className="font-bold">{item.title}</p><p className="mt-1 text-sm text-slate-700">{item.explanation}</p><p className="mt-2 text-sm font-semibold text-slate-800">What to do: ask for technical help and quote reference {item.reference}.</p></article>)}</div>}
+        {attention.length === 0 ? <p className="mt-2 text-slate-700">Everything currently monitored is operating normally. You do not need to do anything.</p> : <div className="mt-4 space-y-3">{attention.map((item) => <article id={item.reference} key={item.reference} className="scroll-mt-6 rounded-xl border border-amber-200 bg-white p-4"><p className="font-bold">{item.title}</p><p className="mt-1 text-sm text-slate-700">{item.explanation}</p><p className="mt-2 text-sm font-semibold text-slate-800">What to do: ask for technical help and quote reference {item.reference}.</p></article>)}</div>}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">What is deliberately not active</h3>
         <p className="mt-1 text-sm text-slate-600">These are planned or optional services. They are not faults and do not need action unless you decide to introduce them.</p>
         {dormant.length === 0 ? <p className="mt-4 text-sm text-slate-600">No deliberately inactive services are currently recorded.</p> : <ul className="mt-4 space-y-2 text-sm text-slate-700">{dormant.map((item) => <li key={item.integration_name}><span className="font-semibold">{label(item.integration_name)}:</span> {dormantMessage(item)}</li>)}</ul>}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 className="text-xl font-bold">Commercial readiness</h3>
+        <p className="mt-2 text-sm text-slate-600">Billing is off. No paid offer is configured, and there is no payment action for you to take here.</p>
+        <p className="mt-3 text-sm text-slate-600">Future activation needs an approved benefit, price, entitlement rules, cancellation and refund handling, reconciliation, and verified implementation.</p>
       </section>
 
       <details className="rounded-2xl border border-slate-200 bg-white shadow-sm">

--- a/web/src/lib/ops/work.ts
+++ b/web/src/lib/ops/work.ts
@@ -1,0 +1,78 @@
+export type WorkPriority = "act_now" | "needs_decision" | "later_review";
+
+export type WorkItem = {
+  id: string;
+  priority: WorkPriority;
+  kind: "listing" | "claim" | "profile" | "contact" | "candidate" | "catalogue" | "system";
+  title: string;
+  decision: string;
+  evidence: string;
+  href: string;
+  createdAt: string | null;
+};
+
+type Listing = { vendor_id: string; business_name: string; updated_at: string };
+type Claim = { claim_request_id: string; business_name: string; claim_status: string; created_at: string };
+type Profile = { change_request_id: string; business_name: string; proposed_changes: Record<string, unknown>; created_at: string };
+type Contact = { contact_request_id: string; topic: string; business_name: string | null; requester_name: string; created_at: string };
+type Candidate = { record_id: string; candidate_data: Record<string, unknown>; qualification_reasons: string[]; created_at: string };
+type Catalogue = { record_id: string; vendor_id: string; business_name: string; qualification_reasons: string[]; created_at: string };
+type Health = { integration_name: string; status: string; updated_at: string };
+type Job = { job_id: string; job_type: string; status: string; created_at: string };
+
+export type WorkSource = {
+  listings: Listing[];
+  claims: Claim[];
+  profiles: Profile[];
+  contacts: Contact[];
+  candidates: Candidate[];
+  catalogue: Catalogue[];
+  health: Health[];
+  jobs: Job[];
+};
+
+export const workPriorityOrder: WorkPriority[] = ["act_now", "needs_decision", "later_review"];
+
+export function composeWorkItems(source: WorkSource): WorkItem[] {
+  const items: WorkItem[] = [
+    ...source.health
+      .filter((item) => ["failed", "degraded", "stale"].includes(item.status))
+      .map((item) => ({ id: `health:${item.integration_name}`, priority: "act_now" as const, kind: "system" as const, title: `${label(item.integration_name)} needs technical help`, decision: "Ask for technical help", evidence: "The latest monitored check needs attention. Nothing was changed automatically.", href: `/ops/system#health-${item.integration_name}`, createdAt: item.updated_at })),
+    ...source.jobs
+      .filter((item) => item.status === "failed")
+      .map((item) => ({ id: `job:${item.job_id}`, priority: "act_now" as const, kind: "system" as const, title: `${label(item.job_type)} did not complete`, decision: "Ask for technical help", evidence: "This bounded automated job failed. No business state changed automatically.", href: `/ops/system#job-${item.job_id}`, createdAt: item.created_at })),
+    ...source.listings.map((item) => ({ id: `listing:${item.vendor_id}`, priority: "needs_decision" as const, kind: "listing" as const, title: item.business_name, decision: "Make a listing decision", evidence: "Review the public facts and choose the permitted listing outcome.", href: `/ops/listings/${item.vendor_id}`, createdAt: item.updated_at })),
+    ...source.claims.map((item) => ({ id: `claim:${item.claim_request_id}`, priority: "needs_decision" as const, kind: "claim" as const, title: item.business_name, decision: item.claim_status === "needs_information" ? "Review ownership evidence" : "Review an ownership claim", evidence: "A claim changes ownership only; it never publishes or edits the listing.", href: `/ops/claims/${item.claim_request_id}`, createdAt: item.created_at })),
+    ...source.profiles.map((item) => ({ id: `profile:${item.change_request_id}`, priority: "needs_decision" as const, kind: "profile" as const, title: item.business_name, decision: "Review a proposed profile update", evidence: changedFields(item.proposed_changes), href: `/ops/profile-edits/${item.change_request_id}`, createdAt: item.created_at })),
+    ...source.contacts.map((item) => ({ id: `contact:${item.contact_request_id}`, priority: "needs_decision" as const, kind: "contact" as const, title: item.business_name ?? item.requester_name, decision: `Review ${label(item.topic)} request`, evidence: "This private request does not change a listing by itself.", href: `/ops/contact/${item.contact_request_id}`, createdAt: item.created_at })),
+    ...source.candidates
+      .filter(isOnlyPossibleDuplicate)
+      .map((item) => ({ id: `candidate:${item.record_id}`, priority: "needs_decision" as const, kind: "candidate" as const, title: candidateName(item.candidate_data), decision: "Review a possible duplicate discovery", evidence: "This is private discovery evidence, not a Business or a publication decision.", href: "/ops/candidates?status=open", createdAt: item.created_at })),
+    ...source.catalogue
+      .filter(isOnlyPossibleDuplicate)
+      .map((item) => ({ id: `catalogue:${item.record_id}`, priority: "later_review" as const, kind: "catalogue" as const, title: item.business_name, decision: "Review an older possible duplicate", evidence: "This historic evidence needs a later listing decision; it is not urgent work.", href: `/ops/listings/${item.vendor_id}`, createdAt: item.created_at })),
+  ];
+
+  return items.sort((left, right) => {
+    const priority = workPriorityOrder.indexOf(left.priority) - workPriorityOrder.indexOf(right.priority);
+    if (priority) return priority;
+    return Date.parse(right.createdAt ?? "") - Date.parse(left.createdAt ?? "");
+  });
+}
+
+function isOnlyPossibleDuplicate(item: { qualification_reasons: string[] }) {
+  return item.qualification_reasons.length === 1 && item.qualification_reasons[0] === "possible_duplicate";
+}
+
+function candidateName(candidate: Record<string, unknown>) {
+  return typeof candidate.business_name === "string" && candidate.business_name.trim() ? candidate.business_name : "Possible business from an approved source";
+}
+
+function changedFields(values: Record<string, unknown>) {
+  const fields = Object.keys(values).filter((key) => values[key] !== undefined);
+  return fields.length ? `Proposed: ${fields.map(label).join(", ")}.` : "Review the proposed public details.";
+}
+
+function label(value: string) {
+  return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}


### PR DESCRIPTION
## Summary
- make Work the protected default with a consolidated, priority-grouped decision list
- simplify primary navigation to Work, Businesses and System
- reframe Listings as the Business register and make the all-business view alphabetical
- keep System quiet and add static billing-off readiness

## Boundaries
- no generic work model, provider integration, CRM, ABN queue, Stripe/billing surface, sender/dispatcher, or workflow-policy change
- existing protected RPCs and constrained actions are reused

## Verification
- npm run check
- npm --prefix web run lint (existing image warnings only)
- npm --prefix web run build

## Remaining acceptance
- apply the included narrow remote migration before deployment
- complete authenticated browser walkthrough on desktop and narrow mobile using real data; no fabricated records