### PR TITLE
Fix mobile business submission recovery

### DIFF
--- a/scripts/test-owner-submitted-business-candidate-boundary.ts
+++ b/scripts/test-owner-submitted-business-candidate-boundary.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import { normaliseSubmissionWebsite } from "../web/src/lib/submission-input";
 
 const migration = fs.readFileSync("supabase/migrations/20260722003158_owner_submitted_business_candidate.sql", "utf8");
 const actions = fs.readFileSync("web/src/app/(directory)/join/actions.ts", "utf8");
 const join = fs.readFileSync("web/src/app/(directory)/join/page.tsx", "utf8");
+const ownerForm = fs.readFileSync("web/src/app/(directory)/join/OwnerSubmissionForm.tsx", "utf8");
 
 assert.match(migration, /auth\.uid\(\)/);
 assert.match(migration, /INSERT INTO public\.claim_requests/);
@@ -13,14 +15,23 @@ assert.match(migration, /'publication_unchanged', true/);
 assert.match(migration, /GRANT EXECUTE ON FUNCTION public\.submit_owned_business_candidate_for_current_user[\s\S]*TO authenticated/);
 assert.match(actions, /submit_owned_business_candidate_for_current_user/);
 assert.match(actions, /createClient\(\)/);
-assert.match(actions, /verifyBusinessSubmission\(fields\.token, next\)/);
-assert.match(actions, /fail\(error\.code, next\)/);
+assert.match(actions, /verifyTurnstileToken\(fields\.token, "business_submission"\)/);
+assert.match(actions, /OwnerSubmissionState/);
 assert.match(join, /I own or represent it/);
 assert.match(join, /Suggest a local business/);
-assert.match(join, /Submit business and ownership request/);
+assert.match(ownerForm, /Submit business and ownership request/);
 assert.match(join, /CategoryField/);
 assert.match(join, /Submitting securely/);
 assert.match(join, /min-w-0/);
+assert.match(join, /OwnerSubmissionForm/);
+assert.match(join, /TurnstileField/);
+assert.match(join, /dogtrainersdirectory\.com\.au/);
+assert.match(ownerForm, /block min-w-0/);
+assert.match(ownerForm, /TurnstileField/);
+assert.match(ownerForm, /Your entered details are still here/);
+assert.equal(normaliseSubmissionWebsite("dogtrainersdirectory.com.au"), "https://dogtrainersdirectory.com.au/");
+assert.equal(normaliseSubmissionWebsite("http://example.com/path"), "https://example.com/path");
+assert.equal(normaliseSubmissionWebsite("https://example.com"), "https://example.com/");
 for (const forbidden of ["is_published = true", "SET owner_id =", "is_claimed = true", "TO anon"]) {
   assert(!migration.includes(forbidden), `Owner candidate flow must not contain ${forbidden}.`);
 }

--- a/web/src/app/(directory)/join/JoinFormControls.tsx
+++ b/web/src/app/(directory)/join/JoinFormControls.tsx
@@ -1,9 +1,20 @@
 "use client";
 
-import { useId, useMemo, useState } from "react";
+import Script from "next/script";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useFormStatus } from "react-dom";
 
 type Option = { name: string; slug: string };
