### PR TITLE
Add protected rejected listing deletion

### DIFF
--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -134,6 +134,14 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Current state:** The existing-catalogue requalification policy is versioned to re-run under this rule. It changes only private evidence status; it does not delete, merge, publish, unpublish, claim or alter any business record.
 - **Evidence to close:** Regression coverage for shared-address businesses, a completed requalification run, and an Ops Work list with address-only false positives removed.
 
+### D-015 — Exceptional deletion of rejected listings
+
+- **Date:** 31 July 2026
+- **Decision:** The operator may permanently delete one rejected listing from its protected detail view when it was never public and has no linked operational records. A reason and an explicit `DELETE` confirmation are required.
+- **Guardrail:** This is not bulk clean-up, does not apply to a public or previously public listing, and must retain an append-only audit event. A record with claims, evidence, drafts, submissions, candidate/requalification links, media or redirect history remains retained.
+- **Current state:** The 21 reviewed, never-public rejected legacy records were owner-authorised for deletion. Their audit history was retained.
+- **Evidence to close:** Protected-function, UI-boundary and database verification; an authenticated operator walkthrough when a future eligible rejected record exists.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/docs/REFERENCE/SuburbMates — Listing Lifecycle and Release-State Contract.md
+++ b/docs/REFERENCE/SuburbMates — Listing Lifecycle and Release-State Contract.md
@@ -32,6 +32,7 @@ This contract turns the owner-approved directory policy into a buildable model. 
 3. **Public release remains separate:** a `published` listing becomes publicly browseable only while the global launch gate is enabled. The owner authorised the first public release on 23 July 2026; future release or rollback remains governed by `SUB-14`, not an import or claim.
 4. **Claims remain independent:** the approved normal exact-email path and its future exception/revocation flow never publish a listing or change commercial/SEO state.
 5. **Evidence remains precise:** an ABN or website result is stored as supporting evidence. It is not a universal entry requirement.
+6. **Exceptional permanent deletion:** a protected operator may permanently delete one rejected listing only when it was never public and has no linked operational records. The operator must provide a reason and explicit confirmation; an append-only audit event remains. This is not a bulk clean-up tool and does not apply to public, unpublished or linked records.
 
 ## Allowed lifecycle transitions
 

--- a/docs/REFERENCE/SuburbMates — Unified Operations Specification.md
+++ b/docs/REFERENCE/SuburbMates — Unified Operations Specification.md
@@ -1922,7 +1922,7 @@ Use it directly only for:
 * Missing ABN status does not block publication.
 * Payment status does not control publication.
 * AI output cannot control publication.
-* Rejected listings are retained with reasons.
+* Rejected listings are retained with reasons by default. A never-public rejected listing with no linked operational records may be permanently deleted through the protected detail action, with an explicit reason, confirmation and retained audit event.
 * Every privileged action creates an audit record.
 
 ## 23.3 Claims
@@ -2003,7 +2003,6 @@ The following are deliberately deferred until the core Ops system is stable:
 * real-time analytics warehouse
 * custom report builder
 * complete native-dashboard parity
-* permanent rejected-record purge UI
 * configurable notification centre
 * advanced bulk SEO inspection
 
@@ -2018,7 +2017,7 @@ These must be resolved during repository analysis and must not be silently assum
 3. Claim-verification method.
 4. Premium billing model: recurring, fixed-duration or both.
 5. Slug changes and redirect policy.
-6. Rejected-record retention period.
+6. Rejected-record retention/purge criteria for records that do not meet the protected permanent-deletion conditions.
 7. Exact Search Console OAuth and property model.
 8. Exact Cloudflare datasets available under the account plan.
 9. Cloudflare warning thresholds.

--- a/package.json
+++ b/package.json
@@ -42,8 +42,9 @@
     "submitter-owner-identity:test": "tsx scripts/test-submitter-owner-identity-boundary.ts",
     "owner-submitted-business-candidate:test": "tsx scripts/test-owner-submitted-business-candidate-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
