### PR TITLE
Clarify contact verification readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run existing-catalogue-requalification:test && npm run abn-check:test && npm run abn-evidence:test && npm run transactional-communications:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test && npm run ops-action-queue:test && npm run hubspot-decision-inbox:test",
+    "check": "npm run audit:test && npm run acquire:osm:test && npm run catalogue:merge:test && npm run seed:test && npm run candidate-qualification:test && npm run candidate-handoff:test && npm run candidate-automation-ingest:test && npm run existing-catalogue-requalification:test && npm run abn-check:test && npm run abn-evidence:test && npm run transactional-communications:test && npm run owner-media:test && npm run public-catalogue:test && npm run directory-ranking:test && npm run resident-journey:test && npm run contact-intake:test && npm run edge-functions:test && npm run vendor-slug:test && npm run website-safety:test && npm run owner-status:test && npm run ops-system:test && npm run ops-action-queue:test && npm run hubspot-decision-inbox:test",
     "dev": "npm --prefix web run dev",
     "seed": "tsx --env-file=.env.local scripts/seed.ts",
     "seed:test": "tsx --env-file-if-exists=.env.local scripts/test-seed-policy.ts",
@@ -17,6 +17,7 @@
     "abn-check:test": "tsx scripts/test-abn-lookup.ts",
     "abn-evidence:test": "tsx scripts/test-abn-evidence-boundary.ts",
     "transactional-communications:test": "tsx scripts/test-transactional-communications-boundary.ts",
+    "contact-intake:test": "tsx scripts/test-contact-intake-boundary.ts",
     "owner-media:test": "tsx scripts/test-owner-media-boundary.ts",
     "claim:test": "tsx --env-file=.env.local scripts/test-claims.ts",
     "audit": "tsx --env-file-if-exists=.env.local scripts/audit-vendor-candidates.ts",

--- a/scripts/test-contact-intake-boundary.ts
+++ b/scripts/test-contact-intake-boundary.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const page = fs.readFileSync("web/src/app/(directory)/contact/page.tsx", "utf8");
+const form = fs.readFileSync("web/src/app/(directory)/contact/ContactForm.tsx", "utf8");
+const actions = fs.readFileSync("web/src/app/(directory)/contact/actions.ts", "utf8");
+
+assert.match(page, /ContactForm/);
+assert.doesNotMatch(page, /cf-turnstile/);
+assert.match(form, /TurnstileField siteKey=\{siteKey\} action="contact"/);
+assert.match(form, /Send support request/);
+assert.match(form, /Sending securely/);
+assert.match(form, /min-w-0/);
+assert.match(actions, /verifyTurnstileToken\(token, "contact"\)/);
+assert.match(actions, /submit_contact_request/);
+console.log("Contact intake boundary checks passed.");

