### PR TITLE
Complete Ops navigation and register filters

### DIFF
--- a/scripts/test-ops-workspace-boundary.ts
+++ b/scripts/test-ops-workspace-boundary.ts
@@ -7,6 +7,7 @@ const page = fs.readFileSync("web/src/app/ops/page.tsx", "utf8");
 const businesses = fs.readFileSync("web/src/app/ops/listings/page.tsx", "utf8");
 const system = fs.readFileSync("web/src/app/ops/system/page.tsx", "utf8");
 const registerMigration = fs.readFileSync("supabase/migrations/20260725120000_alphabetical_ops_business_register.sql", "utf8");
+const navigationMigration = fs.readFileSync("supabase/migrations/20260725133000_complete_ops_navigation_filters.sql", "utf8");
 
 assert.match(layout, /Work/);
 assert.match(layout, /Businesses/);
@@ -27,9 +28,16 @@ assert.match(page, /ops_list_candidate_handoff_records/);
 assert.match(page, /ops_list_existing_catalogue_requalification_exceptions/);
 assert.match(businesses, /Business register/);
 assert.match(businesses, /"all"/);
+assert.match(businesses, /ownership/);
+assert.match(businesses, /source/);
 assert.doesNotMatch(businesses, /Tier: \{listing\.tier\}/);
+assert.match(work, /\/ops\/candidates\/\$\{item\.record_id\}/);
+assert(fs.existsSync("web/src/app/ops/candidates/[recordId]/page.tsx"), "Work candidate rows need a route to the selected evidence and permitted action.");
 assert.match(registerMigration, /PERFORM private\.require_active_operator\(\)/);
 assert.match(registerMigration, /CASE WHEN v_status = 'all' THEN vendor\.business_name END ASC/);
