### PR TITLE
Fix website safety workflow parsing

### DIFF
--- a/.github/workflows/website-safety.yml
+++ b/.github/workflows/website-safety.yml
@@ -35,4 +35,5 @@ jobs:
           if-no-files-found: error
           path: artifacts/website-safety-report.json
       - name: Record evidence summary
-        run: node -e 'const report=require("./artifacts/website-safety-report.json"); console.log(`Website evidence retained: ${report.total} checked, ${report.flagged} background exception(s).`);'
+        run: |
+          node -e 'const report=require("./artifacts/website-safety-report.json"); console.log(`Website evidence retained: ${report.total} checked, ${report.flagged} background exception(s).`);'

--- a/scripts/test-website-safety.mjs
+++ b/scripts/test-website-safety.mjs
@@ -21,6 +21,7 @@ await assert.rejects(
 const workflow = fs.readFileSync(".github/workflows/website-safety.yml", "utf8");
 assert.match(workflow, /workflow_dispatch: \{\}/);
 assert.match(workflow, /Record evidence summary/);
+assert.match(workflow, /Record evidence summary\n\s+run: \|/);
 assert.doesNotMatch(workflow, /Fail when review is needed/);
 assert.doesNotMatch(workflow, /website check\(s\) need review/);
 assert.doesNotMatch(workflow, /issues: write/);


### PR DESCRIPTION
GitHub could not register or run Website Safety because the one-line summary command made the YAML invalid. Uses a YAML block scalar instead and adds a regression assertion.\n\nVerification: YAML parser and npm run website-safety:test.