### PR TITLE
Reconcile current authentication and Ops guidance

### DIFF
--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -79,7 +79,7 @@ Public directory reads use `public.published_vendors`, a safe projection contain
 
 ### Owners
 
-- `/login`: Supabase passwordless email authentication.
+- `/login`: existing authorised accounts sign in with email and password. Password reset and an eight-digit email-code fallback are delivered through Supabase Auth; there is no public account-registration flow.
 - `/claim`: a matching authenticated email can submit a pending claim request only.
 - `/dashboard`: an approved owner can submit a proposed profile change.
 - claim approval, rejection, information requests, and revocation are operator-only and audited;
@@ -141,7 +141,7 @@ Current allowed sources and rules are documented in `docs/vendor-acquisition-str
 | GitHub | Source, CI, scheduled safe discovery | Connected; `Verify` runs on branch pushes and pull requests |
 | Supabase | PostgreSQL, Auth, RLS, RPC workflows | Connected; local and remote migrations aligned through `20260725210822` |
 | Cloudflare | DNS, Worker delivery, Turnstile | Live; contact widget restricted to `suburbmates.com.au`; runtime secrets are managed bindings |
-| Resend | Supabase Auth SMTP only at launch | Domain verified; passwordless email-code sign-in into `/ops` is the approved path |
+| Resend | Supabase Auth delivery only | Domain verified; password reset and the eight-digit email-code fallback are delivered from `auth@suburbmates.com.au`. No general sender, marketing mail or public inbox is enabled. |
 | Stripe | Future optional paid upgrades | Test account only; webhook returns 501; keep disabled until benefits and pricing are approved |
 | ABN Lookup | Optional operator-run supporting evidence | One-listing-at-a-time evidence path is implemented; never gate listing, claim, or publication on ABN alone |
 

--- a/docs/OPS/PUBLIC_RELEASE_ACCEPTANCE.md
+++ b/docs/OPS/PUBLIC_RELEASE_ACCEPTANCE.md
@@ -6,7 +6,7 @@ The owner authorised the first public release on 23 July 2026. This register pre
 
 Use real activity only. Do not create fake production businesses, claims, ABNs, images or contact requests merely to satisfy this checklist. Record the time, route and plain-English result in the relevant Linear issue after each walkthrough.
 
-1. **Cross-device access:** On the Mac browser, open `/login`, request a code for the approved address, read the newest eight-digit code on the phone, then type it into the Mac browser. Confirm the intended private page opens. Do not click an email link or request repeated codes while rate-limited.
+1. **Account access:** On the Mac browser, open `/login` and sign in with the approved address and password. When the email-code fallback needs verification, request the newest eight-digit code, read it on the phone, then type it into the Mac browser. Confirm the intended private page opens. Do not click an email link or request repeated codes while rate-limited.
 2. **Owner and submitter paths:** Complete the claim, profile-change, missing-business and request-status journeys only when there is a real owner or community submission to use. Confirm that each stays private or pending until the stated operator decision.
 3. **Operator ABN and media:** In `/ops`, use only a real listing with operator-held ABN evidence and an actual owner-authorised image. Check that ABN information stays private and media remains private until the operator decision.
 4. **Status email and failure:** Use an actual permitted decision, not a fabricated request. Confirm the in-product status first. Then record one genuine delivery result and one safe, deliberate provider-failure result without enabling retries, bulk sends, marketing or a general inbox.

--- a/docs/OPS/README.md
+++ b/docs/OPS/README.md
@@ -15,15 +15,13 @@ Write the reason in the decision note. The system keeps it as permanent audit ev
 
 ## Getting in
 
-Open `/ops` and sign in with `admin@suburbmates.com.au`. Request a sign-in code, then enter the newest eight-digit code in the browser you are using. The email can be opened on another device. If a code fails, wait for the stated email limit before requesting another.
+Open `/ops` and sign in with `admin@suburbmates.com.au` using the normal password form. If the password is unavailable, use **Set or reset password**. The eight-digit email code is a fallback: request it, then enter the newest code in the browser you are using. The email can be opened on another device. If a code fails, wait for the stated email limit before requesting another.
 
 ## Daily order
 
-1. **Listings** — decide whether a business is suitable for the public directory.
-2. **Claims** — decide whether a person should control an existing listing.
-3. **Profile edits** — decide whether an approved owner’s proposed public changes are accurate.
-4. **Contact** — handle support, correction, claim-help, and privacy messages.
-5. **System** — notice warnings and confirm decisions appear in the permanent record.
+1. **Work** — open only the genuine decisions that need judgment; use its priority groups rather than treating background evidence as a queue.
+2. **Businesses** — find a vendor, its authorised evidence and its protected detail/actions when Work links you there or you need to look something up.
+3. **System** — act only on a plain-language warning; otherwise leave background evidence and routine health alone.
 
 Routine exact-email claims are intended to be low-friction. Claims requiring a challenge, recovery, revocation, conflict resolution or sensitive-change review belong in the protected Claims queue. A claim never publishes a listing or changes unrelated trust/commercial state.
 

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -64,7 +64,7 @@ No branch, pull request, automation run or lane handover changes product policy 
 ### D-006 — Communications and account access
 
 - **Date:** 19 July 2026
-- **Decision:** Communications is a first-class user journey. Passwordless sign-in from `auth@suburbmates.com.au` is active, and only the approved staged status messages may use that sender. A public support inbox, marketing mail, bulk notification system and uncontrolled retries remain disabled.
+- **Decision:** Communications is a first-class user journey. Existing authorised accounts use password sign-in as the normal path; password reset and the eight-digit email-code fallback are delivered from `auth@suburbmates.com.au`. Only the approved staged status messages may use that sender. A public support inbox, marketing mail, bulk notification system and uncontrolled retries remain disabled.
 - **Decision required before expansion:** `SUB-15` must approve the exact post-release message catalogue: trigger, recipient, sender, content boundary, contact/consent basis, retained evidence, failure state, retention and Ops action.
 - **Guardrail:** A user must retain an in-product status/recovery path if a message cannot be delivered. A message never changes publication, ownership, trust, commercial or claim state.
 - **Evidence to close:** Approved journey/map, message catalogue, authorised implementation and end-to-end delivery/failure evidence for each enabled message.
@@ -80,10 +80,10 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **First launch:** The initial public launch is complete when the minimum end-to-end journeys above are proven. Stripe, broad email, bulk ABN checks, AI publication and optional polish are not launch prerequisites.
 - **Evidence to close:** Update authority/issue descriptions; build the ready foundation work; then verify each public journey and release gate.
 
-### D-008 — Cross-device passwordless access
+### D-008 — Cross-device email-code fallback
 
 - **Date:** 22 July 2026
-- **Decision:** The approved `auth@suburbmates.com.au` passwordless email uses an eight-digit, one-time code entered in the browser where the person wants to sign in. It replaces the browser-bound magic-link interaction.
+- **Decision:** The approved `auth@suburbmates.com.au` email-code fallback uses an eight-digit, one-time code entered in the browser where the person wants to sign in. It replaces the browser-bound magic-link interaction; password sign-in remains the normal path for existing authorised accounts.
 - **Guardrail:** This changes neither the approved sender nor any other communications capability. Codes expire through Supabase Auth, are single-use, and do not decide a claim, publication, ownership or any other product state.
 - **Evidence to close:** A live owner-device test of code delivery, expiry, supersession and successful session handoff, followed by removal of the temporary review callback.
 


### PR DESCRIPTION
## Scope

Documentation-only reconciliation of current implemented behaviour:

- password sign-in is the normal path for existing authorised accounts; password reset and email-code fallback remain delivered from `auth@suburbmates.com.au`;
- the Ops guide reflects Work, Businesses and System as the daily surfaces;
- post-release acceptance no longer treats email-code access as the sole normal sign-in path.

## Boundaries

No application, database, deployment, provider or communication-sender change.

## Verification

- `git diff --check`
- current implementation and Decision Log D-012 reviewed

Companion PR #84 updates the Journey Map acceptance playbook; this PR intentionally does not duplicate it.