-    "ops-action-queue:test": "tsx scripts/test-ops-action-queue-boundary.ts && npm run ops-workspace:test",
+    "ops-action-queue:test": "tsx scripts/test-ops-action-queue-boundary.ts && npm run ops-workspace:test && npm run rejected-listing-deletion:test",
     "ops-workspace:test": "tsx scripts/test-ops-workspace-boundary.ts",
+    "rejected-listing-deletion:test": "tsx scripts/test-rejected-listing-deletion-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"
   },
   "devDependencies": {

--- a/scripts/test-rejected-listing-deletion-boundary.ts
+++ b/scripts/test-rejected-listing-deletion-boundary.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const migration = fs.readFileSync("supabase/migrations/20260731094423_delete_rejected_ops_listings.sql", "utf8");
+const actions = fs.readFileSync("web/src/app/ops/listings/actions.ts", "utf8");
+const detail = fs.readFileSync("web/src/app/ops/listings/[vendorId]/page.tsx", "utf8");
+
+assert.match(migration, /private\.require_active_operator\(\)/);
+assert.match(migration, /listing_status IS DISTINCT FROM 'rejected'/);
+assert.match(migration, /is_published OR v_vendor\.published_at IS NOT NULL/);
+assert.match(migration, /rejected_listing_permanently_deleted/);
+assert.match(migration, /REVOKE ALL ON FUNCTION public\.ops_delete_rejected_listing/);
+assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.ops_delete_rejected_listing\(UUID, TEXT\) TO authenticated/);
+assert.match(actions, /confirmation !== "DELETE"/);
+assert.match(actions, /ops_delete_rejected_listing/);
+assert.match(detail, /status === "rejected"/);
+assert.match(detail, /Permanently delete rejected listing/);
+assert.match(detail, /Type DELETE to confirm/);
+
+console.log("Rejected-listing deletion boundary checks passed.");

