### PR TITLE
Require deployment-complete sync evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,4 +15,6 @@ Before any material audit, implementation, migration, release, or Ops action:
 
 Live production, the remote database and `origin/main` are factual evidence; a chat summary, local branch or old report is not. Record an observed contradiction before changing behaviour.
 
+For an owner-authorised deployable change, **sync** means: merge the approved change, deploy it through the normal `web` delivery path, verify the served production behaviour, and then report the result. A branch push, green CI run or merge is not a completed sync. Use these exact status labels: **local only**, **in review**, **merged**, **deployed—verification pending**, or **live verified**. Stop at an earlier label only when the owner explicitly limits the scope or a concrete deployment blocker is reported.
+
 The public directory is released. `/ops` and private workflows remain protected. Stripe, general outbound email, AI publication, bulk ABN checks and automated media processing remain disabled unless the owner explicitly changes that policy. Do not create fake durable production records merely to satisfy acceptance.

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -142,6 +142,14 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Current state:** The 21 reviewed, never-public rejected records were owner-authorised for deletion. Their audit history was retained.
 - **Evidence to close:** Protected-function, UI-boundary and database verification; an authenticated operator walkthrough when a future eligible rejected record exists.
 
+### D-016 — Deployment-complete sync rule
+
+- **Date:** 7 August 2026
+- **Decision:** For an owner-authorised deployable change, “sync” includes the normal merge, deployment and live verification path. It does not end at a branch push, pull-request merge or passing CI run.
+- **Required evidence:** Record the merged commit or pull request, deployment version or URL, affected live route or integration, and the relevant live result. Public route, sitemap, access-control or catalogue changes also require the production smoke check.
+- **Status rule:** Use only `local only`, `in review`, `merged`, `deployed—verification pending`, or `live verified`. A missing deployment or live proof is a stated blocker; it is never silently handed back to the owner.
+- **Guardrail:** This rule does not authorise an unapproved product, database, security or commercial change. It completes the normal delivery of an already owner-authorised deployable change.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |

--- a/docs/REFERENCE/SuburbMates — Execution Governance and Readiness Protocol.md
+++ b/docs/REFERENCE/SuburbMates — Execution Governance and Readiness Protocol.md
@@ -81,6 +81,9 @@ If any item is missing, improve the issue or return it to Backlog. Do not begin 
 
 - Review checks scope, authority alignment, dependency state, test evidence and unintended changes.
 - A merge requires a current-baseline comparison; a merge is not a deployment or final acceptance.
+- For an owner-authorised deployable **sync**, release or production push, complete the normal deployment path after merge. Do not reinterpret the request as “CI only” unless the owner explicitly says not to deploy.
+- Before reporting that sync complete, record: merged commit/PR, deployment version or URL, the affected live route or integration, and the live verification result. Run the production smoke check when public catalogue, route, access-control or sitemap behaviour is affected.
+- Use only these delivery states: **local only**, **in review**, **merged**, **deployed—verification pending**, and **live verified**. A missing deployment or live proof is a concrete blocker, not an implicit handoff to the owner.
 - A public release requires the relevant journey, data, Ops and automation evidence plus explicit owner release authority.
 - **Done** requires the issue's evidence, not a commit, pull request or optimistic status update.
 


### PR DESCRIPTION
## Summary
- define owner-authorised sync as merge, deploy and live verification
- add explicit delivery-state vocabulary
- prevent CI-only completion claims

## Verification
- deployment-complete authority checks
- git diff --check

Documentation and operating-instruction change only; no production behaviour or service configuration changed.