### PR TITLE
Keep Turnstile within mobile submission forms

### DIFF
--- a/scripts/test-owner-submitted-business-candidate-boundary.ts
+++ b/scripts/test-owner-submitted-business-candidate-boundary.ts
@@ -27,6 +27,8 @@ assert.match(join, /OwnerSubmissionForm/);
 assert.match(join, /TurnstileField/);
 assert.match(join, /dogtrainersdirectory\.com\.au/);
 assert.match(ownerForm, /block min-w-0/);
+assert.match(ownerForm, /grid-cols-1/);
+assert.match(join, /grid-cols-1/);
 assert.match(ownerForm, /TurnstileField/);
 assert.match(ownerForm, /Your entered details are still here/);
 assert.equal(normaliseSubmissionWebsite("dogtrainersdirectory.com.au"), "https://dogtrainersdirectory.com.au/");

--- a/web/src/app/(directory)/join/OwnerSubmissionForm.tsx
+++ b/web/src/app/(directory)/join/OwnerSubmissionForm.tsx
@@ -12,7 +12,7 @@ export function OwnerSubmissionForm({ categories, suburbs, siteKey, email }: { c
   const formRef = useRef<HTMLFormElement>(null);
   useEffect(() => { if (state.status === "success") formRef.current?.reset(); }, [state.status]);
 
-  return <form ref={formRef} action={formAction} className="mt-6 grid min-w-0 gap-5 sm:grid-cols-2">
+  return <form ref={formRef} action={formAction} className="mt-6 grid min-w-0 grid-cols-1 gap-5 sm:grid-cols-2">
     <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
     {state.status === "success" && <Outcome state={state} />}
     {state.status === "error" && <Outcome state={state} />}

--- a/web/src/app/(directory)/join/page.tsx
+++ b/web/src/app/(directory)/join/page.tsx
@@ -85,7 +85,7 @@ export default async function JoinPage({ searchParams }: {
         {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{submissionError(message.error)}</p>}
 
         {!siteKey ? <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Secure business submission is temporarily unavailable. You can still search and claim an existing listing.</p> : (
-          <form action={submitBusinessAction} className="mt-6 grid min-w-0 gap-5 sm:grid-cols-2">
+          <form action={submitBusinessAction} className="mt-6 grid min-w-0 grid-cols-1 gap-5 sm:grid-cols-2">
             <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
             <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
             <div><Field label="Your email" name="submitterEmail" type="email" required maxLength={254} autoComplete="email" /><p className="mt-2 text-xs font-normal leading-5 text-slate-600">No account is created. This is only used if you later choose to check the private submission status.</p></div>


### PR DESCRIPTION
## Root cause\nThe explicit Turnstile widget has a 395px intrinsic width. The join forms used an implicit CSS Grid column, allowing that widget to expand the entire form on phone screens.\n\n## Fix\nUse an explicit shrinkable one-column grid on mobile while preserving the existing two-column desktop layout.\n\n## Verification\n- npm run owner-submitted-business-candidate:test\n- npm --prefix web run lint\n- npm --prefix web run build\n\nNo schema, permissions, publication, claim, communications, or anti-abuse change.