### PR TITLE
Add least-privilege HubSpot Decision Inbox

### DIFF
--- a/.github/workflows/hubspot-decision-inbox.yml
+++ b/.github/workflows/hubspot-decision-inbox.yml
@@ -21,7 +21,10 @@ jobs:
         env:
           HUBSPOT_DECISION_INBOX_SYNC_TOKEN: ${{ secrets.HUBSPOT_DECISION_INBOX_SYNC_TOKEN }}
         run: |
-          test -n "$HUBSPOT_DECISION_INBOX_SYNC_TOKEN"
+          if [ -z "$HUBSPOT_DECISION_INBOX_SYNC_TOKEN" ]; then
+            echo "HubSpot Decision Inbox is not configured yet; no sync was attempted."
+            exit 0
+          fi
           curl --fail --silent --show-error --retry 1 --retry-all-errors \
             --request POST \
             --header "Authorization: Bearer $HUBSPOT_DECISION_INBOX_SYNC_TOKEN" \

--- a/.github/workflows/hubspot-decision-inbox.yml
+++ b/.github/workflows/hubspot-decision-inbox.yml
@@ -1,0 +1,28 @@
+name: HubSpot Decision Inbox
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hubspot-decision-inbox
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Sync genuine Ops decisions only
+        env:
+          HUBSPOT_DECISION_INBOX_SYNC_TOKEN: ${{ secrets.HUBSPOT_DECISION_INBOX_SYNC_TOKEN }}
+        run: |
+          test -n "$HUBSPOT_DECISION_INBOX_SYNC_TOKEN"
+          curl --fail --silent --show-error --retry 1 --retry-all-errors \
+            --request POST \
+            --header "Authorization: Bearer $HUBSPOT_DECISION_INBOX_SYNC_TOKEN" \
+            https://suburbmates.com.au/api/automation/hubspot-decision-inbox

--- a/docs/OPS/HUBSPOT_DECISION_INBOX.md
+++ b/docs/OPS/HUBSPOT_DECISION_INBOX.md
@@ -27,7 +27,7 @@ Exactly one HubSpot task may exist for each current, genuine operator action:
 
 The one-way integration creates or updates HubSpot **Tasks** only. Every task includes one canonical protected SuburbMates link and uses a stable SuburbMates work identifier. A successful protected Ops decision attempts to close its mapped HubSpot task, but a HubSpot outage must never block or reverse the decision. The next bounded reconciliation closes anything missed.
 
-Credentials are server-only and least-privilege: HubSpot task write access only. They are never exposed to the browser, stored in the database, or granted access to contacts, companies, deals, marketing, billing, or sensitive data.
+Credentials are server-only and least-privilege within HubSpot's available model: the Task API mandates the single coarse `crm.objects.contacts.write` scope even for unassociated Tasks. The integration code uses that token only for Task create/update calls; it never reads or writes contacts, companies, deals, marketing, billing, or sensitive data. The token is never exposed to the browser or stored in the database.
 
 ## Operator routine
 