--- a/web/src/app/(directory)/contact/ContactForm.tsx
+++ b/web/src/app/(directory)/contact/ContactForm.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { submitContactAction } from "./actions";
+import { SubmitButton, TurnstileField } from "../join/JoinFormControls";
+
+export function ContactForm({ siteKey, initialTopic, initialBusiness }: { siteKey: string; initialTopic: string; initialBusiness: string }) {
+  return <form action={submitContactAction} className="mt-6 space-y-5">
+    <div className="hidden" aria-hidden="true">
+      <label htmlFor="website">Leave this field empty</label>
+      <input id="website" name="website" type="text" tabIndex={-1} autoComplete="off" />
+    </div>
+
+    <div className="grid gap-5 sm:grid-cols-2">
+      <Field label="Your name" name="requesterName" required minLength={2} maxLength={120} autoComplete="name" />
+      <Field label="Reply email" name="requesterEmail" type="email" required maxLength={254} autoComplete="email" />
+    </div>
+
+    <label className="block min-w-0 text-sm font-bold">What do you need help with?
+      <select name="topic" required defaultValue={initialTopic} className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 bg-white p-3 font-normal">
+        <option value="general">General support</option>
+        <option value="listing_correction">Correct a listing</option>
+        <option value="claim_help">Claim help</option>
+        <option value="privacy">Privacy request</option>
+        <option value="technical">Technical problem</option>
+        <option value="partnership">Partnership</option>
+        <option value="other">Something else</option>
+      </select>
+    </label>
+
+    <Field label="Business name (optional)" name="businessName" maxLength={200} autoComplete="organization" defaultValue={initialBusiness} />
+    <label className="block min-w-0 text-sm font-bold">Message
+      <textarea name="message" required minLength={10} maxLength={4000} rows={7} className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" />
+    </label>
+
+    <label className="flex min-w-0 items-start gap-3 text-sm leading-6 text-slate-700">
+      <input name="consent" type="checkbox" required className="mt-1 h-4 w-4 shrink-0" />
+      <span>I agree that SuburbMates may use these details to review and respond to this request as described in the <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span>
+    </label>
+
+    <TurnstileField siteKey={siteKey} action="contact" />
+    <SubmitButton pendingLabel="Sending securely…">Send support request</SubmitButton>
+  </form>;
+}
+
+function Field({ label, name, type = "text", required, minLength, maxLength, autoComplete, defaultValue }: { label: string; name: string; type?: string; required?: boolean; minLength?: number; maxLength: number; autoComplete?: string; defaultValue?: string }) {
+  return <label className="block min-w-0 text-sm font-bold">{label}
+    <input name={name} type={type} required={required} minLength={minLength} maxLength={maxLength} autoComplete={autoComplete} defaultValue={defaultValue} className="mt-2 w-full min-w-0 rounded-xl border border-slate-300 p-3 font-normal" />
+  </label>;
+}

--- a/web/src/app/(directory)/contact/page.tsx
+++ b/web/src/app/(directory)/contact/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import Script from "next/script";
 import { runtimeEnv } from "@/lib/runtime-env";
-import { submitContactAction } from "./actions";
+import { ContactForm } from "./ContactForm";
 
 export const dynamic = "force-dynamic";
 
@@ -41,77 +40,15 @@ export default async function ContactPage({
 
       <section className="mt-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
         <h2 className="text-2xl font-black">Send a support request</h2>
-        <p className="mt-2 text-sm leading-6 text-slate-600">
-          Your request goes to the private SuburbMates operations queue. We use your details only to review and respond to this request.
-        </p>
+        <p className="mt-2 text-sm leading-6 text-slate-600">Your request goes to the private SuburbMates operations queue. We use your details only to review and respond to this request.</p>
 
-        {message.sent === "1" && (
-          <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">
-            Your request has been received. Keep this page for your records; an operator will review it.
-          </p>
-        )}
-        {message.error && (
-          <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">
-            {contactError(message.error)}
-          </p>
-        )}
+        {message.sent === "1" && <p className="mt-5 rounded-xl border border-green-300 bg-green-50 p-4 text-sm font-semibold text-green-800" role="status">Your request has been received. Keep this page for your records; an operator will review it.</p>}
+        {message.error && <p className="mt-5 rounded-xl border border-red-300 bg-red-50 p-4 text-sm font-semibold text-red-800" role="alert">{contactError(message.error)}</p>}
 
         {!siteKey ? (
-          <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">
-            The secure contact form is temporarily unavailable. Claim and listing links above remain available.
-          </p>
-        ) : (
-          <form action={submitContactAction} className="mt-6 space-y-5">
-            <div className="hidden" aria-hidden="true">
-              <label htmlFor="website">Leave this field empty</label>
-              <input id="website" name="website" type="text" tabIndex={-1} autoComplete="off" />
-            </div>
-
-            <div className="grid gap-5 sm:grid-cols-2">
-              <label className="block text-sm font-bold">
-                Your name
-                <input name="requesterName" required minLength={2} maxLength={120} autoComplete="name" className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" />
-              </label>
-              <label className="block text-sm font-bold">
-                Reply email
-                <input name="requesterEmail" type="email" required maxLength={254} autoComplete="email" className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" />
-              </label>
-            </div>
-
-            <label className="block text-sm font-bold">
-              What do you need help with?
-              <select name="topic" required defaultValue={initialTopic} className="mt-2 w-full rounded-xl border border-slate-300 bg-white p-3 font-normal">
-                <option value="general">General support</option>
-                <option value="listing_correction">Correct a listing</option>
-                <option value="claim_help">Claim help</option>
-                <option value="privacy">Privacy request</option>
-                <option value="technical">Technical problem</option>
-                <option value="partnership">Partnership</option>
-                <option value="other">Something else</option>
-              </select>
-            </label>
-
-            <label className="block text-sm font-bold">
-              Business name <span className="font-normal text-slate-500">(optional)</span>
-              <input name="businessName" defaultValue={initialBusiness} maxLength={200} autoComplete="organization" className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" />
-            </label>
-
-            <label className="block text-sm font-bold">
-              Message
-              <textarea name="message" required minLength={10} maxLength={4000} rows={7} className="mt-2 w-full rounded-xl border border-slate-300 p-3 font-normal" />
-            </label>
-
-            <label className="flex items-start gap-3 text-sm leading-6 text-slate-700">
-              <input name="consent" type="checkbox" required className="mt-1 h-4 w-4" />
-              <span>I agree that SuburbMates may use these details to review and respond to my request as described in the <Link href="/privacy" className="font-bold underline">privacy notice</Link>.</span>
-            </label>
-
-            <div className="cf-turnstile" data-sitekey={siteKey} data-action="contact" data-theme="light" />
-            <button type="submit" className="btn btn-primary">Send support request</button>
-          </form>
-        )}
+          <p className="mt-5 rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm font-semibold text-amber-900">The secure contact form is temporarily unavailable. Claim and listing links above remain available.</p>
+        ) : <ContactForm siteKey={siteKey} initialTopic={initialTopic} initialBusiness={initialBusiness} />}
       </section>