+
+type TurnstileApi = {
+  render: (container: HTMLElement, options: Record<string, unknown>) => string;
+  reset: (widgetId: string) => void;
+  remove: (widgetId: string) => void;
+};
+
+declare global {
+  interface Window { turnstile?: TurnstileApi; }
+}
 
 export function CategoryField({ options }: { options: Option[] }) {
   const [query, setQuery] = useState("");
@@ -52,4 +63,46 @@ export function CategoryField({ options }: { options: Option[] }) {
 export function SubmitButton({ children, pendingLabel }: { children: string; pendingLabel: string }) {
   const { pending } = useFormStatus();
   return <button disabled={pending} className="btn btn-primary" aria-describedby="submission-progress">{pending ? pendingLabel : children}<span id="submission-progress" className="sr-only" aria-live="polite">{pending ? " Submission in progress." : ""}</span></button>;
+}
+
+export function TurnstileField({ siteKey }: { siteKey: string }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const [token, setToken] = useState("");
+  const [message, setMessage] = useState("Confirming you are human…");
+
+  function resetOrRender() {
+    setToken("");
+    if (widgetIdRef.current && window.turnstile) {
+      window.turnstile.reset(widgetIdRef.current);
+      setMessage("Confirming you are human…");
+      return;
+    }
+    render();
+  }
+
+  function render() {
+    if (!containerRef.current || !window.turnstile) return;
+    if (widgetIdRef.current) window.turnstile.remove(widgetIdRef.current);
+    containerRef.current.replaceChildren();
+    widgetIdRef.current = window.turnstile.render(containerRef.current, {
+      sitekey: siteKey,
+      action: "business_submission",
+      theme: "light",
+      size: "flexible",
+      callback: (nextToken: string) => { setToken(nextToken); setMessage("Human verification ready."); },
+      "expired-callback": () => { setToken(""); setMessage("Human verification expired. Refresh it before submitting."); },
+      "error-callback": () => { setToken(""); setMessage("Human verification could not load. Check your connection and refresh it."); },
+    });
+  }
+
+  useEffect(() => { if (window.turnstile) render(); return () => { if (widgetIdRef.current && window.turnstile) window.turnstile.remove(widgetIdRef.current); }; // Turnstile is an external imperative widget; mount once and remove once.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div className="min-w-0 sm:col-span-2">
+    <Script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" strategy="afterInteractive" onLoad={render} />
+    <input type="hidden" name="cf-turnstile-response" value={token} />
+    <div ref={containerRef} className="min-h-[65px] min-w-0" aria-live="polite" />
+    <p className="mt-2 text-xs leading-5 text-slate-600">{message} {!token && <button type="button" onClick={resetOrRender} className="font-bold underline underline-offset-2">Refresh verification</button>}</p>
+  </div>;
 }

--- a/web/src/app/(directory)/join/OwnerSubmissionForm.tsx
+++ b/web/src/app/(directory)/join/OwnerSubmissionForm.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useActionState, useEffect, useRef } from "react";
+import Link from "next/link";
+import { submitOwnedBusinessAction, type OwnerSubmissionState } from "./actions";
+import { CategoryField, SubmitButton, TurnstileField } from "./JoinFormControls";
+
+type Option = { name: string; slug: string };
+
+export function OwnerSubmissionForm({ categories, suburbs, siteKey, email }: { categories: Option[]; suburbs: Option[]; siteKey: string; email: string }) {
+  const [state, formAction] = useActionState(submitOwnedBusinessAction, { status: "idle", attempt: 0 });
+  const formRef = useRef<HTMLFormElement>(null);
+  useEffect(() => { if (state.status === "success") formRef.current?.reset(); }, [state.status]);
+
+  return <form ref={formRef} action={formAction} className="mt-6 grid min-w-0 gap-5 sm:grid-cols-2">
+    <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
+    {state.status === "success" && <Outcome state={state} />}
+    {state.status === "error" && <Outcome state={state} />}
+    <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
+    <p className="min-w-0 rounded-xl bg-slate-50 p-3 text-sm leading-6 text-slate-600">Signed in as <strong>{email}</strong>. This email is used only for your private request status.</p>
+    <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
+    <CategoryField options={categories} />
+    <Select label="Location" name="suburbSlug" options={suburbs} />
+    <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" />
+    <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" />
+    <Field label="Website (optional)" name="website" type="text" inputMode="url" maxLength={500} placeholder="dogtrainersdirectory.com.au" />
+    <p className="text-sm text-slate-600 sm:col-span-2">Provide at least one way customers can contact this business: email, phone, or website. A website can be entered with or without `https://`.</p>
+    <Field label="ABN (optional)" name="abn" maxLength={14} placeholder="11 digits" />
+    <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" />
+    <label className="flex min-w-0 items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4 shrink-0" /><span>I confirm these are genuine business details and that I am authorised to request ownership review. SuburbMates may review the details and evidence under its <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
+    <TurnstileField key={`owner-turnstile-${state.attempt}`} siteKey={siteKey} />
+    <div className="sm:col-span-2"><SubmitButton pendingLabel="Submitting securely…">Submit business and ownership request</SubmitButton></div>
+  </form>;
+}
+
+function Outcome({ state }: { state: OwnerSubmissionState }) {
+  if (state.status === "success") return <p className="rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800 sm:col-span-2" role="status">Your business candidate and ownership request were received for review. They remain private and pending until an operator decides.</p>;
+  const message: Record<NonNullable<OwnerSubmissionState["code"]>, string> = {
+    invalid: "Check the highlighted requirements and try again. Your entered details are still here.",
+    duplicate: "A matching listing appears to exist. Search the directory and use the claim process instead.",
+    rate_limit: "Too many submissions were made recently. Please try again later.",
+    verification: "Human verification was not completed. Your entered details are still here; refresh verification and submit again.",
+    verification_unavailable: "Human verification is temporarily unavailable. Your entered details are still here; refresh verification and try again.",
+    submit: "The request could not be saved. Your entered details are still here; please try again.",
+  };
+  return <p className="rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800 sm:col-span-2" role="alert">{message[state.code ?? "submit"]}</p>;
+}
+
+function Field({ label, name, type = "text", required, maxLength, autoComplete, placeholder, inputMode }: { label: string; name: string; type?: string; required?: boolean; maxLength: number; autoComplete?: string; placeholder?: string; inputMode?: "url" | "email" | "tel" | "text" }) {
+  return <label className="block min-w-0 text-sm font-bold">{label}<input name={name} type={type} inputMode={inputMode} required={required} maxLength={maxLength} autoComplete={autoComplete} placeholder={placeholder} className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" /></label>;
+}
+
+function Select({ label, name, options }: { label: string; name: string; options: Option[] }) {
+  return <label className="block min-w-0 text-sm font-bold">{label}<select name={name} required defaultValue="" className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="" disabled>Choose one</option>{options.map((option) => <option key={option.slug} value={option.slug}>{option.name}</option>)}</select></label>;
+}

--- a/web/src/app/(directory)/join/actions.ts
+++ b/web/src/app/(directory)/join/actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { TurnstileVerificationError, verifyTurnstileToken } from "@/lib/turnstile";
+import { normaliseSubmissionWebsite } from "@/lib/submission-input";
 import { createAdminClient } from "@/utils/supabase/admin";
 import { createClient } from "@/utils/supabase/server";
 
@@ -10,6 +11,7 @@ function fail(code: string, next = "/join"): never {
 }
 
 function readBusinessFields(formData: FormData) {
+  const website = normaliseSubmissionWebsite(String(formData.get("website") ?? ""));
   return {
     submitterName: String(formData.get("submitterName") ?? "").trim(),
     businessName: String(formData.get("businessName") ?? "").trim(),
@@ -17,7 +19,7 @@ function readBusinessFields(formData: FormData) {
     suburbSlug: String(formData.get("suburbSlug") ?? "").trim(),
     contactEmail: String(formData.get("contactEmail") ?? "").trim().toLowerCase(),
     phone: String(formData.get("phone") ?? "").trim(),
-    website: String(formData.get("website") ?? "").trim(),
+    website,
     streetAddress: String(formData.get("streetAddress") ?? "").trim(),
     abn: String(formData.get("abn") ?? "").replace(/\s/g, ""),
     token: String(formData.get("cf-turnstile-response") ?? ""),
@@ -46,6 +48,16 @@ async function verifyBusinessSubmission(token: string, next?: string) {
     if (error instanceof TurnstileVerificationError) fail(error.code, next);
     fail("verification", next);
   }
+}
+
+export type OwnerSubmissionState = {
+  status: "idle" | "error" | "success";
+  code?: "invalid" | "duplicate" | "rate_limit" | "verification" | "verification_unavailable" | "submit";
+  attempt: number;
+};
+
+function ownerError(previousState: OwnerSubmissionState, code: NonNullable<OwnerSubmissionState["code"]>): OwnerSubmissionState {
+  return { status: "error", code, attempt: previousState.attempt + 1 };
 }
 
 export async function submitBusinessAction(formData: FormData) {
@@ -93,20 +105,24 @@ export async function submitBusinessAction(formData: FormData) {
   redirect("/join?submitted=1");
 }
 
-export async function submitOwnedBusinessAction(formData: FormData) {
-  const next = "/join?path=owner";
-  if (String(formData.get("companyWebsite") ?? "").trim()) redirect(`${next}&submitted=1`);
+export async function submitOwnedBusinessAction(previousState: OwnerSubmissionState, formData: FormData): Promise<OwnerSubmissionState> {
+  if (String(formData.get("companyWebsite") ?? "").trim()) return { status: "success", attempt: previousState.attempt };
 
   const fields = readBusinessFields(formData);
   const relationshipExplanation = String(formData.get("relationshipExplanation") ?? "").trim();
   if (!validBusinessFields(fields) || relationshipExplanation.length < 10 || relationshipExplanation.length > 1000) {
-    redirect(`${next}&error=invalid`);
+    return ownerError(previousState, "invalid");
   }
 
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user?.email) redirect(`/login?next=${encodeURIComponent(next)}`);
-  const verification = await verifyBusinessSubmission(fields.token, next);
+  if (!user?.email) redirect(`/login?next=${encodeURIComponent("/join?path=owner")}`);
+  let verification: Awaited<ReturnType<typeof verifyTurnstileToken>>;
+  try {
+    verification = await verifyTurnstileToken(fields.token, "business_submission");
+  } catch (error) {
+    return ownerError(previousState, error instanceof TurnstileVerificationError ? error.code : "verification");
+  }
 
   const { error } = await supabase.rpc("submit_owned_business_candidate_for_current_user", {
     p_submitter_name: fields.submitterName,
@@ -123,10 +139,10 @@ export async function submitOwnedBusinessAction(formData: FormData) {
     p_turnstile_action: verification.action,
   });
   if (error) {
-    if (error.code === "23505" || error.message.includes("matching listing")) redirect(`${next}&error=duplicate`);
-    if (error.message.includes("Too many recent submissions")) redirect(`${next}&error=rate_limit`);
-    redirect(`${next}&error=submit`);
+    if (error.code === "23505" || error.message.includes("matching listing")) return ownerError(previousState, "duplicate");
+    if (error.message.includes("Too many recent submissions")) return ownerError(previousState, "rate_limit");
+    return ownerError(previousState, "submit");
   }
 
-  redirect(`${next}&submitted=1`);
+  return { status: "success", attempt: previousState.attempt };
 }

--- a/web/src/app/(directory)/join/page.tsx
+++ b/web/src/app/(directory)/join/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import Script from "next/script";
 import { runtimeEnv } from "@/lib/runtime-env";
 import { createClient } from "@/utils/supabase/server";
-import { submitBusinessAction, submitOwnedBusinessAction } from "./actions";
-import { CategoryField, SubmitButton } from "./JoinFormControls";
+import { submitBusinessAction } from "./actions";
+import { CategoryField, SubmitButton, TurnstileField } from "./JoinFormControls";
+import { OwnerSubmissionForm } from "./OwnerSubmissionForm";
 
 export const dynamic = "force-dynamic";
 
@@ -94,12 +94,12 @@ export default async function JoinPage({ searchParams }: {
             <Select label="Location" name="suburbSlug" options={suburbsResult.data ?? []} />
             <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" />
             <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" />
-            <Field label="Website (optional, HTTPS)" name="website" type="url" maxLength={500} placeholder="https://" />
-            <p className="text-sm text-slate-600 sm:col-span-2">Provide at least one way customers can contact this business: email, phone, or website.</p>
+            <Field label="Website (optional)" name="website" type="text" inputMode="url" maxLength={500} placeholder="dogtrainersdirectory.com.au" />
+            <p className="text-sm text-slate-600 sm:col-span-2">Provide at least one way customers can contact this business: email, phone, or website. A website can be entered with or without `https://`.</p>
             <Field label="ABN (optional)" name="abn" maxLength={14} placeholder="11 digits" />
             <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" />
-            <label className="flex items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4" /><span>I confirm these are genuine business details and agree that SuburbMates may review them for directory publication as described in the <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
-            <div className="sm:col-span-2"><div className="cf-turnstile" data-sitekey={siteKey} data-action="business_submission" data-theme="light" /></div>
+            <label className="flex min-w-0 items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4 shrink-0" /><span>I confirm these are genuine business details and agree that SuburbMates may review them for directory publication as described in the <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
+            <TurnstileField siteKey={siteKey} />
             <div className="sm:col-span-2"><SubmitButton pendingLabel="Submitting securely…">Submit for review</SubmitButton></div>
           </form>
         )}
@@ -112,36 +112,18 @@ export default async function JoinPage({ searchParams }: {
         {message.submitted === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Your business candidate and ownership request were received for review. They remain private and pending until an operator decides.</p>}
         {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
         {!authResult.data.user?.email ? <div className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-5"><h3 className="font-black">Sign in to continue</h3><p className="mt-2 text-sm leading-6 text-slate-600">Your pending ownership request must be attached to your account so you can track it privately. Signing in does not approve ownership.</p><Link href={`/login?next=${encodeURIComponent(`/join?path=owner&q=${encodeURIComponent(query)}&suburb=${encodeURIComponent(suburb)}`)}`} className="btn btn-primary mt-4">Sign in to continue</Link></div> : !siteKey ? <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Secure business submission is temporarily unavailable. Please try again shortly.</p> : (
-          <form action={submitOwnedBusinessAction} className="mt-6 grid min-w-0 gap-5 sm:grid-cols-2">
-            <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
-            <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
-            <p className="rounded-xl bg-slate-50 p-3 text-sm leading-6 text-slate-600">Signed in as <strong>{authResult.data.user.email}</strong>. This email is used only for your private request status.</p>
-            <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
-            <CategoryField options={categoriesResult.data ?? []} />
-            <Select label="Location" name="suburbSlug" options={suburbsResult.data ?? []} />
-            <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" />
-            <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" />
-            <Field label="Website (optional, HTTPS)" name="website" type="url" maxLength={500} placeholder="https://" />
-            <p className="text-sm text-slate-600 sm:col-span-2">Provide at least one way customers can contact this business: email, phone, or website.</p>
-            <Field label="ABN (optional)" name="abn" maxLength={14} placeholder="11 digits" />
-            <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" />
-            <label className="min-w-0 text-sm font-bold sm:col-span-2">Your connection to this business<textarea name="relationshipExplanation" required minLength={10} maxLength={1000} className="mt-2 min-h-28 w-full rounded-xl border border-slate-300 p-3 font-normal" placeholder="For example: I am the owner, manager, or authorised representative…" /></label>
-            <label className="flex items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4" /><span>I confirm these are genuine business details and that I am authorised to request ownership review. SuburbMates may review the details and evidence under its <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
-            <div className="sm:col-span-2"><div className="cf-turnstile" data-sitekey={siteKey} data-action="business_submission" data-theme="light" /></div>
-            <div className="sm:col-span-2"><SubmitButton pendingLabel="Submitting securely…">Submit business and ownership request</SubmitButton></div>
-          </form>
+          <OwnerSubmissionForm categories={categoriesResult.data ?? []} suburbs={suburbsResult.data ?? []} siteKey={siteKey} email={authResult.data.user.email} />
         )}
       </section>}
-      {siteKey && <Script src="https://challenges.cloudflare.com/turnstile/v0/api.js" strategy="afterInteractive" />}
     </div>
   );
 }
 
-function Field({ label, name, type = "text", required, maxLength, autoComplete, placeholder }: { label: string; name: string; type?: string; required?: boolean; maxLength: number; autoComplete?: string; placeholder?: string }) {
-  return <label className="min-w-0 text-sm font-bold">{label}<input name={name} type={type} required={required} maxLength={maxLength} autoComplete={autoComplete} placeholder={placeholder} className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" /></label>;
+function Field({ label, name, type = "text", required, maxLength, autoComplete, placeholder, inputMode }: { label: string; name: string; type?: string; required?: boolean; maxLength: number; autoComplete?: string; placeholder?: string; inputMode?: "url" | "email" | "tel" | "text" }) {
+  return <label className="block min-w-0 text-sm font-bold">{label}<input name={name} type={type} inputMode={inputMode} required={required} maxLength={maxLength} autoComplete={autoComplete} placeholder={placeholder} className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" /></label>;
 }
 function Select({ label, name, options }: { label: string; name: string; options: { name: string; slug: string }[] }) {
-  return <label className="min-w-0 text-sm font-bold">{label}<select name={name} required defaultValue="" className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="" disabled>Choose one</option>{options.map((option) => <option key={option.slug} value={option.slug}>{option.name}</option>)}</select></label>;
+  return <label className="block min-w-0 text-sm font-bold">{label}<select name={name} required defaultValue="" className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="" disabled>Choose one</option>{options.map((option) => <option key={option.slug} value={option.slug}>{option.name}</option>)}</select></label>;
 }
 function submissionError(code: string) {
   if (code === "invalid") return "Check every required field, use an HTTPS website if supplied, confirm the declaration, and try again.";

--- a/web/src/lib/submission-input.ts
+++ b/web/src/lib/submission-input.ts
@@ -1,0 +1,15 @@
+export function normaliseSubmissionWebsite(value: string) {
+  const input = value.trim();
+  if (!input) return "";
+
+  const candidate = /^https?:\/\//i.test(input)
+    ? input.replace(/^http:\/\//i, "https://")
+    : `https://${input}`;
+
+  try {
+    const url = new URL(candidate);
+    return url.protocol === "https:" && url.hostname ? url.toString() : input;
+  } catch {
+    return input;
+  }
+}


### PR DESCRIPTION
## Summary
- repair narrow mobile form control layout for both business-submission paths
- accept bare website domains and canonicalise them to HTTPS server-side
- make owner Turnstile errors recoverable without clearing entered details

## Verification
- npm run owner-submitted-business-candidate:test
- npm run check
- npm --prefix web run lint
- npm --prefix web run build

No schema, permissions, publication, claim, or communication changes.