--- a/docs/OPS/HUBSPOT_DECISION_INBOX.md
+++ b/docs/OPS/HUBSPOT_DECISION_INBOX.md
@@ -1,0 +1,37 @@
+# HubSpot Decision Inbox Contract
+
+## Purpose
+
+HubSpot is the solo operator's daily **Decision Inbox**. SuburbMates `/ops` remains the protected **Decision Room** and the only place that changes directory, ownership, profile, contact, privacy, or audit state.
+
+## What reaches HubSpot
+
+Exactly one HubSpot task may exist for each current, genuine operator action:
+
+| Label | Source in SuburbMates | HubSpot contents | Closure condition |
+| --- | --- | --- | --- |
+| Listing review | A listing in `draft` or `pending_review` | Plain title, priority, safe business name, direct `/ops/listings/:id` link | Listing no longer needs review after a protected decision. |
+| Possible duplicate | An open, sole `possible_duplicate` exception | Plain title and direct protected evidence link; no raw candidate data | Exception is acknowledged or dismissed, or its related review changes state. |
+| Ownership claim | A `pending` or `needs_information` claim | Safe business name and `/ops/claims/:id` link; no claimant identity or evidence | Claim is decided. |
+| Profile change | A `pending` profile-change request | Safe business name and `/ops/profile-edits/:id` link; no proposed values | Request is decided. |
+| Contact or privacy request | A `new` or `in_progress` contact request | Request class and `/ops/contact/:id` link only; business name only when explicitly safe | Request reaches a terminal decision. |
+| System issue | A failed, degraded or stale monitored health row, or a failed job | Plain service/job label and `/ops/system` anchor; no error payload | The monitored issue is healthy/current or the failed job is no longer actionable. |
+
+## Never send to HubSpot
+
+- directory-wide listings, background exclusions, repeat discoveries, or historic evidence gaps;
+- private contact message text, requester details, claimant details, evidence, ABNs, account data, media paths, audit notes, provider errors, or credentials;
+- a HubSpot action that publishes, claims, edits, deletes, or otherwise changes a SuburbMates record.
+
+## Technical boundary
+
+The one-way integration creates or updates HubSpot **Tasks** only. Every task includes one canonical protected SuburbMates link and uses a stable SuburbMates work identifier. A successful protected Ops decision attempts to close its mapped HubSpot task, but a HubSpot outage must never block or reverse the decision. The next bounded reconciliation closes anything missed.
+
+Credentials are server-only and least-privilege: HubSpot task write access only. They are never exposed to the browser, stored in the database, or granted access to contacts, companies, deals, marketing, billing, or sensitive data.
+
+## Operator routine
+
+1. Open HubSpot and work only the short Decision Inbox.
+2. Open the linked `/ops` page.
+3. Read the protected evidence and make the bounded decision there.
+4. The corresponding HubSpot task closes automatically; background evidence remains out of sight.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run existing-catalogue-requalification:test && npm run abn-check:test && npm run abn-evidence:test && npm run transactional-communications:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test && npm run ops-action-queue:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run existing-catalogue-requalification:test && npm run abn-check:test && npm run abn-evidence:test && npm run transactional-communications:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test && npm run ops-action-queue:test && npm run hubspot-decision-inbox:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -43,6 +43,7 @@
     "owner-submitted-business-candidate:test": "tsx scripts/test-owner-submitted-business-candidate-boundary.ts",
     "ops-system:test": "tsx scripts/test-ops-system-boundary.ts",
     "ops-action-queue:test": "tsx scripts/test-ops-action-queue-boundary.ts && npm run ops-workspace:test && npm run rejected-listing-deletion:test",
+    "hubspot-decision-inbox:test": "tsx scripts/test-hubspot-decision-inbox-boundary.ts",
     "ops-workspace:test": "tsx scripts/test-ops-workspace-boundary.ts",
     "rejected-listing-deletion:test": "tsx scripts/test-rejected-listing-deletion-boundary.ts",
     "verify:db": "tsx --env-file=.env.local scripts/verify-db.ts"

