### PR TITLE
Fix business submission feedback and category search

### DIFF
--- a/scripts/test-owner-submitted-business-candidate-boundary.ts
+++ b/scripts/test-owner-submitted-business-candidate-boundary.ts
@@ -13,9 +13,14 @@ assert.match(migration, /'publication_unchanged', true/);
 assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.submit_owned_business_candidate_for_current_user[\s\S]*TO authenticated/);
 assert.match(actions, /submit_owned_business_candidate_for_current_user/);
 assert.match(actions, /createClient\(\)/);
+assert.match(actions, /verifyBusinessSubmission\(fields\.token, next\)/);
+assert.match(actions, /fail\(error\.code, next\)/);
 assert.match(join, /I own or represent it/);
 assert.match(join, /Suggest a local business/);
 assert.match(join, /Submit business and ownership request/);
+assert.match(join, /CategoryField/);
+assert.match(join, /Submitting securely/);
+assert.match(join, /min-w-0/);
 for (const forbidden of ["is_published = true", "SET owner_id =", "is_claimed = true", "TO anon"]) {
   assert(!migration.includes(forbidden), `Owner candidate flow must not contain ${forbidden}.`);
 }

--- a/web/src/app/(directory)/join/JoinFormControls.tsx
+++ b/web/src/app/(directory)/join/JoinFormControls.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+type Option = { name: string; slug: string };
+
+export function CategoryField({ options }: { options: Option[] }) {
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<Option | null>(null);
+  const [open, setOpen] = useState(false);
+  const listId = useId();
+  const matches = useMemo(() => {
+    const term = query.trim().toLocaleLowerCase();
+    if (!term) return options.slice(0, 8);
+    return options.filter((option) => option.name.toLocaleLowerCase().includes(term)).slice(0, 8);
+  }, [options, query]);
+
+  function choose(option: Option) {
+    setSelected(option);
+    setQuery(option.name);
+    setOpen(false);
+  }
+
+  return <div className="relative min-w-0 text-sm font-bold">
+    <label htmlFor={listId}>Category</label>
+    <input type="hidden" name="categorySlug" value={selected?.slug ?? ""} />
+    <input
+      id={listId}
+      type="search"
+      value={query}
+      autoComplete="off"
+      placeholder="Start typing a category"
+      role="combobox"
+      aria-autocomplete="list"
+      aria-controls={`${listId}-options`}
+      aria-expanded={open}
+      aria-invalid={query.length > 0 && !selected}
+      onChange={(event) => { setQuery(event.target.value); setSelected(null); setOpen(true); }}
+      onFocus={() => setOpen(true)}
+      className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal"
+    />
+    <p className="mt-2 text-xs font-normal leading-5 text-slate-600">Type to find and choose a category.</p>
+    {open && <ul id={`${listId}-options`} role="listbox" className="absolute z-10 mt-2 max-h-64 w-full overflow-auto rounded-xl border border-slate-200 bg-white p-1 shadow-lg">
+      {matches.length > 0 ? matches.map((option) => <li key={option.slug} role="option" aria-selected={selected?.slug === option.slug}>
+        <button type="button" onMouseDown={(event) => event.preventDefault()} onClick={() => choose(option)} className="w-full rounded-lg px-3 py-2 text-left text-sm font-medium hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-indigo-600">{option.name}</button>
+      </li>) : <li className="px-3 py-2 text-sm font-normal text-slate-600">No matching category. Try another term.</li>}
+    </ul>}
+  </div>;
+}
+
+export function SubmitButton({ children, pendingLabel }: { children: string; pendingLabel: string }) {
+  const { pending } = useFormStatus();
+  return <button disabled={pending} className="btn btn-primary" aria-describedby="submission-progress">{pending ? pendingLabel : children}<span id="submission-progress" className="sr-only" aria-live="polite">{pending ? " Submission in progress." : ""}</span></button>;
+}

--- a/web/src/app/(directory)/join/actions.ts
+++ b/web/src/app/(directory)/join/actions.ts
@@ -5,8 +5,8 @@ import { TurnstileVerificationError, verifyTurnstileToken } from "@/lib/turnstil
 import { createAdminClient } from "@/utils/supabase/admin";
 import { createClient } from "@/utils/supabase/server";
 
