### PR TITLE
Stop address-only duplicate exceptions

### DIFF
--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -126,6 +126,14 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Guardrail:** This authorisation does not enable Stripe, general outbound email, bulk ABN checks, AI publication, raw-candidate publication or automated ownership decisions.
 - **Outstanding evidence:** Complete real authenticated owner/submitter and operator walkthroughs, including the candidate-to-Ops, ABN evidence and owner-media paths. Any failure must be recorded and corrected; it is not a reason to publish additional listings.
 
+### D-014 — Address-only matching is not duplicate evidence
+
+- **Date:** 26 July 2026
+- **Decision:** A shared street address alone is not a duplicate signal. Shopping centres and multi-tenant buildings legitimately contain many different businesses; automation must not create an operator task merely because two listings share an address.
+- **Rule:** Automatic duplicate blocking requires a strong identifier match: the same normalised website, phone number, or both business name and address. Similar names at different addresses remain distinct listings unless separate source evidence shows they are the same entity.
+- **Current state:** The existing-catalogue requalification policy is versioned to re-run under this rule. It changes only private evidence status; it does not delete, merge, publish, unpublish, claim or alter any business record.
+- **Evidence to close:** Regression coverage for shared-address businesses, a completed requalification run, and an Ops Work list with address-only false positives removed.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/scripts/requalify-existing-catalogue.ts
+++ b/scripts/requalify-existing-catalogue.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { createClient } from "@supabase/supabase-js";
 import { qualifyExistingCatalogueListing, type ExistingCatalogueListing } from "../web/src/lib/automation/existing-catalogue-requalification";
 
-const policyVersion = "existing-catalogue-v1";
+const policyVersion = "existing-catalogue-v2";
 const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
 const secret = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
 

--- a/scripts/test-candidate-qualification.ts
+++ b/scripts/test-candidate-qualification.ts
@@ -12,7 +12,8 @@ const valid = { source: "openstreetmap", businessName: "Northcote Plumbing", cat
 
 assert.equal(qualifyCandidate(valid, options).outcome, "qualified");
 assert.deepEqual(qualifyCandidate({ ...valid, phone: "03 9000 0000" }, options).reasons, ["strong_duplicate"]);
-assert.deepEqual(qualifyCandidate({ ...valid, businessName: "Acme Plumbing", streetAddress: "99 Elsewhere Road", phone: "03 8111 2222", website: "https://different.example" }, options).reasons, ["possible_duplicate"]);
+assert.equal(qualifyCandidate({ ...valid, businessName: "Acme Plumbing", streetAddress: "99 Elsewhere Road", phone: "03 8111 2222", website: "https://different.example" }, options).outcome, "qualified");
+assert.equal(qualifyCandidate({ ...valid, businessName: "Different Business", streetAddress: "1 High Street" }, options).outcome, "qualified");
 assert(qualifyCandidate({ ...valid, phone: "", website: "", contactEmail: "" }, options).reasons.includes("missing_reachable_contact"));
 assert(qualifyCandidate({ ...valid, website: "http://unsafe.example" }, options).reasons.includes("unsafe_or_invalid_website"));
 assert(qualifyCandidate({ ...valid, websiteSafety: "unsafe" }, options).reasons.includes("unsafe_or_broken_destination"));

--- a/scripts/test-existing-catalogue-requalification.ts
+++ b/scripts/test-existing-catalogue-requalification.ts
@@ -24,6 +24,7 @@ const valid = {
 };
 
 assert.equal(qualifyExistingCatalogueListing(valid, options).outcome, "qualified");
+assert.equal(qualifyExistingCatalogueListing({ ...valid, businessName: "Different Business", streetAddress: "2 Main Street" }, options).outcome, "qualified");
 assert(qualifyExistingCatalogueListing({ ...valid, phone: null, website: null, contactEmail: null }, options).reasons.includes("missing_reachable_contact"));
 assert(qualifyExistingCatalogueListing({ ...valid, listingSource: "seeded_by_suburbmates", sourceUrl: null, sourceCheckedOn: null }, options).reasons.includes("unproven_existing_provenance"));
 assert(qualifyExistingCatalogueListing({ ...valid, phone: "03 9000 0000" }, options).reasons.includes("strong_duplicate"));

--- a/web/src/lib/automation/candidate-qualification.ts
+++ b/web/src/lib/automation/candidate-qualification.ts
@@ -42,7 +42,6 @@ export function qualifyCandidate(candidate: CandidateInput, options: { allowedSo
   if (candidate.websiteSafety === "unsafe") reasons.push("unsafe_or_broken_destination");
   const duplicate = findStrongDuplicate(normalized, options.existingListings);
   if (duplicate) reasons.push("strong_duplicate");
-  else if (findNearDuplicate(normalized, options.existingListings)) reasons.push("possible_duplicate");
   return { outcome: reasons.length === 0 ? "qualified" : "exception", reasons, duplicateVendorId: duplicate?.id ?? null, normalized };
 }
 
@@ -54,9 +53,6 @@ function findStrongDuplicate(normalized: Qualification["normalized"], listings: 
     const website = normalizeWebsite(listing.website); const phone = normalizePhone(listing.phone); const name = normalizeText(listing.businessName); const address = normalizeText(listing.streetAddress);
     return (normalized.website !== "" && normalized.website === website) || (normalized.phone !== "" && normalized.phone === phone) || (normalized.businessName !== "" && normalized.businessName === name && normalized.streetAddress !== "" && normalized.streetAddress === address);
   });
-}
-function findNearDuplicate(normalized: Qualification["normalized"], listings: readonly ExistingListing[]) {
-  return listings.some((listing) => normalized.businessName !== "" && normalized.businessName === normalizeText(listing.businessName) || normalized.streetAddress !== "" && normalized.streetAddress === normalizeText(listing.streetAddress));
 }
 export function normalizeText(value: string | null | undefined) { return (value ?? "").trim().toLowerCase().replace(/[^a-z0-9]+/g, " ").replace(/\s+/g, " ").trim(); }
 export function normalizePhone(value: string | null | undefined) { return (value ?? "").replace(/\D/g, "").replace(/^61(?=\d{9,10}$)/, "0"); }


### PR DESCRIPTION
Removes address-only duplicate escalation, retains strong identifier checks, versions the private requalification policy, and records the owner-approved rule. Does not delete, merge, publish, unpublish, claim, or alter business records.