--- a/scripts/test-hubspot-decision-inbox-boundary.ts
+++ b/scripts/test-hubspot-decision-inbox-boundary.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { makeHubSpotDecisionTask } from "../web/src/lib/hubspot/decision-task.ts";
+
+const privateText = "private requester@example.test ABN 12345678901 confidential message";
+const contactTask = makeHubSpotDecisionTask({
+  workId: "contact:11111111-1111-4111-8111-111111111111",
+  kind: "contact",
+  priority: "needs_decision",
+  href: "/ops/contact/11111111-1111-4111-8111-111111111111",
+  title: privateText,
+  topic: "privacy",
+}, "123", "https://suburbmates.com.au", "2026-08-05T00:00:00.000Z");
+
+assert.equal(contactTask.properties.hs_task_subject, "Review privacy request");
+assert.doesNotMatch(JSON.stringify(contactTask), /requester@example|12345678901|confidential message/);
+assert.match(contactTask.properties.hs_task_body, /^Open the protected SuburbMates decision: https:\/\/suburbmates\.com\.au\/ops\/contact\//);
+assert.throws(() => makeHubSpotDecisionTask({ workId: "bad", kind: "system", priority: "act_now", href: "/contact" }, "123", "https://suburbmates.com.au", "2026-08-05T00:00:00.000Z"));
+
+const integration = fs.readFileSync("web/src/lib/hubspot/decision-inbox.ts", "utf8");
+const route = fs.readFileSync("web/src/app/api/automation/hubspot-decision-inbox/route.ts", "utf8");
+const workflow = fs.readFileSync(".github/workflows/hubspot-decision-inbox.yml", "utf8");
+const migration = fs.readFileSync("supabase/migrations/20260805112425_hubspot_decision_inbox.sql", "utf8");
+
+assert.match(integration, /HUBSPOT_PRIVATE_APP_TOKEN/);
+assert.match(integration, /HUBSPOT_DECISION_INBOX_ENABLED/);
+assert.match(integration, /candidate_handoff_records"\)\.select\("id, qualification_reasons"/);
+assert.doesNotMatch(integration, /candidate_data|requester_email|requester_name|claimant_email|proposed_changes|ABN/);
+assert.match(route, /HUBSPOT_DECISION_INBOX_SYNC_TOKEN/);
+assert.match(workflow, /HUBSPOT_DECISION_INBOX_SYNC_TOKEN/);
+assert.match(workflow, /hubspot-decision-inbox/);
+assert.match(migration, /ENABLE ROW LEVEL SECURITY/);
+assert.match(migration, /REVOKE ALL ON TABLE public\.hubspot_decision_inbox_items FROM PUBLIC, anon, authenticated/);
+assert.match(migration, /GRANT ALL ON TABLE public\.hubspot_decision_inbox_items TO service_role/);
+
+console.log("HubSpot Decision Inbox boundary checks passed.");

--- a/scripts/test-hubspot-decision-inbox-boundary.ts
+++ b/scripts/test-hubspot-decision-inbox-boundary.ts
@@ -32,6 +32,7 @@ assert.doesNotMatch(integration, /candidate_data|requester_email|requester_name|
 assert.match(route, /HUBSPOT_DECISION_INBOX_SYNC_TOKEN/);
 assert.match(workflow, /HUBSPOT_DECISION_INBOX_SYNC_TOKEN/);
 assert.match(workflow, /hubspot-decision-inbox/);
+assert.match(workflow, /no sync was attempted/);
 assert.match(migration, /ENABLE ROW LEVEL SECURITY/);
 assert.match(migration, /REVOKE ALL ON TABLE public\.hubspot_decision_inbox_items FROM PUBLIC, anon, authenticated/);
 assert.match(migration, /GRANT ALL ON TABLE public\.hubspot_decision_inbox_items TO service_role/);

--- a/scripts/test-hubspot-decision-inbox-boundary.ts
+++ b/scripts/test-hubspot-decision-inbox-boundary.ts
@@ -21,6 +21,9 @@ const integration = fs.readFileSync("web/src/lib/hubspot/decision-inbox.ts", "ut
 const route = fs.readFileSync("web/src/app/api/automation/hubspot-decision-inbox/route.ts", "utf8");
 const workflow = fs.readFileSync(".github/workflows/hubspot-decision-inbox.yml", "utf8");
 const migration = fs.readFileSync("supabase/migrations/20260805112425_hubspot_decision_inbox.sql", "utf8");
+const listings = fs.readFileSync("web/src/app/ops/listings/actions.ts", "utf8");
+const claims = fs.readFileSync("web/src/app/ops/claims/actions.ts", "utf8");
+const contact = fs.readFileSync("web/src/app/ops/contact/actions.ts", "utf8");
 
 assert.match(integration, /HUBSPOT_PRIVATE_APP_TOKEN/);
 assert.match(integration, /HUBSPOT_DECISION_INBOX_ENABLED/);
@@ -32,5 +35,8 @@ assert.match(workflow, /hubspot-decision-inbox/);
 assert.match(migration, /ENABLE ROW LEVEL SECURITY/);
 assert.match(migration, /REVOKE ALL ON TABLE public\.hubspot_decision_inbox_items FROM PUBLIC, anon, authenticated/);
 assert.match(migration, /GRANT ALL ON TABLE public\.hubspot_decision_inbox_items TO service_role/);
+assert.match(listings, /decision === "publish" \|\| decision === "reject"/);
+assert.match(claims, /action !== "needs_information"/);
+assert.match(contact, /status === "resolved" \|\| status === "spam"/);
 
 console.log("HubSpot Decision Inbox boundary checks passed.");

--- a/supabase/migrations/20260805112425_hubspot_decision_inbox.sql
+++ b/supabase/migrations/20260805112425_hubspot_decision_inbox.sql
@@ -1,0 +1,27 @@
+-- HubSpot is a one-way, low-detail Decision Inbox. This mapping contains only
+-- the stable SuburbMates work identifier and the HubSpot task identifier; it
+-- never stores request text, claimant data, contact details, ABNs or audit
+-- notes. SuburbMates /ops remains the only decision-making surface.
+
+CREATE TABLE public.hubspot_decision_inbox_items (
+  work_item_id TEXT PRIMARY KEY,
+  hubspot_task_id TEXT NOT NULL UNIQUE,
+  work_kind TEXT NOT NULL CHECK (work_kind IN (
+    'listing', 'claim', 'profile', 'contact', 'candidate', 'catalogue', 'system'
+  )),
+  task_state TEXT NOT NULL DEFAULT 'open' CHECK (task_state IN ('open', 'completed')),
+  fingerprint TEXT NOT NULL,
+  last_synced_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc'::text, now()),
+  completed_at TIMESTAMPTZ
+);
+
+ALTER TABLE public.hubspot_decision_inbox_items ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.hubspot_decision_inbox_items FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.hubspot_decision_inbox_items TO service_role;
+
+CREATE INDEX hubspot_decision_inbox_open_idx
+  ON public.hubspot_decision_inbox_items (task_state, last_synced_at DESC)
+  WHERE task_state = 'open';
+
+COMMENT ON TABLE public.hubspot_decision_inbox_items IS
+  'Service-only mapping for low-detail HubSpot Decision Inbox tasks. It contains no protected Ops evidence.';

--- a/web/src/app/api/automation/hubspot-decision-inbox/route.ts
+++ b/web/src/app/api/automation/hubspot-decision-inbox/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { syncHubSpotDecisionInbox } from "@/lib/hubspot/decision-inbox";
+import { runtimeEnv } from "@/lib/runtime-env";
+
+export async function POST(request: NextRequest) {
+  const token = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+  const expectedToken = runtimeEnv("HUBSPOT_DECISION_INBOX_SYNC_TOKEN");
+  if (!token || !expectedToken || token !== expectedToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const result = await syncHubSpotDecisionInbox();
+    if (!result.enabled) return NextResponse.json({ error: "HubSpot Decision Inbox is not configured" }, { status: 503 });
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json({ error: "HubSpot Decision Inbox sync failed" }, { status: 500 });
+  }
+}

--- a/web/src/app/ops/candidates/actions.ts
+++ b/web/src/app/ops/candidates/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
+import { closeHubSpotDecisionInboxTask } from "@/lib/hubspot/decision-inbox";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -21,6 +22,7 @@ export async function resolveCandidateExceptionAction(formData: FormData) {
     p_operator_note: note,
   });
   if (error) redirect(`${detailPath}?error=resolve`);
+  await closeHubSpotDecisionInboxTask(`candidate:${recordId}`);
   revalidatePath("/ops");
   revalidatePath("/ops/candidates");
   revalidatePath(detailPath);

--- a/web/src/app/ops/claims/actions.ts
+++ b/web/src/app/ops/claims/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 import { sendStage1Status } from "@/lib/communications/stage1-status";
+import { closeHubSpotDecisionInboxTask } from "@/lib/hubspot/decision-inbox";
 
 const allowedActions = new Set(["needs_information", "approve", "reject", "revoke"]);
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -29,6 +30,7 @@ export async function reviewClaimAction(formData: FormData) {
   if (error) {
     redirect(`${detailPath}?error=decision`);
   }
+  if (action !== "needs_information") await closeHubSpotDecisionInboxTask(`claim:${claimId}`);
   await sendStage1Status("claim_request", claimId);
 
   revalidatePath("/ops");

--- a/web/src/app/ops/contact/actions.ts
+++ b/web/src/app/ops/contact/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 import { sendStage2Outcome } from "@/lib/communications/stage1-status";
+import { closeHubSpotDecisionInboxTask } from "@/lib/hubspot/decision-inbox";
 
 const allowedStatuses = new Set(["new", "in_progress", "resolved", "spam"]);
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -25,6 +26,7 @@ export async function reviewContactAction(formData: FormData) {
     p_reason: reason,
   });
   if (error) redirect(`${detailPath}?error=decision`);
+  if (status === "resolved" || status === "spam") await closeHubSpotDecisionInboxTask(`contact:${requestId}`);
   if (status === "resolved") await sendStage2Outcome("contact_request", requestId);
 
   revalidatePath("/ops");

--- a/web/src/app/ops/listings/actions.ts
+++ b/web/src/app/ops/listings/actions.ts
@@ -107,7 +107,7 @@ export async function decideListingAction(formData: FormData) {
     p_operator_note: note,
   });
   if (error) redirect(`${detailPath}?error=decision`);
-  await closeHubSpotDecisionInboxTask(`listing:${vendorId}`);
+  if (decision === "publish" || decision === "reject") await closeHubSpotDecisionInboxTask(`listing:${vendorId}`);
   const { data: afterRoute } = await supabase.rpc("resolve_public_vendor_route", { p_route_key: vendorId });
 
   revalidatePath("/ops");

--- a/web/src/app/ops/listings/actions.ts
+++ b/web/src/app/ops/listings/actions.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 import { checkAbn, normalizeAbn } from "@/lib/automation/abn-lookup";
 import { sendStage2Outcome } from "@/lib/communications/stage1-status";
+import { closeHubSpotDecisionInboxTask } from "@/lib/hubspot/decision-inbox";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const decisions = new Set(["publish", "approve_changes", "reject", "unpublish", "restore"]);
@@ -106,6 +107,7 @@ export async function decideListingAction(formData: FormData) {
     p_operator_note: note,
   });
   if (error) redirect(`${detailPath}?error=decision`);
+  await closeHubSpotDecisionInboxTask(`listing:${vendorId}`);
   const { data: afterRoute } = await supabase.rpc("resolve_public_vendor_route", { p_route_key: vendorId });
 
   revalidatePath("/ops");

--- a/web/src/app/ops/profile-edits/actions.ts
+++ b/web/src/app/ops/profile-edits/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { verifyOpsAdmin } from "@/lib/ops/auth";
 import { sendStage1Status } from "@/lib/communications/stage1-status";
+import { closeHubSpotDecisionInboxTask } from "@/lib/hubspot/decision-inbox";
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -25,6 +26,7 @@ export async function reviewProfileChangeAction(formData: FormData) {
   });
 
   if (error) redirect(`${detailPath}?error=decision`);
