### PR TITLE
Wrap mobile owner submission button

### DIFF
--- a/scripts/test-owner-submitted-business-candidate-boundary.ts
+++ b/scripts/test-owner-submitted-business-candidate-boundary.ts
@@ -6,6 +6,7 @@ const migration = fs.readFileSync("supabase/migrations/20260722003158_owner_subm
 const actions = fs.readFileSync("web/src/app/(directory)/join/actions.ts", "utf8");
 const join = fs.readFileSync("web/src/app/(directory)/join/page.tsx", "utf8");
 const ownerForm = fs.readFileSync("web/src/app/(directory)/join/OwnerSubmissionForm.tsx", "utf8");
+const controls = fs.readFileSync("web/src/app/(directory)/join/JoinFormControls.tsx", "utf8");
 
 assert.match(migration, /auth\.uid\(\)/);
 assert.match(migration, /INSERT INTO public\.claim_requests/);
@@ -31,6 +32,7 @@ assert.match(ownerForm, /grid-cols-1/);
 assert.match(join, /grid-cols-1/);
 assert.match(ownerForm, /TurnstileField/);
 assert.match(ownerForm, /Your entered details are still here/);
+assert.match(controls, /w-full whitespace-normal sm:w-auto/);
 assert.equal(normaliseSubmissionWebsite("dogtrainersdirectory.com.au"), "https://dogtrainersdirectory.com.au/");
 assert.equal(normaliseSubmissionWebsite("http://example.com/path"), "https://example.com/path");
 assert.equal(normaliseSubmissionWebsite("https://example.com"), "https://example.com/");

--- a/web/src/app/(directory)/join/JoinFormControls.tsx
+++ b/web/src/app/(directory)/join/JoinFormControls.tsx
@@ -62,7 +62,7 @@ export function CategoryField({ options }: { options: Option[] }) {
 
 export function SubmitButton({ children, pendingLabel }: { children: string; pendingLabel: string }) {
   const { pending } = useFormStatus();
-  return <button disabled={pending} className="btn btn-primary" aria-describedby="submission-progress">{pending ? pendingLabel : children}<span id="submission-progress" className="sr-only" aria-live="polite">{pending ? " Submission in progress." : ""}</span></button>;
+  return <button disabled={pending} className="btn btn-primary w-full whitespace-normal sm:w-auto" aria-describedby="submission-progress">{pending ? pendingLabel : children}<span id="submission-progress" className="sr-only" aria-live="polite">{pending ? " Submission in progress." : ""}</span></button>;
 }
 
 export function TurnstileField({ siteKey }: { siteKey: string }) {


### PR DESCRIPTION
## Root cause\nThe owner form's long submit button inherited the global no-wrap button style and widened the page to 443px on a 390px viewport.\n\n## Fix\nThe existing shared submission button now fills the mobile column and allows its label to wrap; desktop remains auto-width.\n\n## Verification\n- npm run owner-submitted-business-candidate:test\n- npm --prefix web run lint\n- npm --prefix web run build\n\nNo data, schema, permissions, publication, claim, communication, or anti-abuse change.