### PR TITLE
Reconcile release authority and public accessibility

### DIFF
--- a/docs/AUTOMATION/EXISTING_CATALOGUE_REQUALIFICATION_AUDIT.md
+++ b/docs/AUTOMATION/EXISTING_CATALOGUE_REQUALIFICATION_AUDIT.md
@@ -1,7 +1,7 @@
 # Existing catalogue requalification audit
 
-**Date:** 23 July 2026 (Australia/Melbourne)  
-**Scope:** read-only inspection of the live published catalogue. No listing, publication, ownership, evidence or audit record was changed.
+**Date:** 26 July 2026 (Australia/Melbourne)
+**Scope:** private, idempotent evidence classification of the live published catalogue. It retained requalification evidence and one audit record; no listing, publication, ownership, commercial or lifecycle state changed.
 
 ## Why this audit exists
 
@@ -11,46 +11,35 @@ The approved qualification policy applies to every directory listing: permitted 
 
 | Check | Result |
 | --- | ---: |
-| Published listings inspected | 1,600 |
-| `approved_import` provenance | 1,598 |
-| `seeded_by_suburbmates` provenance | 2 |
-| Source URL present | 1,598 |
-| Source check date present | 1,598 |
-| Category and suburb present | 1,600 |
-| Street address present | 973 |
-| At least one usable email, phone or HTTPS website | 790 |
-| Non-HTTPS or malformed stored website | 0 |
-| Strong duplicate signal by website | 6 groups / 12 listings |
-| Strong duplicate signal by phone | 2 groups / 4 listings |
-| Strong duplicate signal by exact normalised name and address | 0 groups |
+| Published listings inspected | 1,601 |
+| Completed evidence policy | `existing-catalogue-v2` |
+| Shared-address rule | Address alone is not duplicate evidence |
 
-The duplicate signal counts can overlap. They are review signals, not evidence that every paired listing is an erroneous duplicate.
+The current policy uses only strong identifier matches (same normalised website, phone, or both name and address) for duplicate blocking. A shared street address is not duplicate evidence.
 
 ## Completed private evidence pass
 
-The idempotent `existing-catalogue-v1` run completed on 23 July 2026:
+The idempotent `existing-catalogue-v2` run completed on 26 July 2026:
 
 | Result | Count |
 | --- | ---: |
-| Listings classified | 1,600 |
-| Qualified from stored evidence | 584 |
-| Exceptions retained for Ops | 1,016 |
+| Listings classified | 1,601 |
+| Qualified from stored evidence | 619 |
+| Private background exceptions | 982 |
 | Missing reachable contact | 810 |
 | Unsupported category | 354 |
-| Possible duplicate | 107 |
 | Strong duplicate | 16 |
-| Incomplete provenance | 2 |
+| Unproven existing provenance | 2 |
 
 Reason counts overlap because one listing can need more than one follow-up. Re-running the same evidence pass returned the completed run rather than creating another run, record set or audit event.
 
-The classification did not change a listing's lifecycle, ownership, commercial state or public visibility: the live published count remained 1,600 and the sitemap remained 1,684 URLs. The protected `/ops/catalogue-review` page exposes the exceptions in plain language to the authorised operator.
+The classification did not change a listing's lifecycle, ownership, commercial state or public visibility. These records are retained for audit and batch-improvement work; they are not individual operator tasks. Only a genuine unresolved duplicate may appear in Ops Work.
 
 ## Next operational work
 
-1. Review the exception queue, starting with missing contact details, strong duplicates and incomplete provenance.
-2. Preserve the evidence result until a separately authorised lifecycle decision is made for any individual exception.
-3. Re-run only when source or listing data materially changes; the policy fingerprint makes an unchanged rerun idempotent.
-4. Use the public route and sitemap smoke checks after any future listing decision.
+1. Preserve the evidence result until a separately authorised lifecycle decision is made for any individual exception.
+2. Re-run only when source or listing data materially changes; the policy fingerprint makes an unchanged rerun idempotent.
+3. Use the public route and sitemap smoke checks after any future listing decision.
 
 ## Evidence used
 

