### PR TITLE
Harden public web delivery metadata and headers

### DIFF
--- a/scripts/test-resident-journey-policy.ts
+++ b/scripts/test-resident-journey-policy.ts
@@ -22,6 +22,9 @@ async function run() {
   assert.match(homeClient, /ReactDOM\.preload\("\/hero-bg\.jpg", \{ as: "image", fetchPriority: "high" \}\)/, "the public hero image must preload at high priority");
   assert.match(heroSearch, /Search business name or keyword/, "home search must accept a business name or keyword");
   assert.match(heroSearch, /params\.set\("q", query\.trim\(\)\)/, "home search must carry keyword search into the directory");
+  assert.match(heroSearch, /action="\/businesses"/, "home search must retain a browser-native directory fallback");
+  assert.match(heroSearch, /name="q"/, "home search fallback must submit the keyword");
+  assert.match(heroSearch, /focus-visible:ring-2 focus-visible:ring-white/, "hero controls must show a visible keyboard focus state");
   assert.match(homeClient, /Find or claim your business/, "home must direct owners to the search-first claim journey");
   assert.match(homeClient, /href="\/join\?add=1"/, "home must provide a separate missing-business route");
   assert.match(homeClient, /City of Darebin/, "home must describe the approved local area");

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,8 +1,42 @@
 import type { NextConfig } from "next";
 
+const supabaseOrigin = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, "");
+const connectSources = ["'self'", "https://challenges.cloudflare.com", supabaseOrigin].filter(Boolean).join(" ");
+
+// Keep this compatible with Next's inline bootstrap and the hosted Turnstile
+// widget. Do not add unsafe-eval: production does not require it.
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  `connect-src ${connectSources}`,
+  "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "frame-src https://challenges.cloudflare.com",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "upgrade-insecure-requests",
+].join("; ");
+
 const nextConfig: NextConfig = {
   turbopack: {
     root: process.cwd(),
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Content-Security-Policy", value: contentSecurityPolicy },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+        ],
+      },
+    ];
   },
 };
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -12,6 +12,25 @@ export const metadata: Metadata = {
     : "SuburbMates is preparing a better way to discover local businesses.",
   alternates: { canonical: "/" },
   robots: publicLaunchEnabled ? undefined : { index: false, follow: false },
+  openGraph: {
+    title: publicLaunchEnabled ? "SuburbMates — Discover local businesses" : "SuburbMates — Preparing for launch",
+    description: publicLaunchEnabled
+      ? "Discover local businesses across the City of Darebin."
+      : "SuburbMates is preparing a better way to discover local businesses.",
+    url: "https://suburbmates.com.au",
+    siteName: "SuburbMates",
+    locale: "en_AU",
+    type: "website",
+    images: [{ url: "/hero-bg.jpg", width: 1024, height: 1024, alt: "SuburbMates local business directory" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: publicLaunchEnabled ? "SuburbMates — Discover local businesses" : "SuburbMates — Preparing for launch",
+    description: publicLaunchEnabled
+      ? "Discover local businesses across the City of Darebin."
+      : "SuburbMates is preparing a better way to discover local businesses.",
+    images: ["/hero-bg.jpg"],
+  },
 };
 
 export default function RootLayout({

--- a/web/src/app/vendor/[slug]/page.tsx
+++ b/web/src/app/vendor/[slug]/page.tsx
@@ -41,12 +41,23 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const suburbRelation = vendor.suburbs as unknown as { name: string } | { name: string }[] | null;
   const categoryName = (Array.isArray(categoryRelation) ? categoryRelation[0]?.name : categoryRelation?.name) ?? "Local business";
   const suburbName = (Array.isArray(suburbRelation) ? suburbRelation[0]?.name : suburbRelation?.name) ?? vendor.suburb_slug;
+  const title = `${vendor.business_name} | ${categoryName} in ${suburbName}`;
+  const description = vendor.description ? vendor.description.substring(0, 155) : `View public contact details for ${vendor.business_name} in ${suburbName}.`;
+  const canonicalUrl = `/vendor/${route.currentSlug}`;
   
   return {
-    title: `${vendor.business_name} | ${categoryName} in ${suburbName}`,
-    description: vendor.description ? vendor.description.substring(0, 155) : `View public contact details for ${vendor.business_name} in ${suburbName}.`,
-    alternates: { canonical: `/vendor/${route.currentSlug}` },
+    title,
+    description,
+    alternates: { canonical: canonicalUrl },
     robots: vendor.is_published ? undefined : { index: false, follow: false },
+    openGraph: {
+      title,
+      description,
+      url: `https://suburbmates.com.au${canonicalUrl}`,
+      siteName: "SuburbMates",
+      type: "website",
+    },
+    twitter: { card: "summary", title, description },
   };
 }
 

--- a/web/src/components/ui/HeroSearch.tsx
+++ b/web/src/components/ui/HeroSearch.tsx
@@ -28,6 +28,8 @@ export function HeroSearch({ categories, suburbs }: HeroSearchProps) {
 
   return (
     <motion.form
+      action="/businesses"
+      method="get"
       onSubmit={handleSearch}
       className="relative mx-auto w-full max-w-5xl"
       initial={{ y: 20, opacity: 0 }}
@@ -48,13 +50,14 @@ export function HeroSearch({ categories, suburbs }: HeroSearchProps) {
           <label className="sr-only" htmlFor="hero-search">Search business name or keyword</label>
           <input
             id="hero-search"
+            name="q"
             type="search"
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
             placeholder="Search business name or keyword"
-            className="w-full bg-transparent py-4 pl-12 pr-4 text-base text-white placeholder:text-white/60 focus:outline-none focus:ring-0 sm:text-lg"
+            className="w-full rounded-xl bg-transparent py-4 pl-12 pr-4 text-base text-white placeholder:text-white/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black lg:rounded-l-full sm:text-lg"
           />
         </div>
 
@@ -62,11 +65,12 @@ export function HeroSearch({ categories, suburbs }: HeroSearchProps) {
           <label className="sr-only" htmlFor="hero-category">Select a service</label>
           <select
             id="hero-category"
+            name="category"
             value={selectedCategory}
             onChange={(event) => setSelectedCategory(event.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            className="w-full cursor-pointer appearance-none border-none bg-transparent px-5 py-4 text-base focus:outline-none focus:ring-0 sm:text-lg"
+            className="w-full cursor-pointer appearance-none rounded-xl border-none bg-transparent px-5 py-4 text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:text-lg"
             style={{ color: selectedCategory ? "var(--sm-text-on-inverse)" : "rgba(255,255,255,0.75)" }}
           >
             <option value="" className="text-black">All services</option>
@@ -80,11 +84,12 @@ export function HeroSearch({ categories, suburbs }: HeroSearchProps) {
           <label className="sr-only" htmlFor="hero-suburb">Select a suburb</label>
           <select
             id="hero-suburb"
+            name="suburb"
             value={selectedSuburb}
             onChange={(event) => setSelectedSuburb(event.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            className="w-full cursor-pointer appearance-none border-none bg-transparent px-5 py-4 text-base focus:outline-none focus:ring-0 sm:text-lg"
+            className="w-full cursor-pointer appearance-none rounded-xl border-none bg-transparent px-5 py-4 text-base focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:text-lg"
             style={{ color: selectedSuburb ? "var(--sm-text-on-inverse)" : "rgba(255,255,255,0.75)" }}
           >
             <option value="" className="text-black">All suburbs</option>
@@ -94,7 +99,7 @@ export function HeroSearch({ categories, suburbs }: HeroSearchProps) {
           </select>
         </div>
 
-        <button type="submit" className="btn btn-inverse m-2 min-h-11 justify-center" aria-label="Search directory">Search</button>
+        <button type="submit" className="btn btn-inverse m-2 min-h-11 justify-center focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black" aria-label="Search directory">Search</button>
       </div>
     </motion.form>
   );


### PR DESCRIPTION
## Summary
- add CSP and standard browser security headers with Supabase and Turnstile allowances
- add accurate Open Graph and Twitter metadata
- strengthen hero keyboard focus and native form fallback

## Deliberately excluded
- no one-year immutable media cache on removable media
- no database index migration without demonstrated query need
- no stale handover facts or obsolete homepage regressions

## Verification
- npm run check
- web: npm run lint
- web: npm run build
- web: npm run cf:build
- local header inspection