+assert.match(navigationMigration, /p_ownership_status TEXT DEFAULT NULL/);
+assert.match(navigationMigration, /p_listing_source TEXT DEFAULT NULL/);
+assert.match(navigationMigration, /p_record_id UUID DEFAULT NULL/);
 assert.match(system, /Commercial readiness/);
 assert.match(system, /Billing is off/);
 for (const forbidden of ["work_items", "realtime", "Stripe checkout", "subscription", "invoice", "ABN request"]) {

--- a/supabase/migrations/20260725133000_complete_ops_navigation_filters.sql
+++ b/supabase/migrations/20260725133000_complete_ops_navigation_filters.sql
@@ -1,0 +1,130 @@
+-- Complete the existing protected Ops composition without adding a workflow
+-- system: the Business register can filter fields it already reads, and a Work
+-- row can open the exact private candidate evidence it represents.
+
+DROP FUNCTION IF EXISTS public.ops_list_listings(TEXT, TEXT, UUID, INTEGER, INTEGER);
+
+CREATE FUNCTION public.ops_list_listings(
+  p_status TEXT DEFAULT 'review',
+  p_query TEXT DEFAULT NULL,
+  p_vendor_id UUID DEFAULT NULL,
+  p_ownership_status TEXT DEFAULT NULL,
+  p_listing_source TEXT DEFAULT NULL,
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+  vendor_id UUID, business_name TEXT, category_slug TEXT, suburb_slug TEXT,
+  street_address TEXT, contact_email TEXT, phone TEXT, website TEXT, description TEXT,
+  listing_status TEXT, listing_source TEXT, ownership_status TEXT, is_published BOOLEAN,
+  is_claimed BOOLEAN, tier TEXT, moderation_reason TEXT, reviewed_at TIMESTAMPTZ,
+  published_at TIMESTAMPTZ, rejected_at TIMESTAMPTZ, unpublished_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ, active_draft_id UUID,
+  draft_base_values JSONB, draft_values JSONB
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_status TEXT := lower(trim(coalesce(p_status, 'review')));
+  v_query TEXT := nullif(trim(coalesce(p_query, '')), '');
+  v_ownership_status TEXT := nullif(lower(trim(coalesce(p_ownership_status, ''))), '');
+  v_listing_source TEXT := nullif(lower(trim(coalesce(p_listing_source, ''))), '');
+BEGIN
+  PERFORM private.require_active_operator();
+  IF v_status NOT IN ('review', 'unclassified', 'draft', 'pending_review', 'published', 'rejected', 'unpublished', 'all')
+    OR v_ownership_status NOT IN ('unclaimed', 'claim_pending', 'claimed', 'owner_verified')
+    OR v_listing_source NOT IN ('seeded_by_suburbmates', 'operator_added', 'business_submitted', 'claimed_existing_listing', 'approved_import') THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invalid listing filter.';
+  END IF;
+  IF p_limit < 1 OR p_limit > 200 OR p_offset < 0 OR length(coalesce(v_query, '')) > 200 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invalid listing search or pagination values.';
+  END IF;
+
+  RETURN QUERY
+  SELECT vendor.id, vendor.business_name, vendor.category_slug, vendor.suburb_slug,
+    vendor.street_address, vendor.contact_email, vendor.phone, vendor.website, vendor.description,
+    vendor.listing_status, vendor.listing_source, vendor.ownership_status,
+    vendor.is_published, vendor.is_claimed, vendor.tier, vendor.moderation_reason,
+    vendor.reviewed_at, vendor.published_at, vendor.rejected_at, vendor.unpublished_at,
+    vendor.created_at, vendor.updated_at, active_draft.id, active_draft.base_values, active_draft.draft_values
+  FROM public.vendors AS vendor
+  LEFT JOIN LATERAL (
+    SELECT draft.id, draft.base_values, draft.draft_values
+    FROM public.operator_listing_drafts AS draft
+    WHERE draft.vendor_id = vendor.id AND draft.draft_status = 'active'
+    LIMIT 1
+  ) AS active_draft ON true
+  WHERE (p_vendor_id IS NULL OR vendor.id = p_vendor_id)
+    AND (v_query IS NULL OR vendor.business_name ILIKE '%' || replace(replace(replace(v_query, '\\', '\\\\'), '%', '\\%'), '_', '\\_') || '%' ESCAPE '\\')
+    AND (v_ownership_status IS NULL OR vendor.ownership_status = v_ownership_status)
+    AND (v_listing_source IS NULL OR vendor.listing_source = v_listing_source)
+    AND (
+      v_status = 'all'
+      OR (v_status = 'review' AND (vendor.listing_status IS NULL OR vendor.listing_status IN ('draft', 'pending_review')))
+      OR (v_status = 'unclassified' AND vendor.listing_status IS NULL)
+      OR vendor.listing_status = v_status
+    )
+  ORDER BY
+    CASE WHEN v_status = 'all' THEN 0 WHEN vendor.listing_status IS NULL OR vendor.listing_status IN ('draft', 'pending_review') THEN 0 ELSE 1 END,
+    CASE WHEN v_status = 'all' THEN vendor.business_name END ASC NULLS LAST,
+    CASE WHEN v_status <> 'all' THEN vendor.updated_at END DESC NULLS LAST,
+    vendor.business_name
+  LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ops_list_listings(TEXT, TEXT, UUID, TEXT, TEXT, INTEGER, INTEGER) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.ops_list_listings(TEXT, TEXT, UUID, TEXT, TEXT, INTEGER, INTEGER) TO authenticated;
+
+DROP FUNCTION IF EXISTS public.ops_list_candidate_handoff_records(TEXT, INTEGER, INTEGER);
+
+CREATE FUNCTION public.ops_list_candidate_handoff_records(
+  p_status TEXT DEFAULT 'open',
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0,
+  p_record_id UUID DEFAULT NULL
+)
+RETURNS TABLE (
+  record_id UUID, run_id UUID, source TEXT, source_record_key TEXT,
+  candidate_data JSONB, normalized_data JSONB, qualification_outcome TEXT,
+  qualification_reasons JSONB, duplicate_vendor_id UUID, vendor_id UUID,
+  exception_status TEXT, resolution_note TEXT, resolved_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_status TEXT := lower(trim(coalesce(p_status, 'open')));
+BEGIN
+  PERFORM private.require_active_operator();
+  IF v_status NOT IN ('open', 'acknowledged', 'dismissed', 'all') OR p_limit < 1 OR p_limit > 200 OR p_offset < 0 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'Invalid candidate handoff filter or pagination values.';
+  END IF;
+  RETURN QUERY
+  SELECT record.id, run.id, run.source, record.source_record_key, record.candidate_data,
+    record.normalized_data, record.qualification_outcome, record.qualification_reasons,
+    record.duplicate_vendor_id, record.vendor_id, record.exception_status,
+    record.resolution_note, record.resolved_at, record.created_at
+  FROM public.candidate_handoff_records AS record
+  JOIN public.candidate_handoff_runs AS run ON run.id = record.run_id
+  WHERE record.qualification_outcome = 'exception'
+    AND (p_record_id IS NULL OR record.id = p_record_id)
+    AND (v_status = 'all' OR record.exception_status = v_status)
+  ORDER BY record.created_at DESC
+  LIMIT p_limit OFFSET p_offset;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ops_list_candidate_handoff_records(TEXT, INTEGER, INTEGER, UUID) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.ops_list_candidate_handoff_records(TEXT, INTEGER, INTEGER, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.ops_list_listings(TEXT, TEXT, UUID, TEXT, TEXT, INTEGER, INTEGER) IS
+  'Operator-only listing reader with existing lifecycle, ownership and source filters.';
+COMMENT ON FUNCTION public.ops_list_candidate_handoff_records(TEXT, INTEGER, INTEGER, UUID) IS
+  'Operator-only candidate exception reader. An optional record ID supports a Work row opening its exact evidence.';

--- a/web/src/app/ops/candidates/[recordId]/page.tsx
+++ b/web/src/app/ops/candidates/[recordId]/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createOpsDataClient } from "@/lib/ops/auth";
+import { formatOpsDateTime } from "@/lib/ops/date";
+import { resolveCandidateExceptionAction } from "../actions";
+
+type CandidateException = {
+  record_id: string;
+  source: string;
+  source_record_key: string;
+  candidate_data: Record<string, unknown>;
+  qualification_reasons: string[];
+  duplicate_vendor_id: string | null;
+  exception_status: string;
+  resolution_note: string | null;
+  created_at: string;
+};
+
+export default async function CandidateDetailPage({ params, searchParams }: { params: Promise<{ recordId: string }>; searchParams: Promise<{ error?: string; success?: string }> }) {
+  const { recordId } = await params;
+  const message = await searchParams;
+  const supabase = await createOpsDataClient();
+  const { data, error } = await supabase.rpc("ops_list_candidate_handoff_records", { p_status: "all", p_limit: 1, p_offset: 0, p_record_id: recordId });
+  if (error) throw new Error("The candidate evidence could not be loaded.");
+  const record = data?.[0] as CandidateException | undefined;
+  if (!record) notFound();
+  const candidate = record.candidate_data;
+
+  return <div className="space-y-7">
+    <Link href="/ops" className="text-sm font-bold underline underline-offset-4">← Back to Work</Link>
+    <header><p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">Possible duplicate discovery</p><h2 className="mt-2 text-4xl font-black tracking-tight">{text(candidate.business_name) || "Possible business from an approved source"}</h2><p className="mt-3 max-w-3xl text-slate-600">This private discovery is not a Business and has not been published. Review the evidence, then record one safe outcome.</p></header>
+    {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800">The decision could not be recorded. Refresh and try again.</p>}
+    {message.success && <p className="rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800">Decision recorded. This did not publish, claim or edit a business listing.</p>}
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"><div className="flex flex-wrap items-start justify-between gap-4"><div><h3 className="text-xl font-bold">Evidence</h3><p className="mt-1 text-sm text-slate-600">{text(candidate.category_slug) || "No category"} · {text(candidate.suburb_slug) || "No location"} · source: {label(record.source)}</p></div><span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-950">{label(record.exception_status)}</span></div><div className="mt-5 grid gap-3 text-sm sm:grid-cols-2"><Field label="Address" value={text(candidate.street_address)} /><Field label="Email" value={text(candidate.contact_email)} /><Field label="Phone" value={text(candidate.phone)} /><Field label="Website" value={text(candidate.website)} /></div><div className="mt-5 rounded-xl bg-amber-50 p-4"><p className="font-bold">Why this needs your decision</p><ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">{record.qualification_reasons.map((reason) => <li key={reason}>{reasonLabel(reason)}</li>)}</ul></div>{record.duplicate_vendor_id && <p className="mt-4 text-sm"><Link className="font-bold underline" href={`/ops/listings/${record.duplicate_vendor_id}`}>Review the possible matching business</Link></p>}<p className="mt-4 text-xs text-slate-500">Received {formatOpsDateTime(record.created_at)} · reference {record.source_record_key}</p></section>
+    {record.resolution_note ? <section className="rounded-2xl border border-slate-200 bg-slate-50 p-6"><p className="font-bold">Recorded decision</p><p className="mt-2 text-sm text-slate-700">{record.resolution_note}</p></section> : <form action={resolveCandidateExceptionAction} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"><input type="hidden" name="recordId" value={record.record_id} /><label className="block text-sm font-bold">Decision note<textarea name="note" required maxLength={2000} rows={4} className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label><div className="mt-5 flex flex-wrap gap-3"><button name="action" value="acknowledge" className="btn btn-outline">Acknowledge for follow-up</button><button name="action" value="dismiss" className="btn btn-outline">Dismiss as unsuitable</button></div></form>}
+  </div>;
+}
+
+function Field({ label, value }: { label: string; value: string }) { return value ? <p><span className="font-semibold text-slate-500">{label}:</span> {value}</p> : null; }
+function text(value: unknown) { return typeof value === "string" ? value : ""; }
+function label(value: string) { return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase()); }
+function reasonLabel(reason: string) { return ({ possible_duplicate: "It may match an existing business and needs a human check." } as Record<string, string>)[reason] ?? label(reason); }

--- a/web/src/app/ops/candidates/actions.ts
+++ b/web/src/app/ops/candidates/actions.ts
@@ -10,7 +10,7 @@ export async function resolveCandidateExceptionAction(formData: FormData) {
   const recordId = String(formData.get("recordId") ?? "");
   const action = String(formData.get("action") ?? "");
   const note = String(formData.get("note") ?? "").trim();
-  const detailPath = "/ops/candidates";
+  const detailPath = `/ops/candidates/${recordId}`;
   const { supabase } = await verifyOpsAdmin(detailPath);
   if (!uuidPattern.test(recordId) || !["acknowledge", "dismiss"].includes(action) || note.length < 1 || note.length > 2000) {
     redirect(`${detailPath}?error=invalid`);
@@ -22,6 +22,7 @@ export async function resolveCandidateExceptionAction(formData: FormData) {
   });
   if (error) redirect(`${detailPath}?error=resolve`);
   revalidatePath("/ops");
+  revalidatePath("/ops/candidates");
   revalidatePath(detailPath);
   redirect(`${detailPath}?success=${action}`);
 }

--- a/web/src/app/ops/candidates/page.tsx
+++ b/web/src/app/ops/candidates/page.tsx
@@ -24,7 +24,7 @@ export default async function OpsCandidatesPage({ searchParams }: { searchParams
   const params = await searchParams;
   const status = statuses.includes(params.status as Status) ? (params.status as Status) : "open";
   const supabase = await createOpsDataClient();
-  const { data, error } = await supabase.rpc("ops_list_candidate_handoff_records", { p_status: status, p_limit: 100, p_offset: 0 });
+  const { data, error } = await supabase.rpc("ops_list_candidate_handoff_records", { p_status: status, p_limit: 100, p_offset: 0, p_record_id: null });
   if (error) throw new Error("The candidate exceptions could not be loaded.");
   const records = (data ?? []) as CandidateException[];
 

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -46,7 +46,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
   const message = await searchParams;
   const supabase = await createOpsDataClient();
   const [{ data, error }, categoriesResult, suburbsResult, evidenceResult, routeResult, submissionResult, mediaResult] = await Promise.all([
-    supabase.rpc("ops_list_listings", { p_status: "all", p_query: null, p_vendor_id: vendorId, p_limit: 1, p_offset: 0 }),
+    supabase.rpc("ops_list_listings", { p_status: "all", p_query: null, p_vendor_id: vendorId, p_ownership_status: null, p_listing_source: null, p_limit: 1, p_offset: 0 }),
     supabase.from("categories").select("name, slug").order("name"),
     supabase.from("suburbs").select("name, slug").order("name"),
     supabase.rpc("ops_list_listing_evidence", { p_vendor_id: vendorId }),

--- a/web/src/app/ops/listings/page.tsx
+++ b/web/src/app/ops/listings/page.tsx
@@ -3,7 +3,11 @@ import { QueuePagination } from "@/components/ops/QueuePagination";
 import { createOpsDataClient } from "@/lib/ops/auth";
 
 const statuses = ["all", "review", "unclassified", "draft", "pending_review", "published", "rejected", "unpublished"] as const;
+const ownershipStatuses = ["all", "unclaimed", "claim_pending", "claimed", "owner_verified"] as const;
+const sources = ["all", "seeded_by_suburbmates", "operator_added", "business_submitted", "claimed_existing_listing", "approved_import"] as const;
 type Status = (typeof statuses)[number];
+type OwnershipStatus = (typeof ownershipStatuses)[number];
+type Source = (typeof sources)[number];
 
 type OpsListing = {
   vendor_id: string;
@@ -18,9 +22,11 @@ type OpsListing = {
   active_draft_id: string | null;
 };
 
-export default async function OpsListingsPage({ searchParams }: { searchParams: Promise<{ status?: string; q?: string; page?: string }> }) {
+export default async function OpsListingsPage({ searchParams }: { searchParams: Promise<{ status?: string; ownership?: string; source?: string; q?: string; page?: string }> }) {
   const params = await searchParams;
   const status = statuses.includes(params.status as Status) ? (params.status as Status) : "all";
+  const ownership = ownershipStatuses.includes(params.ownership as OwnershipStatus) ? (params.ownership as OwnershipStatus) : "all";
+  const source = sources.includes(params.source as Source) ? (params.source as Source) : "all";
   const q = typeof params.q === "string" ? params.q.slice(0, 200) : "";
   const page = pageNumber(params.page);
   const supabase = await createOpsDataClient();
@@ -28,6 +34,8 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
     p_status: status,
     p_query: q || null,
     p_vendor_id: null,
+    p_ownership_status: ownership === "all" ? null : ownership,
+    p_listing_source: source === "all" ? null : source,
     p_limit: 101,
     p_offset: page * 100,
   });
@@ -35,7 +43,8 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
   const results = (data ?? []) as OpsListing[];
   const listings = results.slice(0, 100);
   const hasNextPage = results.length > 100;
-  const pageHref = (targetPage: number) => `/ops/listings?${new URLSearchParams({ status, ...(q ? { q } : {}), ...(targetPage ? { page: String(targetPage) } : {}) }).toString()}`;
+  const pageHref = (targetPage: number) => `/ops/listings?${new URLSearchParams({ status, ownership, source, ...(q ? { q } : {}), ...(targetPage ? { page: String(targetPage) } : {}) }).toString()}`;
+  const filterHref = (nextStatus: Status) => `/ops/listings?${new URLSearchParams({ status: nextStatus, ownership, source, ...(q ? { q } : {}) }).toString()}`;
 
   return (
     <div className="space-y-7">
@@ -45,15 +54,21 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
         <p className="mt-3 max-w-3xl text-slate-600">Search real directory records and open one business to see its authorised evidence, requests and safe actions. Private candidate records are not businesses.</p>
       </div>
 
-      <form className="flex max-w-xl gap-3" action="/ops/listings">
+      <form className="grid max-w-3xl gap-3 sm:grid-cols-[1fr_auto_auto_auto]" action="/ops/listings">
         <input type="hidden" name="status" value={status} />
         <input name="q" defaultValue={q} maxLength={200} placeholder="Search business name" className="min-w-0 flex-1 rounded-xl border border-slate-300 bg-white px-4 py-3" />
         <button className="btn btn-primary">Search</button>
+        <select aria-label="Filter by ownership" name="ownership" defaultValue={ownership} className="rounded-xl border border-slate-300 bg-white px-3 py-3 text-sm font-semibold">
+          {ownershipStatuses.map((item) => <option key={item} value={item}>{ownershipLabel(item)}</option>)}
+        </select>
+        <select aria-label="Filter by source" name="source" defaultValue={source} className="rounded-xl border border-slate-300 bg-white px-3 py-3 text-sm font-semibold">
+          {sources.map((item) => <option key={item} value={item}>{sourceLabel(item)}</option>)}
+        </select>
       </form>
 
       <nav className="flex flex-wrap gap-2" aria-label="Listing status filters">
         {statuses.map((item) => (
-          <Link key={item} href={`/ops/listings?status=${item}`} aria-current={item === status ? "page" : undefined}
+          <Link key={item} href={filterHref(item)} aria-current={item === status ? "page" : undefined}
             className={`rounded-full border px-4 py-2 text-sm font-bold ${item === status ? "border-slate-950 bg-slate-950 text-white" : "border-slate-300 bg-white"}`}>
             {statusLabel(item)}
           </Link>
@@ -94,6 +109,14 @@ function statusLabel(value: string) {
   if (value === "review") return "Attention";
   if (value === "unclassified") return "Needs classification";
   return value.replaceAll("_", " ").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function ownershipLabel(value: OwnershipStatus) {
+  return value === "all" ? "All ownership" : `Ownership: ${statusLabel(value)}`;
+}
+
+function sourceLabel(value: Source) {
+  return value === "all" ? "All sources" : `Source: ${statusLabel(value)}`;
 }
 
 function pageNumber(value: string | undefined) {

--- a/web/src/app/ops/page.tsx
+++ b/web/src/app/ops/page.tsx
@@ -8,13 +8,13 @@ const pageSize = 200;
 export default async function OpsWorkPage() {
   const supabase = await createOpsDataClient();
   const [listings, pendingClaims, waitingClaims, profiles, newContacts, activeContacts, candidates, catalogue, health, jobs] = await Promise.all([
-    loadAll((offset) => supabase.rpc("ops_list_listings", { p_status: "review", p_query: null, p_vendor_id: null, p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_listings", { p_status: "review", p_query: null, p_vendor_id: null, p_ownership_status: null, p_listing_source: null, p_limit: pageSize, p_offset: offset })),
     loadAll((offset) => supabase.rpc("ops_list_claim_requests", { p_status: "pending", p_claim_request_id: null, p_limit: pageSize, p_offset: offset })),
     loadAll((offset) => supabase.rpc("ops_list_claim_requests", { p_status: "needs_information", p_claim_request_id: null, p_limit: pageSize, p_offset: offset })),
     loadAll((offset) => supabase.rpc("ops_list_profile_changes", { p_status: "pending", p_change_request_id: null, p_limit: pageSize, p_offset: offset })),
     loadAll((offset) => supabase.rpc("ops_list_contact_requests", { p_status: "new", p_contact_request_id: null, p_limit: pageSize, p_offset: offset })),
     loadAll((offset) => supabase.rpc("ops_list_contact_requests", { p_status: "in_progress", p_contact_request_id: null, p_limit: pageSize, p_offset: offset })),
-    loadAll((offset) => supabase.rpc("ops_list_candidate_handoff_records", { p_status: "open", p_limit: pageSize, p_offset: offset })),
+    loadAll((offset) => supabase.rpc("ops_list_candidate_handoff_records", { p_status: "open", p_limit: pageSize, p_offset: offset, p_record_id: null })),
     loadAll((offset) => supabase.rpc("ops_list_existing_catalogue_requalification_exceptions", { p_status: "open", p_limit: pageSize, p_offset: offset })),
     onePage(() => supabase.rpc("ops_list_integration_health")),
     onePage(() => supabase.rpc("ops_list_automation_jobs", { p_limit: pageSize })),

--- a/web/src/lib/ops/work.ts
+++ b/web/src/lib/ops/work.ts
@@ -47,7 +47,7 @@ export function composeWorkItems(source: WorkSource): WorkItem[] {
     ...source.contacts.map((item) => ({ id: `contact:${item.contact_request_id}`, priority: "needs_decision" as const, kind: "contact" as const, title: item.business_name ?? item.requester_name, decision: `Review ${label(item.topic)} request`, evidence: "This private request does not change a listing by itself.", href: `/ops/contact/${item.contact_request_id}`, createdAt: item.created_at })),
     ...source.candidates
       .filter(isOnlyPossibleDuplicate)
-      .map((item) => ({ id: `candidate:${item.record_id}`, priority: "needs_decision" as const, kind: "candidate" as const, title: candidateName(item.candidate_data), decision: "Review a possible duplicate discovery", evidence: "This is private discovery evidence, not a Business or a publication decision.", href: "/ops/candidates?status=open", createdAt: item.created_at })),
+      .map((item) => ({ id: `candidate:${item.record_id}`, priority: "needs_decision" as const, kind: "candidate" as const, title: candidateName(item.candidate_data), decision: "Review a possible duplicate discovery", evidence: "This is private discovery evidence, not a Business or a publication decision.", href: `/ops/candidates/${item.record_id}`, createdAt: item.created_at })),
     ...source.catalogue
       .filter(isOnlyPossibleDuplicate)
       .map((item) => ({ id: `catalogue:${item.record_id}`, priority: "later_review" as const, kind: "catalogue" as const, title: item.business_name, decision: "Review an older possible duplicate", evidence: "This historic evidence needs a later listing decision; it is not urgent work.", href: `/ops/listings/${item.vendor_id}`, createdAt: item.created_at })),


### PR DESCRIPTION
## Scope
- Open each possible-duplicate Work row at its exact private evidence and existing safe action.
- Add ownership and source filters to the protected Business register using existing fields.
- Extend only the two existing operator-only readers; no tables, policies, workflow model, integrations, billing, or communications changes.

## Verification
- `npm run ops-workspace:test`
- `npm run ops-action-queue:test`
- `npm run check`
- `npm --prefix web run lint` (three pre-existing image warnings only)
- `npm --prefix web run build`
- `git diff --check`

## Database proof
The migration was not applied. A rolled-back remote validation attempt could not connect because this environment has no IPv6 route to the configured direct database host; no SQL ran and no remote state changed.