### PR TITLE
Fix owner business submission recovery

### DIFF
--- a/scripts/test-owner-submitted-business-candidate-boundary.ts
+++ b/scripts/test-owner-submitted-business-candidate-boundary.ts
@@ -7,6 +7,7 @@ const actions = fs.readFileSync("web/src/app/(directory)/join/actions.ts", "utf8
 const join = fs.readFileSync("web/src/app/(directory)/join/page.tsx", "utf8");
 const ownerForm = fs.readFileSync("web/src/app/(directory)/join/OwnerSubmissionForm.tsx", "utf8");
 const controls = fs.readFileSync("web/src/app/(directory)/join/JoinFormControls.tsx", "utf8");
+const ownerEmailFix = fs.readFileSync("supabase/migrations/20260804205239_fix_owner_submission_email_validation.sql", "utf8");
 
 assert.match(migration, /auth\.uid\(\)/);
 assert.match(migration, /INSERT INTO public\.claim_requests/);
@@ -32,12 +33,18 @@ assert.match(ownerForm, /grid-cols-1/);
 assert.match(join, /grid-cols-1/);
 assert.match(ownerForm, /TurnstileField/);
 assert.match(ownerForm, /Your entered details are still here/);
+assert.match(actions, /values: OwnerSubmissionValues/);
+assert.match(ownerForm, /defaultValue=\{state\.values\.submitterName\}/);
+assert.match(ownerForm, /defaultValue=\{state\.values\.relationshipExplanation\}/);
+assert.match(ownerForm, /defaultValue=\{state\.values\.suburbSlug\}/);
 assert.match(ownerForm, /name="relationshipExplanation"/);
 assert.match(ownerForm, /minLength=\{10\}/);
 assert.match(controls, /w-full whitespace-normal sm:w-auto/);
 assert.equal(normaliseSubmissionWebsite("dogtrainersdirectory.com.au"), "https://dogtrainersdirectory.com.au/");
 assert.equal(normaliseSubmissionWebsite("http://example.com/path"), "https://example.com/path");
 assert.equal(normaliseSubmissionWebsite("https://example.com"), "https://example.com/");
+assert.match(ownerEmailFix, /p_submitter_email/);
+assert(!ownerEmailFix.includes("\\\\."), "Owner submission email validation must use a single regex escape for the dot.");
 for (const forbidden of ["is_published = true", "SET owner_id =", "is_claimed = true", "TO anon"]) {
   assert(!migration.includes(forbidden), `Owner candidate flow must not contain ${forbidden}.`);
 }

--- a/supabase/migrations/20260804205239_fix_owner_submission_email_validation.sql
+++ b/supabase/migrations/20260804205239_fix_owner_submission_email_validation.sql
@@ -1,0 +1,18 @@
+-- Restore valid email acceptance for private owner submissions. The previous
+-- expression used two backslashes before the dot, which matched a literal
+-- backslash rather than a normal email address.
+
+CREATE OR REPLACE FUNCTION public.submit_business_listing_with_status(
+  p_submitter_name TEXT, p_submitter_email TEXT, p_business_name TEXT, p_category_slug TEXT, p_suburb_slug TEXT,
+  p_contact_email TEXT, p_phone TEXT, p_website TEXT, p_street_address TEXT, p_abn TEXT, p_turnstile_hostname TEXT, p_turnstile_action TEXT
+) RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE v_email TEXT := nullif(lower(trim(coalesce(p_submitter_email,''))), ''); v_vendor_id UUID;
+BEGIN
+  IF v_email IS NULL OR length(v_email)>254 OR v_email !~* '^[^[:space:]@]+@[^[:space:]@]+\.[^[:space:]@]+$' THEN RAISE EXCEPTION USING ERRCODE='22023', MESSAGE='Enter a valid email for private status.'; END IF;
+  v_vendor_id := public.submit_business_listing(p_submitter_name,p_business_name,p_category_slug,p_suburb_slug,p_contact_email,p_phone,p_website,p_street_address,p_abn,p_turnstile_hostname,p_turnstile_action);
+  INSERT INTO public.business_submission_requests (vendor_id,submitter_email) VALUES (v_vendor_id,v_email);
+  RETURN v_vendor_id;
+END;
+$$;

--- a/web/src/app/(directory)/join/JoinFormControls.tsx
+++ b/web/src/app/(directory)/join/JoinFormControls.tsx
@@ -16,9 +16,10 @@ declare global {
   interface Window { turnstile?: TurnstileApi; }
 }
 
-export function CategoryField({ options }: { options: Option[] }) {
-  const [query, setQuery] = useState("");
-  const [selected, setSelected] = useState<Option | null>(null);
+export function CategoryField({ options, initialSlug = "" }: { options: Option[]; initialSlug?: string }) {
+  const initialOption = options.find((option) => option.slug === initialSlug) ?? null;
+  const [query, setQuery] = useState(initialOption?.name ?? "");
+  const [selected, setSelected] = useState<Option | null>(initialOption);
   const [open, setOpen] = useState(false);
   const listId = useId();
   const matches = useMemo(() => {

--- a/web/src/app/(directory)/join/OwnerSubmissionForm.tsx
+++ b/web/src/app/(directory)/join/OwnerSubmissionForm.tsx
@@ -2,33 +2,36 @@
 
 import { useActionState, useEffect, useRef } from "react";
 import Link from "next/link";
-import { submitOwnedBusinessAction, type OwnerSubmissionState } from "./actions";
+import { submitOwnedBusinessAction, type OwnerSubmissionState, type OwnerSubmissionValues } from "./actions";
 import { CategoryField, SubmitButton, TurnstileField } from "./JoinFormControls";
 
 type Option = { name: string; slug: string };
+const emptyOwnerSubmissionValues: OwnerSubmissionValues = {
+  submitterName: "", businessName: "", categorySlug: "", suburbSlug: "", contactEmail: "", phone: "", website: "", abn: "", streetAddress: "", relationshipExplanation: "", consent: false,
+};
 
 export function OwnerSubmissionForm({ categories, suburbs, siteKey, email }: { categories: Option[]; suburbs: Option[]; siteKey: string; email: string }) {
-  const [state, formAction] = useActionState(submitOwnedBusinessAction, { status: "idle", attempt: 0 });
+  const [state, formAction] = useActionState(submitOwnedBusinessAction, { status: "idle", attempt: 0, values: emptyOwnerSubmissionValues });
   const formRef = useRef<HTMLFormElement>(null);
   useEffect(() => { if (state.status === "success") formRef.current?.reset(); }, [state.status]);
 
-  return <form ref={formRef} action={formAction} className="mt-6 grid min-w-0 grid-cols-1 gap-5 sm:grid-cols-2">
+  return <form key={state.attempt} ref={formRef} action={formAction} className="mt-6 grid min-w-0 grid-cols-1 gap-5 sm:grid-cols-2">
     <div className="hidden" aria-hidden="true"><label>Leave empty<input name="companyWebsite" tabIndex={-1} autoComplete="off" /></label></div>
     {state.status === "success" && <Outcome state={state} />}
     {state.status === "error" && <Outcome state={state} />}
-    <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" />
+    <Field label="Your name" name="submitterName" required maxLength={120} autoComplete="name" defaultValue={state.values.submitterName} />
     <p className="min-w-0 rounded-xl bg-slate-50 p-3 text-sm leading-6 text-slate-600">Signed in as <strong>{email}</strong>. This email is used only for your private request status.</p>
-    <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" />
-    <CategoryField options={categories} />
-    <Select label="Location" name="suburbSlug" options={suburbs} />
-    <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" />
-    <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" />
-    <Field label="Website (optional)" name="website" type="text" inputMode="url" maxLength={500} placeholder="dogtrainersdirectory.com.au" />
+    <Field label="Business name" name="businessName" required maxLength={200} autoComplete="organization" defaultValue={state.values.businessName} />
+    <CategoryField options={categories} initialSlug={state.values.categorySlug} />
+    <Select label="Location" name="suburbSlug" options={suburbs} defaultValue={state.values.suburbSlug} />
+    <Field label="Business email (optional)" name="contactEmail" type="email" maxLength={254} autoComplete="email" defaultValue={state.values.contactEmail} />
+    <Field label="Phone (optional)" name="phone" type="tel" maxLength={40} autoComplete="tel" defaultValue={state.values.phone} />
+    <Field label="Website (optional)" name="website" type="text" inputMode="url" maxLength={500} placeholder="dogtrainersdirectory.com.au" defaultValue={state.values.website} />
     <p className="text-sm text-slate-600 sm:col-span-2">Provide at least one way customers can contact this business: email, phone, or website. A website can be entered with or without `https://`.</p>
-    <Field label="ABN (optional)" name="abn" maxLength={14} placeholder="11 digits" />
-    <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" />
-    <label className="block min-w-0 text-sm font-bold sm:col-span-2">Your connection to this business<textarea name="relationshipExplanation" required minLength={10} maxLength={1000} className="mt-2 block min-h-28 w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" placeholder="For example: I am the owner, manager, or authorised representative…" /></label>
-    <label className="flex min-w-0 items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required className="mt-1 h-4 w-4 shrink-0" /><span>I confirm these are genuine business details and that I am authorised to request ownership review. SuburbMates may review the details and evidence under its <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
+    <Field label="ABN (optional)" name="abn" maxLength={14} placeholder="11 digits" defaultValue={state.values.abn} />
+    <Field label="Street address (optional)" name="streetAddress" maxLength={500} autoComplete="street-address" defaultValue={state.values.streetAddress} />
+    <label className="block min-w-0 text-sm font-bold sm:col-span-2">Your connection to this business<textarea name="relationshipExplanation" required minLength={10} maxLength={1000} defaultValue={state.values.relationshipExplanation} className="mt-2 block min-h-28 w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" placeholder="For example: I am the owner, manager, or authorised representative…" /></label>
+    <label className="flex min-w-0 items-start gap-3 text-sm leading-6 text-slate-700 sm:col-span-2"><input name="consent" type="checkbox" required defaultChecked={state.values.consent} className="mt-1 h-4 w-4 shrink-0" /><span>I confirm these are genuine business details and that I am authorised to request ownership review. SuburbMates may review the details and evidence under its <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span></label>
     <TurnstileField key={`owner-turnstile-${state.attempt}`} siteKey={siteKey} />
     <div className="sm:col-span-2"><SubmitButton pendingLabel="Submitting securely…">Submit business and ownership request</SubmitButton></div>
   </form>;
@@ -47,10 +50,10 @@ function Outcome({ state }: { state: OwnerSubmissionState }) {
   return <p className="rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800 sm:col-span-2" role="alert">{message[state.code ?? "submit"]}</p>;
 }
 
-function Field({ label, name, type = "text", required, maxLength, autoComplete, placeholder, inputMode }: { label: string; name: string; type?: string; required?: boolean; maxLength: number; autoComplete?: string; placeholder?: string; inputMode?: "url" | "email" | "tel" | "text" }) {
-  return <label className="block min-w-0 text-sm font-bold">{label}<input name={name} type={type} inputMode={inputMode} required={required} maxLength={maxLength} autoComplete={autoComplete} placeholder={placeholder} className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" /></label>;
+function Field({ label, name, type = "text", required, maxLength, autoComplete, placeholder, inputMode, defaultValue }: { label: string; name: string; type?: string; required?: boolean; maxLength: number; autoComplete?: string; placeholder?: string; inputMode?: "url" | "email" | "tel" | "text"; defaultValue: string }) {
+  return <label className="block min-w-0 text-sm font-bold">{label}<input name={name} type={type} inputMode={inputMode} required={required} maxLength={maxLength} autoComplete={autoComplete} placeholder={placeholder} defaultValue={defaultValue} className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" /></label>;
 }
 
-function Select({ label, name, options }: { label: string; name: string; options: Option[] }) {
-  return <label className="block min-w-0 text-sm font-bold">{label}<select name={name} required defaultValue="" className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="" disabled>Choose one</option>{options.map((option) => <option key={option.slug} value={option.slug}>{option.name}</option>)}</select></label>;
+function Select({ label, name, options, defaultValue }: { label: string; name: string; options: Option[]; defaultValue: string }) {
+  return <label className="block min-w-0 text-sm font-bold">{label}<select name={name} required defaultValue={defaultValue} className="mt-2 block w-full min-w-0 rounded-xl border border-slate-300 bg-white p-3 font-normal"><option value="" disabled>Choose one</option>{options.map((option) => <option key={option.slug} value={option.slug}>{option.name}</option>)}</select></label>;
 }

--- a/web/src/app/(directory)/join/actions.ts
+++ b/web/src/app/(directory)/join/actions.ts
@@ -54,10 +54,41 @@ export type OwnerSubmissionState = {
   status: "idle" | "error" | "success";
   code?: "invalid" | "duplicate" | "rate_limit" | "verification" | "verification_unavailable" | "submit";
   attempt: number;
+  values: OwnerSubmissionValues;
 };
 
-function ownerError(previousState: OwnerSubmissionState, code: NonNullable<OwnerSubmissionState["code"]>): OwnerSubmissionState {
-  return { status: "error", code, attempt: previousState.attempt + 1 };
+export type OwnerSubmissionValues = {
+  submitterName: string;
+  businessName: string;
+  categorySlug: string;
+  suburbSlug: string;
+  contactEmail: string;
+  phone: string;
+  website: string;
+  abn: string;
+  streetAddress: string;
+  relationshipExplanation: string;
+  consent: boolean;
+};
+
+function readOwnerSubmissionValues(formData: FormData): OwnerSubmissionValues {
+  return {
+    submitterName: String(formData.get("submitterName") ?? ""),
+    businessName: String(formData.get("businessName") ?? ""),
+    categorySlug: String(formData.get("categorySlug") ?? ""),
+    suburbSlug: String(formData.get("suburbSlug") ?? ""),
+    contactEmail: String(formData.get("contactEmail") ?? ""),
+    phone: String(formData.get("phone") ?? ""),
+    website: String(formData.get("website") ?? ""),
+    abn: String(formData.get("abn") ?? ""),
+    streetAddress: String(formData.get("streetAddress") ?? ""),
+    relationshipExplanation: String(formData.get("relationshipExplanation") ?? ""),
+    consent: formData.get("consent") === "on",
+  };
+}
+
+function ownerError(previousState: OwnerSubmissionState, code: NonNullable<OwnerSubmissionState["code"]>, values: OwnerSubmissionValues): OwnerSubmissionState {
+  return { status: "error", code, attempt: previousState.attempt + 1, values };
 }
 
 export async function submitBusinessAction(formData: FormData) {
@@ -106,12 +137,13 @@ export async function submitBusinessAction(formData: FormData) {
 }
 
 export async function submitOwnedBusinessAction(previousState: OwnerSubmissionState, formData: FormData): Promise<OwnerSubmissionState> {
-  if (String(formData.get("companyWebsite") ?? "").trim()) return { status: "success", attempt: previousState.attempt };
+  if (String(formData.get("companyWebsite") ?? "").trim()) return { status: "success", attempt: previousState.attempt, values: previousState.values };
 
   const fields = readBusinessFields(formData);
-  const relationshipExplanation = String(formData.get("relationshipExplanation") ?? "").trim();
+  const values = readOwnerSubmissionValues(formData);
+  const relationshipExplanation = values.relationshipExplanation.trim();
   if (!validBusinessFields(fields) || relationshipExplanation.length < 10 || relationshipExplanation.length > 1000) {
-    return ownerError(previousState, "invalid");
+    return ownerError(previousState, "invalid", values);
   }
 
   const supabase = await createClient();
@@ -121,7 +153,7 @@ export async function submitOwnedBusinessAction(previousState: OwnerSubmissionSt
   try {
     verification = await verifyTurnstileToken(fields.token, "business_submission");
   } catch (error) {
-    return ownerError(previousState, error instanceof TurnstileVerificationError ? error.code : "verification");
+    return ownerError(previousState, error instanceof TurnstileVerificationError ? error.code : "verification", values);
   }
 
   const { error } = await supabase.rpc("submit_owned_business_candidate_for_current_user", {
@@ -139,10 +171,10 @@ export async function submitOwnedBusinessAction(previousState: OwnerSubmissionSt
     p_turnstile_action: verification.action,
   });
   if (error) {
-    if (error.code === "23505" || error.message.includes("matching listing")) return ownerError(previousState, "duplicate");
-    if (error.message.includes("Too many recent submissions")) return ownerError(previousState, "rate_limit");
-    return ownerError(previousState, "submit");
+    if (error.code === "23505" || error.message.includes("matching listing")) return ownerError(previousState, "duplicate", values);
+    if (error.message.includes("Too many recent submissions")) return ownerError(previousState, "rate_limit", values);
+    return ownerError(previousState, "submit", values);
   }
 
-  return { status: "success", attempt: previousState.attempt };
+  return { status: "success", attempt: previousState.attempt, values: previousState.values };
 }


### PR DESCRIPTION
## Root cause
- The database email-validation expression used a double regex escape, rejecting normal email addresses.
- Error-state UI claimed values were retained but did not restore them.

## Change
- Correct the private submission email validation function.
- Preserve owner form values, including category, location and consent, after an error.

## Proof
- Focused boundary test, full repository suite, lint, and production build pass.
- Exact remote database call succeeds inside a rolled-back transaction; no data was created.