--- a/docs/AUTOMATION/README.md
+++ b/docs/AUTOMATION/README.md
@@ -2,7 +2,7 @@
 
 This folder is the canonical operational map for SuburbMates automation. It explains what the implemented automations do, what triggers them, which services they use, and their current operating status.
 
-It does not override the locked product and Ops authorities in `docs/REFERENCE/` or the current-state record in `docs/HANDOVER.md`. It records implementation evidence as at 23 July 2026. A pending target-state decision must be reconciled with the locked authorities before it changes production behaviour.
+It does not override the locked product and Ops authorities in `docs/REFERENCE/` or the current-state record in `docs/HANDOVER.md`. It records current implementation evidence. A pending target-state decision must be reconciled with the locked authorities before it changes production behaviour.
 
 ## Read first
 
@@ -24,14 +24,14 @@ Database health updates and contact retention are narrow, audited **Ops** proces
 - Catalogue discovery and Production smoke fixes were merged in pull requests #4 and #5. Controlled manual runs then succeeded on `main`. Website safety completed evidence collection and raised one operator review issue.
 - Stripe billing, bulk ABR/ABN checks, AI publication, media/logo processing, and the legacy inactivity pruner are disabled.
 - Candidate-to-Ops handoff is implemented for approved OpenStreetMap batches. A full manual run on 22 July 2026 covered 1,545 source rows: 1,544 private exceptions and one deterministically qualified, unclaimed listing with retained provenance, contact and audit evidence. The protected exception queue remains normal ongoing Ops work.
-- The existing 1,600-listing catalogue has completed a private deterministic evidence pass: 584 qualified and 1,016 exceptions. It did not change listing visibility; exceptions are available in protected Ops for follow-up.
+- The existing catalogue completed the private `existing-catalogue-v2` evidence pass on 26 July 2026: 619 qualified and 982 exceptions across 1,601 listings. It did not change listing visibility. These are background evidence records, not a queue for the operator to process one by one; only a genuine unresolved duplicate would be surfaced in Work.
 - The database health monitor does not ingest GitHub workflow runs or artefacts. Its green automation-queue status means only that the local job table has no failed or overdue rows; it is not evidence that GitHub checks ran.
 
 ## Verified current gaps
 