-      {siteKey && <Script src="https://challenges.cloudflare.com/turnstile/v0/api.js" strategy="afterInteractive" />}
     </div>
   );
 }

--- a/web/src/app/(directory)/join/JoinFormControls.tsx
+++ b/web/src/app/(directory)/join/JoinFormControls.tsx
@@ -79,7 +79,7 @@ export function SubmitButton({ children, pendingLabel }: { children: string; pen
   return <button ref={buttonRef} disabled={disabled} className="btn btn-primary w-full whitespace-normal sm:w-auto" aria-describedby="submission-progress">{pending ? pendingLabel : children}<span id="submission-progress" className="sr-only" aria-live="polite">{pending ? " Submission in progress." : verificationReady ? "" : " Complete human verification before submitting."}</span></button>;
 }
 
-export function TurnstileField({ siteKey }: { siteKey: string }) {
+export function TurnstileField({ siteKey, action = "business_submission" }: { siteKey: string; action?: "business_submission" | "contact" }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
   const [token, setToken] = useState("");
@@ -116,7 +116,7 @@ export function TurnstileField({ siteKey }: { siteKey: string }) {
     try {
       widgetIdRef.current = window.turnstile.render(containerRef.current, {
         sitekey: siteKey,
-        action: "business_submission",
+        action,
         theme: "light",
         size: "flexible",
         callback: (nextToken: string) => { setToken(nextToken); setMessage("Human verification ready."); notifyVerificationChange(true); },


### PR DESCRIPTION
## Confirmed cross-journey gap
The Contact form used the same external verification dependency but still allowed submission before a token existed. A provider failure would reach the generic server error.

## Change
- Reuse the proven readiness component from business submission.
- Keep contact submit disabled until human verification is ready.
- Show the same clear unavailable/retry state.
- Add contact-intake boundary coverage to the standard repository check.

## Boundaries
No changes to contact persistence, retention, Ops routing, sender, provider, policy, data, or billing.

## Verified locally
- `npm run contact-intake:test`
- `npm run owner-submitted-business-candidate:test`
- `npm --prefix web run lint`
- `npm --prefix web run build`