-function fail(code: string): never {
-  redirect(`/join?error=${encodeURIComponent(code)}`);
+function fail(code: string, next = "/join"): never {
+  redirect(`${next}${next.includes("?") ? "&" : "?"}error=${encodeURIComponent(code)}`);
 }
 
 function readBusinessFields(formData: FormData) {
@@ -39,12 +39,12 @@ function validBusinessFields(fields: ReturnType<typeof readBusinessFields>) {
   );
 }
 
-async function verifyBusinessSubmission(token: string) {
+async function verifyBusinessSubmission(token: string, next?: string) {
   try {
     return await verifyTurnstileToken(token, "business_submission");
   } catch (error) {
-    if (error instanceof TurnstileVerificationError) fail(error.code);
-    fail("verification");
+    if (error instanceof TurnstileVerificationError) fail(error.code, next);
+    fail("verification", next);
   }
 }
 
@@ -106,7 +106,7 @@ export async function submitOwnedBusinessAction(formData: FormData) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user?.email) redirect(`/login?next=${encodeURIComponent(next)}`);
-  const verification = await verifyBusinessSubmission(fields.token);
+  const verification = await verifyBusinessSubmission(fields.token, next);
 
   const { error } = await supabase.rpc("submit_owned_business_candidate_for_current_user", {
     p_submitter_name: fields.submitterName,

--- a/web/src/app/(directory)/join/page.tsx
+++ b/web/src/app/(directory)/join/page.tsx
@@ -4,6 +4,7 @@ import Script from "next/script";
 import { runtimeEnv } from "@/lib/runtime-env";
 import { createClient } from "@/utils/supabase/server";
 import { submitBusinessAction, submitOwnedBusinessAction } from "./actions";
+import { CategoryField, SubmitButton } from "./JoinFormControls";
 
 export const dynamic = "force-dynamic";
 
@@ -84,12 +85,12 @@ export default async function JoinPage({ searchParams }: {
         {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
 
         {!siteKey ? <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Secure business submission is temporarily unavailable. You can still search and claim an existing listing.</p> : (
-          <form action={submitBusinessAction} className="mt-6 grid gap-5 sm:grid-cols-2">
+          <form action={submitBusinessAction} className="mt-6 grid min-w-0 gap-5 sm:grid-cols-2">
             <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
             <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
             <div><Field label="Your email" name="submitterEmail" type="email" required maxLength={254} autoComplete="email" /><p className="mt-2 text-xs font-normal leading-5 text-slate-600">No account is created. This is only used if you later choose to check the private submission status.</p></div>
             <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
-            <Select label="Category" name="categorySlug" options={categoriesResult.data ?? []} />
+            <CategoryField options={categoriesResult.data ?? []} />
             <Select label="Location" name="suburbSlug" options={suburbsResult.data ?? []} />
             <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" />
             <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" />
@@ -99,7 +100,7 @@ export default async function JoinPage({ searchParams }: {
             <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" />
             <label className="flex items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4" /><span>I confirm these are genuine business details and agree that SuburbMates may review them for directory publication as described in the <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
             <div className="sm:col-span-2"><div className="cf-turnstile" data-sitekey={siteKey} data-action="business_submission" data-theme="light" /></div>
-            <div className="sm:col-span-2"><button className="btn btn-primary">Submit for review</button></div>
+            <div className="sm:col-span-2"><SubmitButton pendingLabel="Submitting securely…">Submit for review</SubmitButton></div>
           </form>
         )}
       </section>}
@@ -111,12 +112,12 @@ export default async function JoinPage({ searchParams }: {
         {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Your business candidate and ownership request were received for review. They remain private and pending until an operator decides.</p>}
         {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
         {!authResult.data.user?.email ? <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-5"><h3 className="font-black">Sign in to continue</h3><p className="mt-2 text-sm leading-6 text-slate-600">Your pending ownership request must be attached to your account so you can track it privately. Signing in does not approve ownership.</p><Link href={`/login?next=${encodeURIComponent(`/join?path=owner&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`)}`} className="btn btn-primary mt-4">Sign in to continue</Link></div> : !siteKey ? <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Secure business submission is temporarily unavailable. Please try again shortly.</p> : (
-          <form action={submitOwnedBusinessAction} className="mt-6 grid gap-5 sm:grid-cols-2">
+          <form action={submitOwnedBusinessAction} className="mt-6 grid min-w-0 gap-5 sm:grid-cols-2">
             <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
             <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
             <p className="rounded-xl bg-slate-50 p-3 text-sm leading-6 text-slate-600">Signed in as <strong>{authResult.data.user.email}</strong>. This email is used only for your private request status.</p>
             <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
-            <Select label="Category" name="categorySlug" options={categoriesResult.data ?? []} />
+            <CategoryField options={categoriesResult.data ?? []} />
             <Select label="Location" name="suburbSlug" options={suburbsResult.data ?? []} />
             <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" />
             <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" />
@@ -124,10 +125,10 @@ export default async function JoinPage({ searchParams }: {
             <p className="text-sm text-slate-600 sm:col-span-2">Provide at least one way customers can contact this business: email, phone, or website.</p>
             <Field label="ABN (optional)" name="abn" maxLength={14} placeholder="11 digits" />
             <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" />
-            <label className="text-sm font-bold sm:col-span-2">Your connection to this business<textarea name="relationshipExplanation" required minLength={10} maxLength={1000} className="mt-2 min-h-28 w-full rounded-xl border border-slate-300 p-3 font-normal" placeholder="For example: I am the owner, manager, or authorised representative…" /></label>
+            <label className="min-w-0 text-sm font-bold sm:col-span-2">Your connection to this business<textarea name="relationshipExplanation" required minLength={10} maxLength={1000} className="mt-2 min-h-28 w-full rounded-xl border border-slate-300 p-3 font-normal" placeholder="For example: I am the owner, manager, or authorised representative…" /></label>
             <label className="flex items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4" /><span>I confirm these are genuine business details and that I am authorised to request ownership review. SuburbMates may review the details and evidence under its <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
             <div className="sm:col-span-2"><div className="cf-turnstile" data-sitekey={siteKey} data-action="business_submission" data-theme="light" /></div>
-            <div className="sm:col-span-2"><button className="btn btn-primary">Submit business and ownership request</button></div>
+            <div className="sm:col-span-2"><SubmitButton pendingLabel="Submitting securely…">Submit business and ownership request</SubmitButton></div>
           </form>
         )}
       </section>}
@@ -137,10 +138,10 @@ export default async function JoinPage({ searchParams }: {
 }
 
 function Field({ label, name, type = "text", required, maxLength, autoComplete, placeholder }: { label: string; name: string; type?: string; required?: boolean; maxLength: number; autoComplete?: string; placeholder?: string }) {
-  return <label className="text-sm font-bold">{label}<input name={name} type={type} required={required} maxLength={maxLength} autoComplete={autoComplete} placeholder={placeholder} className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" /></label>;
+  return <label className="min-w-0 text-sm font-bold">{label}<input name={name} type={type} required={required} maxLength={maxLength} autoComplete={autoComplete} placeholder={placeholder} className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" /></label>;
 }
 function Select({ label, name, options }: { label: string; name: string; options: { name: string; slug: string }[] }) {
-  return <label className="text-sm font-bold">{label}<select name={name} required defaultValue="" className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="" disabled>Choose one</option>{options.map((option) => <option key={option.slug} value={option.slug}>{option.name}</option>)}</select></label>;
+  return <label className="min-w-0 text-sm font-bold">{label}<select name={name} required defaultValue="" className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="" disabled>Choose one</option>{options.map((option) => <option key={option.slug} value={option.slug}>{option.name}</option>)}</select></label>;
 }
 function submissionError(code: string) {
   if (code === "invalid") return "Check every required field, use an HTTPS website if supplied, confirm the declaration, and try again.";


### PR DESCRIPTION
## What changed\n- keep owner submissions on the owner form when human verification fails, showing the real error\n- show an honest submitting state while a request is being processed\n- replace the long category dropdown with a type-to-filter picker\n- prevent form controls overflowing grid columns on narrow screens\n\n## Boundaries\n- no database migration, schema, policy, action, sender, or publication change\n- the existing protected owner candidate RPC remains unchanged\n\n## Verification\n- npm run owner-submitted-business-candidate:test\n- npm run check\n- npm --prefix web run lint\n- npm --prefix web run build