### PR TITLE
Refresh new-session project context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# SuburbMates: required context before work
+
+Before any material audit, implementation, migration, release, or Ops action:
+
+1. run the repository bootstrap and refresh `origin/main`;
+2. read the authority in this order:
+   - `docs/REFERENCE/SuburbMates — Decision Log.md`;
+   - `docs/REFERENCE/SuburbMates — Target State and Operating Authority.md`;
+   - `docs/REFERENCE/SuburbMates — Complete User Journey Map.md`;
+   - the relevant detailed specification only where it agrees with those documents;
+3. read `docs/HANDOVER.md` for current factual state, and `docs/OPS/PUBLIC_RELEASE_ACCEPTANCE.md` for remaining release evidence;
+4. retrieve the current Linear issue and its comments before treating a task as ready or complete.
+
+Live production, the remote database and `origin/main` are factual evidence; a chat summary, local branch or old report is not. Record an observed contradiction before changing behaviour.
+
+The public directory is released. `/ops` and private workflows remain protected. Stripe, general outbound email, AI publication, bulk ABN checks and automated media processing remain disabled unless the owner explicitly changes that policy. Do not create fake durable production records merely to satisfy acceptance.
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # SuburbMates
 
-SuburbMates is a public, hyper-local business directory for the City of Darebin. Published listings can remain useful when some contact information is unavailable. New discoveries, ownership claims, and owner changes enter reviewed workflows before they affect public state.
+SuburbMates is a public, hyper-local business directory for the City of Darebin. Qualifying businesses from approved sources can become public unclaimed listings through the deterministic evidence policy; raw public submissions, ownership claims and owner changes remain private and moderated until their permitted decision.
 
-Read [`docs/HANDOVER.md`](docs/HANDOVER.md) before changing the project. It is the canonical project context, current-state record, operating guide, and next-work queue.
+## Start here in a new session
+
+Read [`AGENTS.md`](AGENTS.md) first. It gives the required refresh and authority order. The durable product authority is the [Decision Log](docs/REFERENCE/SuburbMates%20%E2%80%94%20Decision%20Log.md), [Target State](docs/REFERENCE/SuburbMates%20%E2%80%94%20Target%20State%20and%20Operating%20Authority.md) and [Complete User Journey Map](docs/REFERENCE/SuburbMates%20%E2%80%94%20Complete%20User%20Journey%20Map.md). [`docs/HANDOVER.md`](docs/HANDOVER.md) is the current-state record; Linear holds the current work queue and acceptance evidence.
 
 Automation workflows, triggers, integrations, and safety boundaries are mapped in [`docs/AUTOMATION/`](docs/AUTOMATION/).
 

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -41,9 +41,9 @@ No branch, pull request, automation run or lane handover changes product policy 
 
 - **Date:** 19 July 2026
 - **Decision:** Claiming establishes ownership; it does not decide whether an otherwise legitimate listing is published. Owners may propose profile corrections and supporting information through moderated workflows. A public missing-business submission creates a private candidate and cannot publish raw input directly.
-- **Current state:** The finished owner and public-input workflows are build commitments, not accepted completion.
-- **Required alignment:** Implement claim, request-status, profile-change, submission, validation, abuse-control, moderation and necessary transactional communication flows.
-- **Evidence to close:** End-to-end user and operator acceptance evidence, including failed and abuse-resistant paths.
+- **Current state:** Claim, private status, profile-change, owner/community submission, validation, moderation and bounded transactional-status flows are implemented. A real owner submission and claim have been approved and their permitted status deliveries recorded. Profile-change, community-submission and contact/correction outcomes still need real-world acceptance evidence.
+- **Required alignment:** Maintain the existing claim, request-status, profile-change, submission, validation, abuse-control, moderation and necessary transactional communication boundaries.
+- **Evidence to close:** The remaining real user and operator acceptance evidence, including failed and abuse-resistant paths.
 
 ### D-004 — Capability scope
 
@@ -148,6 +148,6 @@ No branch, pull request, automation run or lane handover changes product policy 
 | --- | --- | --- |
 | Publication policy | New approved-source candidates that pass deterministic qualification become unclaimed public listings with retained evidence. The existing catalogue's 982 `existing-catalogue-v2` exceptions remain a private remediation record; no retrospective visibility decision has been recorded. | Keep new-candidate controls operational and record a separate decision before changing visibility of existing listings. |
 | Public product | Public directory release is live with a populated sitemap and indexable released routes. | Maintain production route checks and correct any observed public-data or SEO defect. |
-| Owner and public input | Claim, status, profile correction and missing-business submission paths are implemented, but the real authenticated walkthrough set is not yet recorded. | Complete and record both user and Ops walkthroughs. |
+| Owner and public input | A real owner submission and claim are approved and recorded. Profile correction, community submission and contact/correction still lack real outcome evidence. | Record those outcomes when genuine cases arise; do not fabricate durable production records. |
 | Monetisation | Stripe is disabled. | Leave disabled until separately approved commercial scope exists. |
 | Automation record | Automation safety controls exist but documentation and issue records need current-state reconciliation. | Maintain evidence, exception handling and current documentation as workflows are hardened. |


### PR DESCRIPTION
Documentation-only fresh-session bootstrap: current authority order, released publication posture, Linear work ownership, and recorded owner journey evidence. No product, database, deployment, or integration changes.