### PR TITLE
Align homepage with public journeys

### DIFF
--- a/scripts/test-resident-journey-policy.ts
+++ b/scripts/test-resident-journey-policy.ts
@@ -6,9 +6,10 @@ async function source(path: string) {
 }
 
 async function run() {
-  const [home, homeClient, browse, taxonomy, profile, contact, directoryLayout] = await Promise.all([
+  const [home, homeClient, heroSearch, browse, taxonomy, profile, contact, directoryLayout] = await Promise.all([
     source("web/src/app/(directory)/page.tsx"),
     source("web/src/components/ui/HomeClient.tsx"),
+    source("web/src/components/ui/HeroSearch.tsx"),
     source("web/src/app/(directory)/businesses/page.tsx"),
     source("web/src/app/(directory)/[suburb]/[service]/page.tsx"),
     source("web/src/app/vendor/[slug]/page.tsx"),
@@ -19,6 +20,11 @@ async function run() {
   assert.match(home, /NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED/, "public home must remain behind the launch flag");
   assert.match(home, /<LaunchPage\s*\/>/, "holding home must remain available before release");
   assert.match(homeClient, /ReactDOM\.preload\("\/hero-bg\.jpg", \{ as: "image", fetchPriority: "high" \}\)/, "the public hero image must preload at high priority");
+  assert.match(heroSearch, /Search business name or keyword/, "home search must accept a business name or keyword");
+  assert.match(heroSearch, /params\.set\("q", query\.trim\(\)\)/, "home search must carry keyword search into the directory");
+  assert.match(homeClient, /Find or claim your business/, "home must direct owners to the search-first claim journey");
+  assert.match(homeClient, /href="\/join\?add=1"/, "home must provide a separate missing-business route");
+  assert.match(homeClient, /City of Darebin/, "home must describe the approved local area");
   assert.match(browse, /vendorsError/, "directory fetch failures must not appear as an empty result");
   assert.match(taxonomy, /vendorsRes\.error/, "taxonomy fetch failures must not appear as an empty result");
   assert.doesNotMatch(browse, /tier === "premium"/, "public browse must not present an unapproved premium tier");
@@ -26,7 +32,11 @@ async function run() {
   assert.match(contact, /google\.com\/maps\/search/, "public address must provide a directions action");
   assert.match(profile, /listing_correction/, "profiles must provide a safe report-problem entry point");
   assert.match(directoryLayout, /Skip to main content/, "public pages must offer a keyboard skip link");
-  assert.match(directoryLayout, /hidden[^\"]*sm:block/, "the fixed header must avoid mobile tagline overlap");
+  assert.match(directoryLayout, /hidden[^\"]*xl:block/, "the fixed header must keep the tagline out of constrained layouts");
+  assert.match(directoryLayout, /Mobile navigation/, "the fixed header must provide a mobile navigation path");
+  for (const route of ["/businesses", "/categories", "/locations", "/how-it-works", "/contact", "/privacy", "/login"]) {
+    assert(directoryLayout.includes(`href: "${route}"`) || directoryLayout.includes(`href="${route}"`), `layout must link to ${route}`);
+  }
 
   console.log("Resident journey policy tests passed.");
 }

--- a/web/src/app/(directory)/layout.tsx
+++ b/web/src/app/(directory)/layout.tsx
@@ -2,6 +2,21 @@ import Link from "next/link";
 
 const publicLaunchEnabled = process.env.NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED === "true";
 
+const primaryNavigation = [
+  { href: "/businesses", label: "Browse" },
+  { href: "/categories", label: "Categories" },
+  { href: "/locations", label: "Locations" },
+  { href: "/how-it-works", label: "How it works" },
+];
+
+const footerNavigation = [
+  { href: "/businesses", label: "Browse directory" },
+  { href: "/how-it-works", label: "How it works" },
+  { href: "/contact", label: "Contact or report a problem" },
+  { href: "/privacy", label: "Privacy" },
+  { href: "/login", label: "Sign in" },
+];
+
 export default function DirectoryLayout({
   children,
 }: Readonly<{
@@ -34,9 +49,40 @@ export default function DirectoryLayout({
             SuburbMates
           </Link>
 
-          <p className="hidden text-xs font-bold uppercase tracking-[0.16em] sm:block" style={{ color: "var(--sm-text-tertiary)" }}>
+          <nav aria-label="Primary navigation" className="hidden items-center gap-5 lg:flex">
+            {primaryNavigation.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="rounded px-1 py-2 text-sm font-bold text-slate-700 transition-colors hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black"
+              >
+                {item.label}
+              </Link>
+            ))}
+            <Link href="/login" className="rounded px-1 py-2 text-sm font-bold text-slate-700 transition-colors hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black">
+              Sign in
+            </Link>
+          </nav>
+
+          <p className="hidden text-xs font-bold uppercase tracking-[0.16em] xl:block" style={{ color: "var(--sm-text-tertiary)" }}>
             {publicLaunchEnabled ? "Discover local businesses" : "Preparing for launch"}
           </p>
+
+          <details className="relative lg:hidden">
+            <summary className="cursor-pointer list-none rounded px-3 py-2 text-sm font-bold text-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black [&::-webkit-details-marker]:hidden">
+              Menu
+            </summary>
+            <nav aria-label="Mobile navigation" className="absolute right-0 top-12 z-50 w-64 rounded-xl border border-slate-200 bg-white p-2 shadow-xl">
+              {primaryNavigation.map((item) => (
+                <Link key={item.href} href={item.href} className="block rounded-lg px-4 py-3 text-sm font-bold text-slate-800 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black">
+                  {item.label}
+                </Link>
+              ))}
+              <Link href="/login" className="block rounded-lg px-4 py-3 text-sm font-bold text-slate-800 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black">
+                Sign in
+              </Link>
+            </nav>
+          </details>
         </div>
       </header>
 
@@ -54,7 +100,8 @@ export default function DirectoryLayout({
         }}
         className="py-12"
       >
-        <div className="max-w-7xl mx-auto px-6 flex flex-col md:flex-row justify-between items-center gap-6">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="flex flex-col items-center justify-between gap-6 md:flex-row md:items-start">
 
           <Link
             href="/"
@@ -65,17 +112,23 @@ export default function DirectoryLayout({
             SuburbMates
           </Link>
 
-          <p className="text-xs uppercase tracking-widest font-semibold" style={{ color: "var(--sm-text-on-inverse-secondary)" }}>
-            {publicLaunchEnabled ? "Melbourne's local business directory" : "Launching soon"}
-          </p>
+            <nav aria-label="Footer navigation" className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
+              {footerNavigation.map((item) => (
+                <Link key={item.href} href={item.href} className="rounded font-semibold text-white/80 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white">
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
 
-          {/* Copyright — gray-300 on black = 10.7:1 ✅ */}
-          <p
-            className="text-xs uppercase tracking-widest"
-            style={{ color: "var(--sm-text-on-inverse-secondary)" }}
-          >
-            © {new Date().getFullYear()} SuburbMates
-          </p>
+            <div className="text-center md:text-right">
+              <p className="text-xs font-semibold uppercase tracking-widest" style={{ color: "var(--sm-text-on-inverse-secondary)" }}>
+                {publicLaunchEnabled ? "Darebin's local business directory" : "Launching soon"}
+              </p>
+              <p className="mt-2 text-xs uppercase tracking-widest" style={{ color: "var(--sm-text-on-inverse-secondary)" }}>
+                © {new Date().getFullYear()} SuburbMates
+              </p>
+            </div>
+          </div>
         </div>
       </footer>
     </div>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://suburbmates.com.au"),
   title: publicLaunchEnabled ? "SuburbMates — Discover local businesses" : "SuburbMates — Preparing for launch",
   description: publicLaunchEnabled
-    ? "Discover local businesses across Melbourne's suburbs."
+    ? "Discover local businesses across the City of Darebin."
     : "SuburbMates is preparing a better way to discover local businesses.",
   alternates: { canonical: "/" },
   robots: publicLaunchEnabled ? undefined : { index: false, follow: false },

--- a/web/src/components/ui/HeroSearch.tsx
+++ b/web/src/components/ui/HeroSearch.tsx
@@ -12,102 +12,89 @@ interface HeroSearchProps {
 
 export function HeroSearch({ categories, suburbs }: HeroSearchProps) {
   const router = useRouter();
+  const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("");
   const [selectedSuburb, setSelectedSuburb] = useState("");
   const [isFocused, setIsFocused] = useState(false);
 
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSearch = (event: React.FormEvent) => {
+    event.preventDefault();
     const params = new URLSearchParams();
+    if (query.trim()) params.set("q", query.trim());
     if (selectedCategory) params.set("category", selectedCategory);
     if (selectedSuburb) params.set("suburb", selectedSuburb);
-    
-    // If no filters selected, it will just go to /businesses
-    router.push(`/businesses${params.toString() ? '?' + params.toString() : ''}`);
+    router.push(`/businesses${params.toString() ? `?${params.toString()}` : ""}`);
   };
 
   return (
     <motion.form
       onSubmit={handleSearch}
-      className="relative w-full max-w-3xl mx-auto"
+      className="relative mx-auto w-full max-w-5xl"
       initial={{ y: 20, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ delay: 0.25, duration: 0.5 }}
       role="search"
     >
       <div
-        className="relative flex flex-col md:flex-row items-center overflow-hidden rounded-2xl md:rounded-full transition-all duration-300"
+        className="grid grid-cols-1 overflow-hidden rounded-2xl transition-all duration-300 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)_minmax(0,0.8fr)_auto] lg:rounded-full"
         style={{
           backgroundColor: isFocused ? "rgba(255,255,255,0.18)" : "rgba(255,255,255,0.10)",
-          border: isFocused
-            ? "1.5px solid rgba(255,255,255,0.75)"
-            : "1.5px solid rgba(255,255,255,0.30)",
+          border: isFocused ? "1.5px solid rgba(255,255,255,0.75)" : "1.5px solid rgba(255,255,255,0.30)",
           boxShadow: isFocused ? "0 0 0 3px rgba(255,255,255,0.15)" : "none",
         }}
       >
-        {/* Category Select */}
-        <div className="relative w-full md:w-1/2 flex items-center border-b md:border-b-0 md:border-r border-white/20">
-          <div
-            className="absolute left-5 pointer-events-none"
-            style={{ color: "rgba(255,255,255,0.90)" }}
-            aria-hidden="true"
-          >
-            <Search size={20} />
-          </div>
+        <div className="relative flex items-center border-b border-white/20 lg:border-b-0 lg:border-r">
+          <Search className="pointer-events-none absolute left-5" size={20} color="rgba(255,255,255,0.90)" aria-hidden="true" />
+          <label className="sr-only" htmlFor="hero-search">Search business name or keyword</label>
+          <input
+            id="hero-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            placeholder="Search business name or keyword"
+            className="w-full bg-transparent py-4 pl-12 pr-4 text-base text-white placeholder:text-white/60 focus:outline-none focus:ring-0 sm:text-lg"
+          />
+        </div>
+
+        <div className="flex items-center border-b border-white/20 lg:border-b-0 lg:border-r">
+          <label className="sr-only" htmlFor="hero-category">Select a service</label>
           <select
+            id="hero-category"
             value={selectedCategory}
-            onChange={(e) => setSelectedCategory(e.target.value)}
+            onChange={(event) => setSelectedCategory(event.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            aria-label="Select a service"
-            className="w-full pl-12 pr-4 py-4 md:py-5 text-lg bg-transparent border-none focus:outline-none focus:ring-0 appearance-none cursor-pointer"
-            style={{
-              color: selectedCategory ? "var(--sm-text-on-inverse)" : "rgba(255,255,255,0.55)",
-            }}
+            className="w-full cursor-pointer appearance-none border-none bg-transparent px-5 py-4 text-base focus:outline-none focus:ring-0 sm:text-lg"
+            style={{ color: selectedCategory ? "var(--sm-text-on-inverse)" : "rgba(255,255,255,0.75)" }}
           >
-            <option value="" className="text-black">All Services</option>
-            {categories.map((cat) => (
-              <option key={cat.slug} value={cat.slug} className="text-black">
-                {cat.name}
-              </option>
+            <option value="" className="text-black">All services</option>
+            {categories.map((category) => (
+              <option key={category.slug} value={category.slug} className="text-black">{category.name}</option>
             ))}
           </select>
         </div>
 
-        {/* Suburb Select */}
-        <div className="relative w-full md:w-1/2 flex items-center">
+        <div className="flex items-center border-b border-white/20 lg:border-b-0 lg:border-r">
+          <label className="sr-only" htmlFor="hero-suburb">Select a suburb</label>
           <select
+            id="hero-suburb"
             value={selectedSuburb}
-            onChange={(e) => setSelectedSuburb(e.target.value)}
+            onChange={(event) => setSelectedSuburb(event.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            aria-label="Select a suburb"
-            className="w-full pl-6 pr-32 py-4 md:py-5 text-lg bg-transparent border-none focus:outline-none focus:ring-0 appearance-none cursor-pointer"
-            style={{
-              color: selectedSuburb ? "var(--sm-text-on-inverse)" : "rgba(255,255,255,0.55)",
-            }}
+            className="w-full cursor-pointer appearance-none border-none bg-transparent px-5 py-4 text-base focus:outline-none focus:ring-0 sm:text-lg"
+            style={{ color: selectedSuburb ? "var(--sm-text-on-inverse)" : "rgba(255,255,255,0.75)" }}
           >
-            <option value="" className="text-black">All Suburbs</option>
-            {suburbs.map((sub) => (
-              <option key={sub.slug} value={sub.slug} className="text-black">
-                {sub.name}
-              </option>
+            <option value="" className="text-black">All suburbs</option>
+            {suburbs.map((suburb) => (
+              <option key={suburb.slug} value={suburb.slug} className="text-black">{suburb.name}</option>
             ))}
           </select>
-
-          {/* Submit button */}
-          <button
-            type="submit"
-            aria-label="Search"
-            className="btn btn-inverse absolute right-2 top-1/2 -translate-y-1/2"
-            style={{
-              padding: "0.625rem 1.25rem",
-              fontSize: "0.8125rem",
-            }}
-          >
-            Search
-          </button>
         </div>
+
+        <button type="submit" className="btn btn-inverse m-2 min-h-11 justify-center" aria-label="Search directory">Search</button>
       </div>
     </motion.form>
   );

--- a/web/src/components/ui/HomeClient.tsx
+++ b/web/src/components/ui/HomeClient.tsx
@@ -121,7 +121,7 @@ export function HomeClient({ categories, suburbs, featuredVendors }: HomeClientP
               className="text-xl md:text-2xl font-light tracking-wide mb-12 max-w-2xl mx-auto"
               style={{ color: "var(--sm-text-on-inverse-secondary)" }}
             >
-              Find local businesses in your suburb instantly.
+              Find local businesses across the City of Darebin instantly.
               No sign-ups. No middlemen. Just direct contact.
             </motion.p>
 
@@ -324,18 +324,20 @@ export function HomeClient({ categories, suburbs, featuredVendors }: HomeClientP
             className="text-xl font-light leading-relaxed mb-12 max-w-2xl mx-auto"
             style={{ color: "var(--sm-text-on-inverse-secondary)" }}
           >
-            Join the most straightforward local directory. Get in front of customers
-            looking for exactly what you do — no lock-in contracts.
+            First, look for your existing Darebin business so you can claim it without creating a duplicate. If it is genuinely missing, add it for review.
           </motion.p>
 
-          <motion.div variants={fadeInUp}>
+          <motion.div variants={fadeInUp} className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Link
               href="/join"
               className="btn btn-inverse"
-              aria-label="List your business on SuburbMates"
+              aria-label="Find or claim your business on SuburbMates"
             >
-              <span>List Your Business</span>
+              <span>Find or claim your business</span>
               <ArrowRight size={20} aria-hidden="true" />
+            </Link>
+            <Link href="/join?add=1" className="btn btn-outline border-white/70 text-white hover:bg-white hover:text-black" aria-label="Add a missing business to SuburbMates">
+              Add a missing business
             </Link>
           </motion.div>
         </motion.div>


### PR DESCRIPTION
## Summary
- add accessible public navigation and support links
- add keyword search to the homepage
- clarify search-first claim and missing-business paths
- align public scope copy to the City of Darebin

## Verification
- npm run resident-journey:test
- npm run check
- cd web && npm run lint
- cd web && npm run build
- cd web && npm run cf:build
- local in-app browser: keyword search and narrow mobile menu