### PR TITLE
Preload the public home hero

### DIFF
--- a/scripts/test-resident-journey-policy.ts
+++ b/scripts/test-resident-journey-policy.ts
@@ -6,8 +6,9 @@ async function source(path: string) {
 }
 
 async function run() {
-  const [home, browse, taxonomy, profile, contact, directoryLayout] = await Promise.all([
+  const [home, homeClient, browse, taxonomy, profile, contact, directoryLayout] = await Promise.all([
     source("web/src/app/(directory)/page.tsx"),
+    source("web/src/components/ui/HomeClient.tsx"),
     source("web/src/app/(directory)/businesses/page.tsx"),
     source("web/src/app/(directory)/[suburb]/[service]/page.tsx"),
     source("web/src/app/vendor/[slug]/page.tsx"),
@@ -17,6 +18,7 @@ async function run() {
 
   assert.match(home, /NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED/, "public home must remain behind the launch flag");
   assert.match(home, /<LaunchPage\s*\/>/, "holding home must remain available before release");
+  assert.match(homeClient, /ReactDOM\.preload\("\/hero-bg\.jpg", \{ as: "image", fetchPriority: "high" \}\)/, "the public hero image must preload at high priority");
   assert.match(browse, /vendorsError/, "directory fetch failures must not appear as an empty result");
   assert.match(taxonomy, /vendorsRes\.error/, "taxonomy fetch failures must not appear as an empty result");
   assert.doesNotMatch(browse, /tier === "premium"/, "public browse must not present an unapproved premium tier");

--- a/web/src/components/ui/HomeClient.tsx
+++ b/web/src/components/ui/HomeClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import ReactDOM from "react-dom";
 import { HeroSearch } from "@/components/ui/HeroSearch";
 import { createClient } from "@/utils/supabase/client";
 import Link from "next/link";
@@ -53,6 +54,10 @@ const valueProps = [
 
 export function HomeClient({ categories, suburbs, featuredVendors }: HomeClientProps) {
   const router = useRouter();
+
+  // This is the only above-the-fold image on the public home. The CSS background
+  // would otherwise be discovered after the page body is parsed.
+  ReactDOM.preload("/hero-bg.jpg", { as: "image", fetchPriority: "high" });
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.hash.slice(1));


### PR DESCRIPTION
## Summary
- preload the only above-the-fold public home image at high priority
- retain a resident-journey regression check for the preload

## Verification
- npm run resident-journey:test
- npm --prefix web run lint
- npm --prefix web run build
- npm --prefix web run cf:build
- npm run check
- rendered production-mode home HTML contains the expected preload hint