### PR TITLE
Restore website safety manual dispatch

### DIFF
--- a/.github/workflows/website-safety.yml
+++ b/.github/workflows/website-safety.yml
@@ -3,7 +3,7 @@ name: Website safety evidence
 on:
   schedule:
     - cron: "41 8 * * 1"
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/scripts/test-website-safety.mjs
+++ b/scripts/test-website-safety.mjs
@@ -19,6 +19,7 @@ await assert.rejects(
   /ended early/,
 );
 const workflow = fs.readFileSync(".github/workflows/website-safety.yml", "utf8");
+assert.match(workflow, /workflow_dispatch: \{\}/);
 assert.match(workflow, /Record evidence summary/);
 assert.doesNotMatch(workflow, /Fail when review is needed/);
 assert.doesNotMatch(workflow, /website check\(s\) need review/);


### PR DESCRIPTION
Fixes the GitHub Actions registry not recognising the workflow's blank manual-dispatch trigger. No workflow behaviour changes beyond making the existing manual run capability explicit.\n\nVerification: npm run website-safety:test