+  await closeHubSpotDecisionInboxTask(`profile:${requestId}`);
   await sendStage1Status("profile_change", requestId);
 
   const vendorId = data?.[0]?.vendor_id;

--- a/web/src/lib/hubspot/decision-inbox.ts
+++ b/web/src/lib/hubspot/decision-inbox.ts
@@ -1,0 +1,188 @@
+import "server-only";
+
+import { makeHubSpotDecisionTask, type DecisionInboxItem, type DecisionInboxKind } from "@/lib/hubspot/decision-task";
+import { runtimeEnv } from "@/lib/runtime-env";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+type Mapping = {
+  work_item_id: string;
+  hubspot_task_id: string;
+  work_kind: DecisionInboxKind;
+  task_state: "open" | "completed";
+  fingerprint: string;
+};
+
+type SyncResult = { enabled: boolean; created: number; updated: number; completed: number; open: number };
+
+const hubSpotTaskEndpoint = "https://api.hubapi.com/crm/objects/2026-03/tasks";
+const taskKinds = new Set<DecisionInboxKind>(["listing", "claim", "profile", "contact", "candidate", "catalogue", "system"]);
+
+export async function syncHubSpotDecisionInbox(): Promise<SyncResult> {
+  const config = configForHubSpotDecisionInbox();
+  if (!config) return { enabled: false, created: 0, updated: 0, completed: 0, open: 0 };
+
+  const admin = createAdminClient();
+  const items = await loadOpenDecisionInboxItems();
+  const { data: storedMappings, error: mappingError } = await admin
+    .from("hubspot_decision_inbox_items")
+    .select("work_item_id, hubspot_task_id, work_kind, task_state, fingerprint");
+  if (mappingError) throw new Error("Could not load HubSpot Decision Inbox mappings.");
+  const mappings = new Map((storedMappings ?? []).map((mapping) => [mapping.work_item_id, mapping as Mapping]));
+  const now = new Date().toISOString();
+  let created = 0;
+  let updated = 0;
+  let completed = 0;
+
+  for (const item of items) {
+    const task = makeHubSpotDecisionTask(item, config.ownerId, config.baseUrl, now);
+    const mapping = mappings.get(item.workId);
+    if (!mapping) {
+      const taskId = await createHubSpotTask(config.token, task.properties);
+      await saveMapping(admin, { workItemId: item.workId, taskId, workKind: item.kind, state: "open", fingerprint: task.fingerprint });
+      created++;
+      continue;
+    }
+    if (mapping.task_state === "completed" || mapping.fingerprint !== task.fingerprint) {
+      await updateHubSpotTask(config.token, mapping.hubspot_task_id, task.properties);
+      await saveMapping(admin, { workItemId: item.workId, taskId: mapping.hubspot_task_id, workKind: item.kind, state: "open", fingerprint: task.fingerprint });
+      updated++;
+    }
+  }
+
+  const activeIds = new Set(items.map((item) => item.workId));
+  for (const mapping of mappings.values()) {
+    if (mapping.task_state === "open" && !activeIds.has(mapping.work_item_id)) {
+      await completeHubSpotTask(config.token, mapping.hubspot_task_id);
+      await saveMapping(admin, { workItemId: mapping.work_item_id, taskId: mapping.hubspot_task_id, workKind: mapping.work_kind, state: "completed", fingerprint: mapping.fingerprint });
+      completed++;
+    }
+  }
+
+  return { enabled: true, created, updated, completed, open: items.length };
+}
+
+// A HubSpot outage must not block a protected Ops decision. The scheduled
+// reconciliation will retry any closure that cannot be completed here.
+export async function closeHubSpotDecisionInboxTask(workItemId: string) {
+  const config = configForHubSpotDecisionInbox();
+  if (!config) return false;
+  try {
+    const admin = createAdminClient();
+    const { data: mapping, error } = await admin
+      .from("hubspot_decision_inbox_items")
+      .select("work_item_id, hubspot_task_id, work_kind, task_state, fingerprint")
+      .eq("work_item_id", workItemId)
+      .maybeSingle();
+    if (error || !mapping || mapping.task_state === "completed" || !taskKinds.has(mapping.work_kind as DecisionInboxKind)) return false;
+    await completeHubSpotTask(config.token, mapping.hubspot_task_id);
+    await saveMapping(admin, {
+      workItemId: mapping.work_item_id,
+      taskId: mapping.hubspot_task_id,
+      workKind: mapping.work_kind as DecisionInboxKind,
+      state: "completed",
+      fingerprint: mapping.fingerprint,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function hubSpotDecisionInboxIsConfigured() {
+  return Boolean(configForHubSpotDecisionInbox());
+}
+
+async function loadOpenDecisionInboxItems(): Promise<DecisionInboxItem[]> {
+  const admin = createAdminClient();
+  const [listings, claims, profiles, contacts, candidates, health, jobs, latestCatalogueRun] = await Promise.all([
+    admin.from("vendors").select("id, business_name").or("listing_status.is.null,listing_status.in.(draft,pending_review)"),
+    admin.from("claim_requests").select("id, claim_status, vendors!inner(business_name)").in("claim_status", ["pending", "needs_information"]),
+    admin.from("listing_change_requests").select("id, vendors!inner(business_name)").eq("change_status", "pending"),
+    admin.from("contact_requests").select("id, topic").in("contact_status", ["new", "in_progress"]),
+    admin.from("candidate_handoff_records").select("id, qualification_reasons").eq("qualification_outcome", "exception").eq("exception_status", "open").contains("qualification_reasons", ["possible_duplicate"]),
+    admin.from("integration_health").select("integration_name, status").in("status", ["failed", "degraded", "stale"]),
+    admin.from("automation_jobs").select("id, job_type").eq("status", "failed"),
+    admin.from("existing_catalogue_requalification_runs").select("id").eq("status", "completed").order("completed_at", { ascending: false, nullsFirst: false }).limit(1).maybeSingle(),
+  ]);
+  for (const result of [listings, claims, profiles, contacts, candidates, health, jobs, latestCatalogueRun]) {
+    if (result.error) throw new Error("Could not load the current SuburbMates decision queue.");
+  }
+
+  const catalogue = latestCatalogueRun.data
+    ? await admin.from("existing_catalogue_requalification_records").select("id, vendor_id, qualification_reasons").eq("run_id", latestCatalogueRun.data.id).eq("qualification_outcome", "exception").eq("exception_status", "open").contains("qualification_reasons", ["possible_duplicate"])
+    : { data: [], error: null };
+  if (catalogue.error) throw new Error("Could not load current catalogue review decisions.");
+
+  return [
+    ...(listings.data ?? []).map((row) => item(`listing:${row.id}`, "listing", "needs_decision", `/ops/listings/${row.id}`, row.business_name)),
+    ...(claims.data ?? []).map((row) => item(`claim:${row.id}`, "claim", "needs_decision", `/ops/claims/${row.id}`, firstBusinessName(row.vendors))),
+    ...(profiles.data ?? []).map((row) => item(`profile:${row.id}`, "profile", "needs_decision", `/ops/profile-edits/${row.id}`, firstBusinessName(row.vendors))),
+    ...(contacts.data ?? []).map((row) => item(`contact:${row.id}`, "contact", "needs_decision", `/ops/contact/${row.id}`, null, row.topic)),
+    ...(candidates.data ?? []).filter((row) => isOnlyPossibleDuplicate(row.qualification_reasons)).map((row) => item(`candidate:${row.id}`, "candidate", "needs_decision", `/ops/candidates/${row.id}`)),
+    ...(catalogue.data ?? []).filter((row) => isOnlyPossibleDuplicate(row.qualification_reasons)).map((row) => item(`catalogue:${row.id}`, "catalogue", "later_review", `/ops/listings/${row.vendor_id}`)),
+    ...(health.data ?? []).map((row) => item(`health:${row.integration_name}`, "system", "act_now", `/ops/system#health-${row.integration_name}`, row.integration_name)),
+    ...(jobs.data ?? []).map((row) => item(`job:${row.id}`, "system", "act_now", `/ops/system#job-${row.id}`, row.job_type)),
+  ];
+}
+
+function item(workId: string, kind: DecisionInboxKind, priority: DecisionInboxItem["priority"], href: string, title?: string | null, topic?: string | null): DecisionInboxItem {
+  return { workId, kind, priority, href, title, topic };
+}
+
+function firstBusinessName(value: unknown): string | null {
+  if (Array.isArray(value)) return firstBusinessName(value[0]);
+  if (!value || typeof value !== "object") return null;
+  const businessName = (value as { business_name?: unknown }).business_name;
+  return typeof businessName === "string" ? businessName : null;
+}
+
+function isOnlyPossibleDuplicate(value: unknown) {
+  return Array.isArray(value) && value.length === 1 && value[0] === "possible_duplicate";
+}
+
+async function saveMapping(admin: ReturnType<typeof createAdminClient>, input: { workItemId: string; taskId: string; workKind: DecisionInboxKind; state: "open" | "completed"; fingerprint: string }) {
+  const { error } = await admin.from("hubspot_decision_inbox_items").upsert({
+    work_item_id: input.workItemId,
+    hubspot_task_id: input.taskId,
+    work_kind: input.workKind,
+    task_state: input.state,
+    fingerprint: input.fingerprint,
+    last_synced_at: new Date().toISOString(),
+    completed_at: input.state === "completed" ? new Date().toISOString() : null,
+  }, { onConflict: "work_item_id" });
+  if (error) throw new Error("Could not store the HubSpot Decision Inbox mapping.");
+}
+
+async function createHubSpotTask(token: string, properties: Record<string, string>) {
+  const response = await hubSpotRequest(token, hubSpotTaskEndpoint, "POST", { properties });
+  const body = await response.json().catch(() => null) as { id?: unknown } | null;
+  if (!response.ok || typeof body?.id !== "string") throw new Error("HubSpot could not create the Decision Inbox task.");
+  return body.id;
+}
+
+async function updateHubSpotTask(token: string, taskId: string, properties: Record<string, string>) {
+  const response = await hubSpotRequest(token, `${hubSpotTaskEndpoint}/${encodeURIComponent(taskId)}`, "PATCH", { properties });
+  if (!response.ok) throw new Error("HubSpot could not update the Decision Inbox task.");
+}
+
+async function completeHubSpotTask(token: string, taskId: string) {
+  const response = await hubSpotRequest(token, `${hubSpotTaskEndpoint}/${encodeURIComponent(taskId)}`, "PATCH", { properties: { hs_task_status: "COMPLETED" } });
+  if (!response.ok) throw new Error("HubSpot could not close the Decision Inbox task.");
+}
+
+function hubSpotRequest(token: string, url: string, method: "POST" | "PATCH", body: unknown) {
+  return fetch(url, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(8_000),
+  });
+}
+
+function configForHubSpotDecisionInbox() {
+  if (runtimeEnv("HUBSPOT_DECISION_INBOX_ENABLED") !== "true") return null;
+  const token = runtimeEnv("HUBSPOT_PRIVATE_APP_TOKEN");
+  const ownerId = runtimeEnv("HUBSPOT_OWNER_ID");
+  if (!token || !ownerId) return null;
+  return { token, ownerId, baseUrl: runtimeEnv("NEXT_PUBLIC_BASE_URL") ?? "https://suburbmates.com.au" };
+}

--- a/web/src/lib/hubspot/decision-task.ts
+++ b/web/src/lib/hubspot/decision-task.ts
@@ -1,0 +1,73 @@
+export type DecisionInboxKind = "listing" | "claim" | "profile" | "contact" | "candidate" | "catalogue" | "system";
+export type DecisionInboxPriority = "act_now" | "needs_decision" | "later_review";
+
+export type DecisionInboxItem = {
+  workId: string;
+  kind: DecisionInboxKind;
+  priority: DecisionInboxPriority;
+  href: string;
+  title?: string | null;
+  topic?: string | null;
+};
+
+export type HubSpotTaskPayload = {
+  workId: string;
+  fingerprint: string;
+  properties: {
+    hs_timestamp: string;
+    hs_task_subject: string;
+    hs_task_body: string;
+    hs_task_status: "NOT_STARTED" | "COMPLETED";
+    hs_task_priority: "HIGH" | "MEDIUM" | "LOW";
+    hs_task_type: "TODO";
+    hubspot_owner_id: string;
+  };
+};
+
+const allowedTopics = new Set(["general", "listing_correction", "claim_help", "privacy", "technical", "partnership", "other"]);
+
+export function makeHubSpotDecisionTask(item: DecisionInboxItem, ownerId: string, baseUrl: string, timestamp: string): HubSpotTaskPayload {
+  if (!item.href.startsWith("/ops/")) throw new Error("HubSpot Decision Inbox links must lead to protected Ops.");
+  const url = `${baseUrl.replace(/\/$/, "")}${item.href}`;
+  const subject = decisionSubject(item);
+  const priority = item.priority === "act_now" ? "HIGH" : item.priority === "later_review" ? "LOW" : "MEDIUM";
+  const fingerprint = JSON.stringify([item.kind, item.priority, subject, url]);
+
+  return {
+    workId: item.workId,
+    fingerprint,
+    properties: {
+      hs_timestamp: timestamp,
+      hs_task_subject: subject,
+      hs_task_body: `Open the protected SuburbMates decision: ${url}`,
+      hs_task_status: "NOT_STARTED",
+      hs_task_priority: priority,
+      hs_task_type: "TODO",
+      hubspot_owner_id: ownerId,
+    },
+  };
+}
+
+function decisionSubject(item: DecisionInboxItem): string {
+  const businessName = safeBusinessName(item.title);
+  switch (item.kind) {
+    case "listing": return businessName ? `Review listing — ${businessName}` : "Review listing";
+    case "claim": return businessName ? `Review ownership claim — ${businessName}` : "Review ownership claim";
+    case "profile": return businessName ? `Review profile change — ${businessName}` : "Review profile change";
+    case "contact": return `Review ${safeContactTopic(item.topic)} request`;
+    case "candidate": return "Review possible duplicate";
+    case "catalogue": return "Review older possible duplicate";
+    case "system": return businessName ? `Investigate system issue — ${businessName}` : "Investigate system issue";
+  }
+}
+
+function safeBusinessName(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = value.replace(/\s+/g, " ").trim().slice(0, 180);
+  return normalized || null;
+}
+
+function safeContactTopic(value: string | null | undefined): string {
+  if (!value || !allowedTopics.has(value)) return "contact";
+  return value.replaceAll("_", " ");
+}


### PR DESCRIPTION
## What this adds
- A one-way HubSpot Task inbox for genuine, open SuburbMates Ops decisions only.
- Protected SuburbMates links; no contact text, requester or claimant data, evidence, ABNs, or audit notes leave SuburbMates.
- Successful protected Ops decisions close their mapped HubSpot task without allowing a HubSpot outage to block the decision.
- A 15-minute bounded reconciliation workflow, using a separate sync secret.

## Safety
- No directory import, HubSpot contacts, companies, deals, marketing, billing, or publication changes.
- HubSpot Task API mandates its coarse crm.objects.contacts.write scope. It is the sole requested scope. The SuburbMates service only calls Task create/update endpoints and never reads or writes contacts.

## Verification
- npm run check
- npm --prefix web run cf:build
- Remote Supabase migration 20260805112425_hubspot_decision_inbox.sql applied successfully.