-1. **Review website-safety evidence.** The controlled run checked 588 websites and flagged 86. The report is retained for 30 days in GitHub Actions and [issue #3](https://github.com/carlsuburbmates/suburbmates/issues/3) is the single review entry. No listing was changed.
+1. **Review website-safety evidence only when an issue is raised.** The controlled run checked 588 websites and flagged 86. The report is retained for 30 days in GitHub Actions and [issue #3](https://github.com/carlsuburbmates/suburbmates/issues/3) is the single review entry. No listing was changed.
 2. **Keep GitHub evidence distinct from the database health badge.** GitHub workflow-result ingestion is not implemented. The candidate handoff records its own database run and job state, but a health row is still not proof that every GitHub workflow ran.
-3. **Harden external acquisition.** The current robustness work adds bounded provider requests, response validation, fallback evidence and date-boundary tests. It remains an unmerged candidate until CI and review evidence are attached.
+3. **Maintain external-acquisition safeguards.** Bounded provider requests, response validation, fallback evidence and date-boundary tests are implemented. Any future change must preserve the same qualification and evidence boundary.
 4. **Cloudflare preview-build guard is enabled.** On 18 July, Cloudflare Workers Builds was verified with production branch `main` and non-production branch builds disabled. This prevents PR branches from producing automatic preview deployments.
 
 ## Documentation rule

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -34,7 +34,7 @@ Reverified on 23 July 2026 (Australia/Melbourne):
 - the owner explicitly authorised public release; the public directory is live and indexable;
 - `/`, `/businesses`, a representative published profile, and a populated category route return successfully; `/sitemap.xml` contains 1,685 public URLs;
 - `www.suburbmates.com.au` permanently redirects to the apex domain and unauthenticated `/ops` remains protected behind sign-in;
-- the private existing-catalogue evidence pass classified all 1,600 published listings: 584 qualified and 1,016 retained as Ops exceptions. It made no listing-state change; see `docs/AUTOMATION/EXISTING_CATALOGUE_REQUALIFICATION_AUDIT.md`;
+- the latest private existing-catalogue evidence pass (`existing-catalogue-v2`, 26 July 2026) classified all 1,601 published listings: 619 qualified and 982 retained as background evidence exceptions. It made no listing-state change and does not create a manual operator backlog; see `docs/AUTOMATION/EXISTING_CATALOGUE_REQUALIFICATION_AUDIT.md`;
 - the full repository safety suite, web lint and production build passed on the release baseline. Lint has three existing non-blocking `img` performance warnings.
 
 Never infer the reason for a legacy row’s state. Recheck hosted counts before and after any migration, import, or lifecycle action.
@@ -90,7 +90,9 @@ Public directory reads use `public.published_vendors`, a safe projection contain
 
 `/ops` is deny-by-default and requires both a valid Supabase session and an active `operator_users` row. Service credentials are not an alternate operator identity.
 
-Implemented queues:
+The default Ops workspace is **Work**, which shows only genuine human decisions. **Businesses** is the operator register and **System** is quiet health/readiness context. The protected routes below remain deep links from those three surfaces; they are not a daily workflow checklist.
+
+Implemented protected workflows:
 
 - `/ops/listings`: draft, review, publish, reject, unpublish, restore, and legacy classification;
 - `/ops/claims`: reviewed ownership requests and revocation;
@@ -110,13 +112,13 @@ The permanent operator is `admin@suburbmates.com.au`; the hosted database has ex
 
 The safe automated discovery path is:
 
-1. acquire public-source candidates;
-2. normalize, audit, and deduplicate them;
-3. generate a review artifact;
-4. import new rows as `pending_review` and unpublished;
-5. let an operator review evidence and approve publication.
+1. acquire approved-source candidates;
+2. normalise, audit and deduplicate them;
+3. retain an evidence artefact and private handoff record;
+4. deterministically qualify each candidate against source, scope, contact, duplicate and safety rules; and
+5. create an unclaimed published listing only for a qualifying approved-source candidate while the public-release gate is enabled. Exceptions remain private; raw or uncertain records are never published.
 
-`scripts/seed.ts` preserves publication for existing rows and explicitly sets new rows to unpublished pending review. It must never auto-publish. Empty import fields must not erase existing stored values, and same-name businesses at different addresses must remain distinct.
+`scripts/seed.ts` is a controlled legacy import tool, not the approved-source discovery route. It preserves publication for existing rows and sets new seed rows to unpublished pending review. Empty import fields must not erase existing stored values, and same-name businesses at different addresses must remain distinct.
 
 The weekly GitHub `Catalogue Discovery` workflow acquires/audits/merges candidate evidence, uploads its artifact, and sends approved OpenStreetMap candidates to the authenticated qualification handoff. The handoff retains private evidence for every candidate; only a candidate that passes the deterministic policy may become an unclaimed public listing. It never publishes raw, uncertain or user-submitted data.
 
@@ -175,7 +177,7 @@ After deployment, verify the served production response—not only browser cache
 
 ## Remaining work
 
-1. Exercise every authenticated `/ops` queue in the browser, confirming each routine decision is clear to the non-technical operator and leaves the required audit evidence.
+1. Preserve the released Work/Businesses/System Ops model through a real-data desktop and narrow-mobile acceptance walkthrough after each material Ops change.
 2. Review the one remaining unpublished original seed using real evidence; do not publish it by migration.
 3. Decide whether historical catalogue source fields need a separate immutable evidence migration beyond their canonical `approved_import` provenance.
 4. Review weekly outbound-website evidence reports. The automated checker follows HTTPS redirects only after public-DNS validation, records evidence, and opens one review issue when needed; it never changes a listing automatically. Complete the real ABN and owner-media walkthroughs before treating their workflows as accepted.

--- a/docs/REFERENCE/SuburbMates — Corrected Master Architecture and Execution Plan.md
+++ b/docs/REFERENCE/SuburbMates — Corrected Master Architecture and Execution Plan.md
@@ -1,5 +1,11 @@
 # SuburbMates — Corrected Master Architecture and Execution Plan
 
+## Current authority and implementation status — 26 July 2026
+
+This document remains the detailed technical reference only where it agrees with the current [Target State and Operating Authority](./SuburbMates%20%E2%80%94%20Target%20State%20and%20Operating%20Authority.md) and [Decision Log](./SuburbMates%20%E2%80%94%20Decision%20Log.md). The public directory is released. The approved-source deterministic candidate handoff is implemented for new candidates; it retains evidence and may create an unclaimed public listing only after the current qualification policy passes.
+
+The historical sections below that describe a holding-only site, manual-only publication, Gemini-assisted public content, Stripe checkout/webhooks, payment-derived tiers, provider dashboards, or a Payments surface are not an active implementation brief. Billing remains disabled until a separately approved commercial model exists. New work must follow the Target State, Journey Map and Operations Responsibility and Follow-through Map rather than re-enabling those historical designs.
+
 ## Document status
 
 This document consolidates and corrects the complete platform blueprint supplied in this conversation.

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -33,7 +33,7 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Date:** 19 July 2026
 - **Decision:** A business that deterministically qualifies from an approved source is intended to appear in the directory by default as an unclaimed listing. A business does not need to register, claim, provide an ABN or pay before it appears.
 - **Guardrail:** "Found" means an approved, in-scope, identifiable, deduplicated candidate without known material safety or legitimacy concerns. Provenance and the qualifying evidence must be retained. Exceptions remain visible to an operator and audit-recorded.
-- **Current state:** The token-protected OpenStreetMap handoff automatically creates a new unclaimed listing only after deterministic qualification and retained evidence. The existing 1,600-listing cohort completed a private requalification pass on 23 July 2026: 584 qualified and 1,016 exceptions, with no lifecycle or public-visibility change. The public launch gate remains enabled by the owner's release decision.
+- **Current state:** The token-protected OpenStreetMap handoff automatically creates a new unclaimed listing only after deterministic qualification and retained evidence. The existing catalogue completed a private requalification pass under `existing-catalogue-v2` on 26 July 2026: 619 qualified and 982 exceptions across 1,601 listings, with no lifecycle or public-visibility change. The public launch gate remains enabled by the owner's release decision.
 - **Required alignment:** Maintain and prove the qualification, evidence, duplicate, exception and lifecycle controls for every new approved-source candidate.
 - **Evidence to close:** Policy implementation, tests, controlled data-path verification, operator exception evidence and authorised public release verification.
 
@@ -122,7 +122,7 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Decision:** Routine automated exclusions and repeated discovery events remain private audit evidence, not individual operator tasks. A person reviews only records that require genuine judgment, such as a possible duplicate with no separate automatic exclusion.
 - **Decision:** Existing-catalogue evidence gaps are a future batch data-improvement programme. They do not require the operator to process one listing at a time and do not change a listing's visibility by themselves.
 - **Boundary:** A confirmed duplicate, missing customer contact method, or unsupported category is safely held by automation. Automation does not merge uncertain duplicates, publish a held record, assign ownership, or delete evidence.
-- **Verified result:** Home, browse, a populated category route, a representative published profile and the sitemap return successfully. The sitemap contains 1,684 eligible public URLs; canonical and `www` redirect behaviour are correct; released pages no longer carry the holding-page `noindex` directive; `/ops` still redirects unauthenticated visitors to sign-in.
+- **Verified result:** Home, browse, a populated category route, a representative published profile and the sitemap return successfully. The sitemap contains 1,685 eligible public URLs; canonical and `www` redirect behaviour are correct; released pages no longer carry the holding-page `noindex` directive; `/ops` still redirects unauthenticated visitors to sign-in.
 - **Guardrail:** This authorisation does not enable Stripe, general outbound email, bulk ABN checks, AI publication, raw-candidate publication or automated ownership decisions.
 - **Outstanding evidence:** Complete real authenticated owner/submitter and operator walkthroughs, including the candidate-to-Ops, ABN evidence and owner-media paths. Any failure must be recorded and corrected; it is not a reason to publish additional listings.
 
@@ -138,7 +138,7 @@ No branch, pull request, automation run or lane handover changes product policy 
 
 | Deviation | Current truth | Required resolution |
 | --- | --- | --- |
-| Publication policy | New approved-source candidates that pass deterministic qualification become unclaimed public listings with retained evidence. The existing catalogue's 1,016 exceptions remain a private remediation queue; no retrospective visibility decision has been recorded. | Keep new-candidate controls operational and record a separate decision before changing visibility of existing listings. |
+| Publication policy | New approved-source candidates that pass deterministic qualification become unclaimed public listings with retained evidence. The existing catalogue's 982 `existing-catalogue-v2` exceptions remain a private remediation record; no retrospective visibility decision has been recorded. | Keep new-candidate controls operational and record a separate decision before changing visibility of existing listings. |
 | Public product | Public directory release is live with a populated sitemap and indexable released routes. | Maintain production route checks and correct any observed public-data or SEO defect. |
 | Owner and public input | Claim, status, profile correction and missing-business submission paths are implemented, but the real authenticated walkthrough set is not yet recorded. | Complete and record both user and Ops walkthroughs. |
 | Monetisation | Stripe is disabled. | Leave disabled until separately approved commercial scope exists. |

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -140,4 +140,4 @@ Linear records the verified outcome
 
 ## Alignment required
 
-The older manual-publication wording in the Master Architecture, Unified Operations Specification and Handover must be revised to match this owner decision before the default-publication implementation is enabled. Until that alignment and its tests are complete, existing safe-off behaviour remains in force.
+The older manual-publication, holding-posture and billing wording in the Master Architecture, Unified Operations Specification and historical lane records must be clearly marked as superseded where it conflicts with this authority. The current approved-source default-publication implementation is enabled and tested for new candidates; its qualification, evidence and audit controls must remain intact. Existing-catalogue evidence remains private and does not itself change a listing's visibility.

--- a/docs/REFERENCE/SuburbMates — Unified Operations Specification.md
+++ b/docs/REFERENCE/SuburbMates — Unified Operations Specification.md
@@ -1,5 +1,11 @@
 # SuburbMates — Unified Operations Specification
 
+## Current authority and operating posture — 26 July 2026
+
+This is a detailed reference only where it agrees with the current [Target State and Operating Authority](./SuburbMates%20%E2%80%94%20Target%20State%20and%20Operating%20Authority.md), [Decision Log](./SuburbMates%20%E2%80%94%20Decision%20Log.md), and [Operations Responsibility and Follow-through Map](./SuburbMates%20%E2%80%94%20Operations%20Responsibility%20and%20Follow-through%20Map.md). The current protected Ops surface is **Work**, **Businesses** and **System**: Work contains only genuine human decisions; Businesses is the real directory register; System is quiet health/readiness context. Deep workflow routes remain protected implementation details, not top-level daily destinations.
+
+The historical Stripe, Payments, tier, payment-status, provider-dashboard, AI-content and manual-only-publication sections below are not active scope. Billing is off and must remain off until a separately approved commercial model exists. Deterministically qualifying approved-source candidates may become unclaimed listings with retained evidence; raw, uncertain or user-submitted candidates remain private. No future implementation may revive a historical section that conflicts with these controls.
+
 **Document status:** Standalone Phase 1 specification
 **Authority:** Subordinate to the corrected SuburbMates Master Architecture and Execution Plan
 **Primary operator:** One authorised solo operator

--- a/scripts/test-ops-workspace-boundary.ts
+++ b/scripts/test-ops-workspace-boundary.ts
@@ -6,6 +6,8 @@ const layout = fs.readFileSync("web/src/app/ops/layout.tsx", "utf8");
 const page = fs.readFileSync("web/src/app/ops/page.tsx", "utf8");
 const businesses = fs.readFileSync("web/src/app/ops/listings/page.tsx", "utf8");
 const system = fs.readFileSync("web/src/app/ops/system/page.tsx", "utf8");
+const listingDetail = fs.readFileSync("web/src/app/ops/listings/[vendorId]/page.tsx", "utf8");
+const ownerDashboard = fs.readFileSync("web/src/app/(directory)/dashboard/page.tsx", "utf8");
 const registerMigration = fs.readFileSync("supabase/migrations/20260725120000_alphabetical_ops_business_register.sql", "utf8");
 const globalStyles = fs.readFileSync("web/src/app/globals.css", "utf8");
 const navigationMigration = fs.readFileSync("supabase/migrations/20260725133000_complete_ops_navigation_filters.sql", "utf8");
@@ -41,6 +43,8 @@ assert.match(navigationMigration, /p_listing_source TEXT DEFAULT NULL/);
 assert.match(navigationMigration, /p_record_id UUID DEFAULT NULL/);
 assert.match(system, /Commercial readiness/);
 assert.match(system, /Billing is off/);
+assert.doesNotMatch(listingDetail, /listing\.tier|Premium presentation/, "Ops detail must not expose a billing presentation while billing is off.");
+assert.doesNotMatch(ownerDashboard, /vendor\.tier|>Premium</, "Owner dashboard must not advertise an unapproved paid tier.");
 assert.match(globalStyles, /@layer base\s*\{[\s\S]*?a\s*\{[\s\S]*?color:\s*inherit;/);
 for (const forbidden of ["work_items", "realtime", "Stripe checkout", "subscription", "invoice", "ABN request"]) {
   assert(!page.includes(forbidden) && !work.includes(forbidden), `Ops Work must not introduce ${forbidden}`);

--- a/scripts/test-resident-journey-policy.ts
+++ b/scripts/test-resident-journey-policy.ts
@@ -6,12 +6,13 @@ async function source(path: string) {
 }
 
 async function run() {
-  const [home, browse, taxonomy, profile, contact] = await Promise.all([
+  const [home, browse, taxonomy, profile, contact, directoryLayout] = await Promise.all([
     source("web/src/app/(directory)/page.tsx"),
     source("web/src/app/(directory)/businesses/page.tsx"),
     source("web/src/app/(directory)/[suburb]/[service]/page.tsx"),
     source("web/src/app/vendor/[slug]/page.tsx"),
     source("web/src/components/minisite/contact/ContactComponents.tsx"),
+    source("web/src/app/(directory)/layout.tsx"),
   ]);
 
   assert.match(home, /NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED/, "public home must remain behind the launch flag");
@@ -22,6 +23,8 @@ async function run() {
   assert.doesNotMatch(taxonomy, /tier === "premium"/, "taxonomy results must not present an unapproved premium tier");
   assert.match(contact, /google\.com\/maps\/search/, "public address must provide a directions action");
   assert.match(profile, /listing_correction/, "profiles must provide a safe report-problem entry point");
+  assert.match(directoryLayout, /Skip to main content/, "public pages must offer a keyboard skip link");
+  assert.match(directoryLayout, /hidden[^\"]*sm:block/, "the fixed header must avoid mobile tagline overlap");
 
   console.log("Resident journey policy tests passed.");
 }

--- a/web/src/app/(directory)/dashboard/page.tsx
+++ b/web/src/app/(directory)/dashboard/page.tsx
@@ -12,7 +12,6 @@ type OwnerVendor = {
   business_name: string
   suburb_slug: string | null
   category_slug: string | null
-  tier: string
   is_published: boolean
   street_address: string | null
   contact_email: string | null
@@ -145,9 +144,6 @@ export default async function DashboardPage() {
                           <span className="text-[10px] font-bold uppercase tracking-wider bg-green-100 text-green-800 px-2 py-0.5 rounded">Published</span>
                         ) : (
                           <span className="text-[10px] font-bold uppercase tracking-wider bg-yellow-100 text-yellow-800 px-2 py-0.5 rounded">Draft</span>
-                        )}
-                        {vendor.tier === 'premium' && (
-                          <span className="text-[10px] font-bold uppercase tracking-wider bg-black text-white px-2 py-0.5 rounded">Premium</span>
                         )}
                       </div>
                       <p className="text-sm text-slate-500">

--- a/web/src/app/(directory)/layout.tsx
+++ b/web/src/app/(directory)/layout.tsx
@@ -9,6 +9,12 @@ export default function DirectoryLayout({
 }>) {
   return (
     <div className="min-h-screen flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only absolute left-4 top-4 z-50 rounded-lg bg-white px-4 py-3 font-bold text-black shadow-lg focus:not-sr-only focus:outline-none focus:ring-4 focus:ring-black"
+      >
+        Skip to main content
+      </a>
       {/* ── Header ───────────────────────────────────────── */}
       <header className="fixed top-0 left-0 right-0 z-40 backdrop-blur-md border-b"
         style={{
@@ -16,26 +22,26 @@ export default function DirectoryLayout({
           borderColor: "var(--sm-border)",
         }}
       >
-        <div className="max-w-7xl mx-auto px-6 h-20 flex items-center justify-between">
+        <div className="max-w-7xl mx-auto h-16 px-4 sm:h-20 sm:px-6 flex items-center justify-between gap-3">
 
           {/* Logo */}
           <Link
             href="/"
-            className="text-2xl font-black tracking-tighter uppercase focus-visible:outline-none rounded"
+            className="text-xl font-black tracking-tighter uppercase focus-visible:outline-none rounded sm:text-2xl"
             style={{ color: "var(--sm-text-primary)" }}
             aria-label="SuburbMates home"
           >
             SuburbMates
           </Link>
 
-          <p className="text-xs font-bold uppercase tracking-[0.16em]" style={{ color: "var(--sm-text-tertiary)" }}>
+          <p className="hidden text-xs font-bold uppercase tracking-[0.16em] sm:block" style={{ color: "var(--sm-text-tertiary)" }}>
             {publicLaunchEnabled ? "Discover local businesses" : "Preparing for launch"}
           </p>
         </div>
       </header>
 
       {/* ── Main ─────────────────────────────────────────── */}
-      <main className="flex-grow pt-20" id="main-content">
+      <main className="flex-grow pt-16 sm:pt-20" id="main-content">
         {children}
       </main>
 

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -19,7 +19,6 @@ type Listing = {
   listing_source: string | null;
   ownership_status: string;
   is_published: boolean;
-  tier: string;
   moderation_reason: string | null;
   active_draft_id: string | null;
   draft_values: Record<string, string | null> | null;
@@ -80,7 +79,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
         <div>
           <p className="text-sm font-bold uppercase tracking-[0.18em] text-slate-500">Listing review</p>
           <h2 className="mt-2 text-4xl font-black tracking-tight">{listing.business_name}</h2>
-          <p className="mt-2 text-slate-600">{statusLabel(status ?? "unclassified")} · {listing.ownership_status} · {listing.tier}</p>
+          <p className="mt-2 text-slate-600">{statusLabel(status ?? "unclassified")} · {listing.ownership_status}</p>
         </div>
         {listing.is_published && publicSlug && <Link href={`/vendor/${publicSlug}`} className="btn btn-outline">View public profile</Link>}
       </div>
@@ -105,7 +104,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">ABN check</h3>
-        <p className="mt-2 text-sm text-slate-600">Use this only for a supplied ABN. The result is private evidence. It never publishes a listing, confirms ownership, changes ranking or changes a plan.</p>
+        <p className="mt-2 text-sm text-slate-600">Use this only for a supplied ABN. The result is private evidence. It never publishes a listing, confirms ownership, changes ranking or changes commercial status.</p>
         <form action={runAbnCheckAction} className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-end">
           <input type="hidden" name="vendorId" value={vendorId} />
           <label className="block flex-1 text-sm font-bold">ABN<input name="abn" inputMode="numeric" pattern="[0-9 ]{11,20}" maxLength={20} required placeholder="11 digits" className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label>
@@ -136,7 +135,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
 
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <h3 className="text-xl font-bold">Lifecycle action</h3>
-        <p className="mt-2 text-sm text-slate-600">Publication is your explicit decision. Ownership, ABN, payment and tier remain unchanged. Your decision note becomes a permanent record.</p>
+        <p className="mt-2 text-sm text-slate-600">Publication is your explicit decision. Ownership and ABN evidence remain unchanged. Your decision note becomes a permanent record.</p>
         <form action={decideListingAction} className="mt-5 space-y-4">
           <input type="hidden" name="vendorId" value={vendorId} />
           {(status === "pending_review" || status === "published") && listing.active_draft_id && (
@@ -184,12 +183,12 @@ function statusLabel(status: string) {
 
 function AbnResult({ status }: { status: string }) {
   const message = {
-    active: "ABN is active. The result has been saved as private evidence. It has not changed publication, ownership, ranking or plan.",
+    active: "ABN is active. The result has been saved as private evidence. It has not changed publication, ownership, ranking or commercial status.",
     inactive: "ABN is not active. The result has been saved as private evidence. Review it alongside the rest of the listing evidence.",
     invalid: "This number did not pass ABN validation. No external lookup was made; the result has been recorded privately.",
     not_found: "ABN Lookup did not find this number. The result has been saved as private evidence for review.",
     provider_failure: "ABN Lookup could not complete the check. Nothing else changed; try again later.",
-  }[status] ?? "ABN check recorded. It has not changed publication, ownership, ranking or plan.";
+  }[status] ?? "ABN check recorded. It has not changed publication, ownership, ranking or commercial status.";
   const caution = status !== "active";
   return <p role={caution ? "status" : undefined} className={`rounded-xl border p-4 font-semibold ${caution ? "border-amber-300 bg-amber-50 text-amber-900" : "border-green-300 bg-green-50 text-green-800"}`}>{message}</p>;
 }
@@ -224,5 +223,5 @@ const unpublishReasons = [
   { value: "inaccurate_listing", label: "Inaccurate listing" }, { value: "duplicate_listing", label: "Duplicate listing" },
   { value: "ownership_dispute", label: "Ownership dispute" }, { value: "privacy_or_legal_concern", label: "Privacy or legal concern" },
   { value: "investigation", label: "Investigation" }, { value: "operator_decision", label: "Operator decision" },
-  { value: "payment_presentation_correction", label: "Premium presentation correction only" }, { value: "other", label: "Other" },
+  { value: "other", label: "Other" },
 ] as const;


### PR DESCRIPTION
## What changed
- fixes the observed narrow-screen public-header overlap and adds a keyboard skip link
- removes inactive paid-tier presentation from owner and protected listing views
- reconciles current release, deterministic-qualification and catalogue-v2 facts across authority and handover documents

## Boundaries
- no schema migration, listing mutation, billing activation, new sender, or integration change

## Verification
- `npm run check`
- `npm --prefix web run lint` (3 existing image warnings only)
- `npm --prefix web run build`
- `npm --prefix web run cf:build`
- read-only production smoke: 1,601 vendors, 1,685 sitemap URLs
- local in-app-browser public/mobile and keyboard checks