--- a/supabase/migrations/20260731094423_delete_rejected_ops_listings.sql
+++ b/supabase/migrations/20260731094423_delete_rejected_ops_listings.sql
@@ -1,0 +1,69 @@
+-- A permanent deletion is exceptional. It is available only for a never-public
+-- rejected listing with no linked operational records, and it retains an
+-- append-only audit event after the vendor row is removed.
+
+CREATE FUNCTION public.ops_delete_rejected_listing(
+  p_vendor_id UUID,
+  p_operator_note TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_operator_id UUID := private.require_active_operator();
+  v_note TEXT := nullif(trim(coalesce(p_operator_note, '')), '');
+  v_vendor public.vendors%ROWTYPE;
+BEGIN
+  IF v_note IS NULL OR length(v_note) > 2000 THEN
+    RAISE EXCEPTION USING ERRCODE = '22023', MESSAGE = 'A deletion reason between 1 and 2,000 characters is required.';
+  END IF;
+
+  SELECT * INTO v_vendor
+  FROM public.vendors AS vendor
+  WHERE vendor.id = p_vendor_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION USING ERRCODE = '02000', MESSAGE = 'Listing not found.';
+  END IF;
+  IF v_vendor.listing_status IS DISTINCT FROM 'rejected' OR v_vendor.is_published OR v_vendor.published_at IS NOT NULL THEN
+    RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'Only a never-public rejected listing can be permanently deleted.';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.claim_requests WHERE vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.listing_evidence WHERE vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.listing_change_requests WHERE vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.operator_listing_drafts WHERE vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.vendor_slug_redirects WHERE vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.business_submission_requests WHERE vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.candidate_handoff_records WHERE vendor_id = p_vendor_id OR duplicate_vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.listing_media_proposals WHERE vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.existing_catalogue_requalification_records WHERE vendor_id = p_vendor_id OR duplicate_vendor_id = p_vendor_id)
+    OR EXISTS (SELECT 1 FROM public.emails_queue WHERE vendor_id = p_vendor_id) THEN
+    RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'This rejected listing has linked operational records and must be retained.';
+  END IF;
+
+  INSERT INTO public.audit_events (
+    actor_type, actor_user_id, action, entity_type, entity_id, reason, before_data, after_data
+  ) VALUES (
+    'operator', v_operator_id, 'rejected_listing_permanently_deleted', 'vendor', p_vendor_id::text, v_note,
+    jsonb_build_object(
+      'business_name', v_vendor.business_name,
+      'listing_status', v_vendor.listing_status,
+      'is_published', v_vendor.is_published,
+      'moderation_reason', v_vendor.moderation_reason,
+      'rejected_at', v_vendor.rejected_at
+    ),
+    jsonb_build_object('deleted', true)
+  );
+
+  DELETE FROM public.vendors WHERE id = p_vendor_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ops_delete_rejected_listing(UUID, TEXT) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.ops_delete_rejected_listing(UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION public.ops_delete_rejected_listing(UUID, TEXT) IS
+  'Operator-only permanent deletion for one never-public rejected listing with no linked operational records; audit history remains.';

--- a/web/src/app/ops/listings/[vendorId]/page.tsx
+++ b/web/src/app/ops/listings/[vendorId]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { createOpsDataClient } from "@/lib/ops/auth";
 import { formatOpsDateTime } from "@/lib/ops/date";
-import { decideListingAction, decideMediaProposalAction, runAbnCheckAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
+import { decideListingAction, decideMediaProposalAction, deleteRejectedListingAction, runAbnCheckAction, saveListingDraftAction, setBusinessSubmissionStatusAction } from "../actions";
 import { createAdminClient } from "@/utils/supabase/admin";
 
 type Listing = {
@@ -85,7 +85,7 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
         {listing.is_published && publicSlug && <Link href={`/vendor/${publicSlug}`} className="btn btn-outline">View public profile</Link>}
       </div>
 
-      {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 font-semibold text-red-800">{message.error === "draft" ? "The draft could not be saved. Check required fields and formats." : message.error === "abn" ? "The ABN check could not be recorded. Enter 11 digits and try again." : "The action failed. Refresh and check the listing state, draft and reason."}</p>}
+      {message.error && <p role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 font-semibold text-red-800">{message.error === "draft" ? "The draft could not be saved. Check required fields and formats." : message.error === "abn" ? "The ABN check could not be recorded. Enter 11 digits and try again." : message.error === "delete" ? "This record could not be deleted. Only a never-public rejected listing with no linked operational records can be permanently deleted." : "The action failed. Refresh and check the listing state, draft and reason."}</p>}
       {abnStatus && <AbnResult status={abnStatus} />}
       {successfulAction && <p className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">{success === "draft" ? "Operator draft saved. The public listing and sitemap were not changed." : "Decision recorded with an audit event."}</p>}
 
@@ -155,6 +155,17 @@ export default async function OpsListingDetailPage({ params, searchParams }: {
         {status === "pending_review" && <ReasonDecision vendorId={vendorId} decision="reject" label="Reject listing" reasons={rejectReasons} />}
         {status === "published" && <ReasonDecision vendorId={vendorId} decision="unpublish" label="Unpublish listing" reasons={unpublishReasons} />}
       </section>
+
+      {status === "rejected" && <section className="rounded-2xl border border-red-200 bg-red-50 p-6 shadow-sm">
+        <h3 className="text-xl font-bold text-red-950">Permanently delete rejected listing</h3>
+        <p className="mt-2 text-sm text-red-900">Use this only when this never-public rejected record is no longer needed. It cannot be restored. Its audit history remains.</p>
+        <form action={deleteRejectedListingAction} className="mt-5 space-y-4">
+          <input type="hidden" name="vendorId" value={vendorId} />
+          <label className="block text-sm font-bold text-red-950">Why delete this record?<textarea name="operatorNote" required maxLength={2000} rows={3} className="mt-2 w-full rounded-xl border border-red-300 bg-white p-3 font-normal text-slate-950" placeholder="Record why permanent deletion is appropriate." /></label>
+          <label className="block text-sm font-bold text-red-950">Type DELETE to confirm<input name="confirmation" required autoComplete="off" className="mt-2 w-full rounded-xl border border-red-300 bg-white p-3 font-normal text-slate-950" /></label>
+          <button className="btn border-red-800 bg-red-800 text-white hover:bg-red-900">Permanently delete listing</button>
+        </form>
+      </section>}
     </div>
   );
 }

--- a/web/src/app/ops/listings/actions.ts
+++ b/web/src/app/ops/listings/actions.ts
@@ -121,6 +121,28 @@ export async function decideListingAction(formData: FormData) {
   redirect(`${detailPath}?success=${encodeURIComponent(decision)}`);
 }
 
+export async function deleteRejectedListingAction(formData: FormData) {
+  const vendorId = String(formData.get("vendorId") ?? "");
+  const confirmation = String(formData.get("confirmation") ?? "");
+  const note = String(formData.get("operatorNote") ?? "").trim();
+  const detailPath = `/ops/listings/${vendorId}`;
+  const { supabase } = await verifyOpsAdmin(detailPath);
+  if (!uuidPattern.test(vendorId) || confirmation !== "DELETE" || note.length < 1 || note.length > 2000) {
+    redirect(`${detailPath}?error=delete`);
+  }
+  const { error } = await supabase.rpc("ops_delete_rejected_listing", {
+    p_vendor_id: vendorId,
+    p_operator_note: note,
+  });
+  if (error) redirect(`${detailPath}?error=delete`);
+  revalidatePath("/ops");
+  revalidatePath("/ops/listings");
+  revalidatePath("/");
+  revalidatePath("/businesses");
+  revalidatePath("/sitemap.xml");
+  redirect("/ops/listings?status=rejected&success=deleted");
+}
+
 function nullable(value: FormDataEntryValue | null) {
   const normalized = String(value ?? "").trim();
   return normalized || null;

--- a/web/src/app/ops/listings/page.tsx
+++ b/web/src/app/ops/listings/page.tsx
@@ -22,11 +22,12 @@ type OpsListing = {
   active_draft_id: string | null;
 };
 
-export default async function OpsListingsPage({ searchParams }: { searchParams: Promise<{ status?: string; ownership?: string; source?: string; q?: string; page?: string }> }) {
+export default async function OpsListingsPage({ searchParams }: { searchParams: Promise<{ status?: string; ownership?: string; source?: string; q?: string; page?: string; success?: string }> }) {
   const params = await searchParams;
   const status = statuses.includes(params.status as Status) ? (params.status as Status) : "all";
   const ownership = ownershipStatuses.includes(params.ownership as OwnershipStatus) ? (params.ownership as OwnershipStatus) : "all";
   const source = sources.includes(params.source as Source) ? (params.source as Source) : "all";
+  const success = params.success ?? "";
   const q = typeof params.q === "string" ? params.q.slice(0, 200) : "";
   const page = pageNumber(params.page);
   const supabase = await createOpsDataClient();
@@ -53,6 +54,8 @@ export default async function OpsListingsPage({ searchParams }: { searchParams: 
         <h2 className="mt-2 text-4xl font-black tracking-tight">Business register</h2>
         <p className="mt-3 max-w-3xl text-slate-600">Search real directory records and open one business to see its authorised evidence, requests and safe actions. Private candidate records are not businesses.</p>
       </div>
+
+      {success === "deleted" && <p role="status" className="rounded-xl border border-green-300 bg-green-50 p-4 font-semibold text-green-800">The rejected listing was permanently deleted. Its audit history remains.</p>}
 
       <form className="grid max-w-3xl gap-3 sm:grid-cols-[1fr_auto_auto_auto]" action="/ops/listings">
         <input type="hidden" name="status" value={status} />


### PR DESCRIPTION
## Scope\n- add a protected, individually confirmed delete action for never-public rejected listings\n- retain append-only deletion audit evidence\n- reject deletion if linked operational records exist\n- record the owner-approved policy\n\n## Verification\n- npm run check\n- npm --prefix web run lint\n- npm --prefix web run build\n- remote database migration dry-run in a rolled-back transaction\n\nNo billing, publication, claim, ABN, sender, or workflow changes.