### PR TITLE
Refine directory browsing and query loading

### DIFF
--- a/scripts/test-resident-journey-policy.ts
+++ b/scripts/test-resident-journey-policy.ts
@@ -6,7 +6,7 @@ async function source(path: string) {
 }
 
 async function run() {
-  const [home, homeClient, heroSearch, browse, taxonomy, profile, contact, directoryLayout] = await Promise.all([
+  const [home, homeClient, heroSearch, browse, taxonomy, profile, contact, directoryLayout, directoryBrowse] = await Promise.all([
     source("web/src/app/(directory)/page.tsx"),
     source("web/src/components/ui/HomeClient.tsx"),
     source("web/src/components/ui/HeroSearch.tsx"),
@@ -15,6 +15,7 @@ async function run() {
     source("web/src/app/vendor/[slug]/page.tsx"),
     source("web/src/components/minisite/contact/ContactComponents.tsx"),
     source("web/src/app/(directory)/layout.tsx"),
+    source("web/src/components/ui/DirectoryBrowseClient.tsx"),
   ]);
 
   assert.match(home, /NEXT_PUBLIC_PUBLIC_LAUNCH_ENABLED/, "public home must remain behind the launch flag");
@@ -32,12 +33,18 @@ async function run() {
   assert.match(homeClient, /View profile/, "home previews must direct people to the complete profile");
   assert.doesNotMatch(homeClient, /Call Direct/, "home previews must not duplicate profile contact controls");
   assert.doesNotMatch(homeClient, /No description provided/, "home previews must not expose profile detail before selection");
-  assert.match(browse, /vendorsError/, "directory fetch failures must not appear as an empty result");
+  assert.match(browse, /vendorsRes\.error/, "directory fetch failures must not appear as an empty result");
+  assert.match(browse, /count: "exact"/, "directory results must retain an exact page count");
+  assert.match(browse, /clampedPage !== requestedPage/, "an out-of-range directory page must reload its valid page");
+  assert.match(browse, /replace\(\/\[%_\\\\\]\/g, "\\\\\$&"\)/, "directory keyword search must escape PostgREST wildcard characters");
   assert.match(taxonomy, /vendorsRes\.error/, "taxonomy fetch failures must not appear as an empty result");
   assert.doesNotMatch(browse, /tier === "premium"/, "public browse must not present an unapproved premium tier");
   assert.doesNotMatch(taxonomy, /tier === "premium"/, "taxonomy results must not present an unapproved premium tier");
   assert.match(contact, /google\.com\/maps\/search/, "public address must provide a directions action");
   assert.match(profile, /listing_correction/, "profiles must provide a safe report-problem entry point");
+  assert.match(profile, /replace\(\/<\/g, "\\\\u003c"\)/, "profile structured data must escape script-breaking characters");
+  assert.match(directoryBrowse, /Loading matching businesses/, "directory changes must show pending feedback");
+  assert.match(directoryBrowse, /aria-pressed=\{viewMode === "grid"\}/, "directory view controls must expose their selected state");
   assert.match(directoryLayout, /Skip to main content/, "public pages must offer a keyboard skip link");
   assert.match(directoryLayout, /hidden[^\"]*xl:block/, "the fixed header must keep the tagline out of constrained layouts");
   assert.match(directoryLayout, /Mobile navigation/, "the fixed header must provide a mobile navigation path");

--- a/web/src/app/(directory)/businesses/page.tsx
+++ b/web/src/app/(directory)/businesses/page.tsx
@@ -2,12 +2,18 @@ import { createClient } from "@/utils/supabase/server";
 import { DirectoryBrowseClient } from "@/components/ui/DirectoryBrowseClient";
 import type { Metadata } from "next";
 
-export async function generateMetadata({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }): Promise<Metadata> {
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}): Promise<Metadata> {
   const params = await searchParams;
-  const hasVariant = Object.values(params).some((value) => value !== undefined && value !== "" && value !== "1");
+  const hasVariant = Object.values(params).some(
+    (value) => value !== undefined && value !== "" && value !== "1"
+  );
   return {
     title: "Browse Local Businesses | SuburbMates",
-    description: "Search and browse local businesses in your area.",
+    description: "Search and browse local businesses across the City of Darebin.",
     alternates: { canonical: "/businesses" },
     robots: hasVariant ? { index: false, follow: true } : undefined,
   };
@@ -19,64 +25,55 @@ export default async function BusinessesPage({
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const params = await searchParams;
-  const q = typeof params.q === 'string' ? params.q : '';
-  const suburb = typeof params.suburb === 'string' ? params.suburb : '';
-  const category = typeof params.category === 'string' ? params.category : '';
-  const pageStr = typeof params.page === 'string' ? params.page : '1';
-  let page = parseInt(pageStr, 10);
-  if (isNaN(page) || page < 1) page = 1;
+  const q = typeof params.q === "string" ? params.q : "";
+  const suburb = typeof params.suburb === "string" ? params.suburb : "";
+  const category = typeof params.category === "string" ? params.category : "";
+  const pageStr = typeof params.page === "string" ? params.page : "1";
+  let requestedPage = parseInt(pageStr, 10);
+  if (isNaN(requestedPage) || requestedPage < 1) requestedPage = 1;
   const pageSize = 24;
 
   const supabase = await createClient();
 
-  const [suburbsRes, categoriesRes] = await Promise.all([
-    supabase.from('suburbs').select('name, slug').order('name'),
-    supabase.from('categories').select('name, slug').order('name'),
+  const escapedQ = q ? q.replace(/[%_\\]/g, "\\$&") : "";
+  const vendorFields = "id, slug, business_name, description, contact_email, phone, website, is_claimed, street_address, suburb_slug, category_slug";
+
+  const vendorPage = (targetPage: number) => {
+    const from = (targetPage - 1) * pageSize;
+    let query = supabase.from("published_vendors").select(vendorFields, { count: "exact" });
+    if (escapedQ) query = query.ilike("business_name", `%${escapedQ}%`);
+    if (suburb) query = query.eq("suburb_slug", suburb);
+    if (category) query = query.eq("category_slug", category);
+    return query.order("business_name", { ascending: true }).range(from, from + pageSize - 1);
+  };
+
+  // Execute suburbs, categories, and vendor query concurrently in a single parallel batch
+  const [suburbsRes, categoriesRes, vendorsRes] = await Promise.all([
+    supabase.from("suburbs").select("name, slug").order("name"),
+    supabase.from("categories").select("name, slug").order("name"),
+    vendorPage(requestedPage),
   ]);
 
-  // 1. Get total count and clamp page
-  let countQuery = supabase
-    .from('published_vendors')
-    .select('id', { count: 'exact', head: true });
-
-  const escapedQ = q ? q.replace(/[%_\\]/g, '\\$&') : '';
-
-  if (escapedQ) countQuery = countQuery.ilike('business_name', `%${escapedQ}%`);
-  if (suburb) countQuery = countQuery.eq('suburb_slug', suburb);
-  if (category) countQuery = countQuery.eq('category_slug', category);
-
-  const { count } = await countQuery;
-  const totalCount = count || 0;
-  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
-  
-  page = Math.max(1, Math.min(page, totalPages));
-
-  // 2. Fetch clamped page data
-  let query = supabase
-    .from('published_vendors')
-    .select('id, slug, business_name, description, contact_email, phone, website, is_claimed, street_address, suburb_slug, category_slug');
-
-  if (escapedQ) query = query.ilike('business_name', `%${escapedQ}%`);
-  if (suburb) query = query.eq('suburb_slug', suburb);
-  if (category) query = query.eq('category_slug', category);
-
-  query = query.order('business_name', { ascending: true });
-  
-  const from = (page - 1) * pageSize;
-  const to = from + pageSize - 1;
-  query = query.range(from, to);
-
-  const { data: vendors, error: vendorsError } = await query;
-
-  if (suburbsRes.error || categoriesRes.error || vendorsError) {
+  if (suburbsRes.error || categoriesRes.error || vendorsRes.error) {
     throw new Error("The directory could not be loaded.");
+  }
+
+  const totalCount = vendorsRes.count || 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const clampedPage = Math.max(1, Math.min(requestedPage, totalPages));
+  let resolvedVendors = vendorsRes.data ?? [];
+  if (clampedPage !== requestedPage) {
+    const correctedPage = await vendorPage(clampedPage);
+    if (correctedPage.error) throw new Error("The directory could not be loaded.");
+    resolvedVendors = correctedPage.data ?? [];
   }
 
   return (
     <DirectoryBrowseClient
-      vendors={vendors || []}
+      key={`${q}:${suburb}:${category}:${clampedPage}`}
+      vendors={resolvedVendors}
       totalCount={totalCount}
-      currentPage={page}
+      currentPage={clampedPage}
       pageSize={pageSize}
       suburbs={suburbsRes.data || []}
       categories={categoriesRes.data || []}

--- a/web/src/app/vendor/[slug]/page.tsx
+++ b/web/src/app/vendor/[slug]/page.tsx
@@ -68,21 +68,25 @@ export default async function VendorWebsite({ params }: PageProps) {
   if (!route) notFound();
   if (route.redirectRequired) permanentRedirect(`/vendor/${route.currentSlug}`);
 
-  const { data: vendor, error } = await supabase
-    .from("published_vendors")
-    .select(`
-      *,
-      suburbs (name),
-      categories (name)
-    `)
-    .eq("id", route.vendorId)
-    .single();
+  // Concurrently fetch published vendor details and public vendor media in a single parallel batch
+  const [vendorResult, mediaResult] = await Promise.all([
+    supabase
+      .from("published_vendors")
+      .select(`
+        *,
+        suburbs (name),
+        categories (name)
+      `)
+      .eq("id", route.vendorId)
+      .single(),
+    supabase.rpc("list_public_vendor_media", { p_vendor_id: route.vendorId }),
+  ]);
 
-  if (error || !vendor) {
+  const vendor = vendorResult.data;
+  if (vendorResult.error || !vendor) {
     notFound();
   }
-  const { data: mediaRows } = await supabase.rpc("list_public_vendor_media", { p_vendor_id: vendor.id });
-  const media = (mediaRows ?? []) as { media_id: string; media_kind: string; alt_text: string }[];
+  const media = (mediaResult.data ?? []) as { media_id: string; media_kind: string; alt_text: string }[];
 
   // Compute design parameters out of existing data deterministically
   const design = getVendorDesign(vendor.id, vendor.created_at);

--- a/web/src/components/ui/DirectoryBrowseClient.tsx
+++ b/web/src/components/ui/DirectoryBrowseClient.tsx
@@ -1,9 +1,27 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Search, MapPin, Phone, Globe, Star, Mail, ExternalLink, Filter, ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  Search,
+  MapPin,
+  Phone,
+  Globe,
+  Mail,
+  ExternalLink,
+  Filter,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ChevronUp,
+  LayoutGrid,
+  List,
+  Sparkles,
+  X,
+  Building2,
+} from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 
 type DirectoryVendor = {
   id: string;
@@ -46,6 +64,9 @@ export function DirectoryBrowseClient({
   const [q, setQ] = useState(initialQ);
   const [suburb, setSuburb] = useState(initialSuburb);
   const [category, setCategory] = useState(initialCategory);
+  const [expandedVendorId, setExpandedVendorId] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const [isPending, startTransition] = useTransition();
 
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
@@ -60,191 +81,339 @@ export function DirectoryBrowseClient({
     if (sub) params.set("suburb", sub);
     if (cat) params.set("category", cat);
     if (page > 1) params.set("page", page.toString());
-    
-    router.push(`/businesses?${params.toString()}`);
+    startTransition(() => router.push(`/businesses?${params.toString()}`));
   };
 
+  const clearAllFilters = () => {
+    setQ("");
+    setSuburb("");
+    setCategory("");
+    updateUrl(1, "", "", "");
+  };
+
+  const toggleExpand = (id: string) => {
+    setExpandedVendorId((prev) => (prev === id ? null : id));
+  };
+
+  const activeFiltersCount = (q ? 1 : 0) + (suburb ? 1 : 0) + (category ? 1 : 0);
+
   return (
-    <div className="min-h-screen bg-slate-50/50 pb-20">
-      <section className="bg-black text-white py-12 px-6 relative overflow-hidden" aria-label="Page Header">
+    <div className="min-h-screen bg-slate-50/70 pb-24">
+      {/* ── Header ───────────────────────────────────────────── */}
+      <section
+        className="relative bg-black px-6 py-14 text-white overflow-hidden"
+        aria-label="Directory Header"
+      >
         <div
-          className="absolute top-1/2 left-1/4 -translate-y-1/2 w-[500px] h-[500px] rounded-full blur-[140px] pointer-events-none"
-          style={{ backgroundColor: "rgba(255,255,255,0.03)" }}
+          className="absolute top-1/2 left-1/3 -translate-y-1/2 w-[600px] h-[600px] rounded-full blur-[150px] pointer-events-none"
+          style={{ backgroundColor: "rgba(255,255,255,0.04)" }}
           aria-hidden="true"
         />
-        
-        <div className="max-w-5xl mx-auto relative z-10">
-          <h1 className="text-3xl md:text-5xl font-black tracking-tighter uppercase mb-4 leading-none">
-            Browse Local Businesses
-          </h1>
-          <p className="text-base md:text-lg max-w-2xl font-light tracking-wide text-slate-300">
-            Search our directory of {totalCount} local businesses. No middlemen, just direct contact.
-          </p>
+
+        <div className="max-w-6xl mx-auto relative z-10">
+          <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+            <div>
+              <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 backdrop-blur-md text-xs font-bold uppercase tracking-widest text-slate-300 mb-4 border border-white/10">
+                <Sparkles size={13} className="text-amber-400" />
+                Hyper-Local Business Directory
+              </span>
+              <h1 className="text-4xl md:text-6xl font-black tracking-tighter uppercase leading-none">
+                Browse Local Businesses
+              </h1>
+              <p className="text-base md:text-lg max-w-2xl font-light tracking-wide text-slate-300 mt-3">
+                Discover <span className="font-bold text-white">{totalCount}</span> local businesses across Darebin. Direct contact, zero lead-selling.
+              </p>
+            </div>
+
+            {/* View Toggle */}
+            <div className="flex items-center gap-1 bg-white/10 backdrop-blur-md p-1.5 rounded-xl border border-white/10 self-start md:self-auto">
+              <button
+                type="button"
+                onClick={() => setViewMode("grid")}
+                className={`flex items-center gap-2 px-3.5 py-2 rounded-lg text-xs font-bold transition-all ${
+                  viewMode === "grid"
+                    ? "bg-white text-black shadow-md scale-100"
+                    : "text-slate-300 hover:text-white hover:bg-white/10"
+                }`}
+                aria-label="Grid view"
+                aria-pressed={viewMode === "grid"}
+              >
+                <LayoutGrid size={15} />
+                <span className="hidden sm:inline">Grid</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("list")}
+                className={`flex items-center gap-2 px-3.5 py-2 rounded-lg text-xs font-bold transition-all ${
+                  viewMode === "list"
+                    ? "bg-white text-black shadow-md scale-100"
+                    : "text-slate-300 hover:text-white hover:bg-white/10"
+                }`}
+                aria-label="Compact list view"
+                aria-pressed={viewMode === "list"}
+              >
+                <List size={15} />
+                <span className="hidden sm:inline">Compact List</span>
+              </button>
+            </div>
+          </div>
         </div>
       </section>
 
-      <main className="max-w-5xl mx-auto px-6 py-8">
-        <div className="bg-white p-4 rounded-xl shadow-sm border border-slate-200 mb-8">
-          <form onSubmit={handleSearch} className="flex flex-col md:flex-row gap-4">
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 py-8">
+        {/* ── Search & Filter Bar ────────────────────────────── */}
+        <div className="bg-white/90 backdrop-blur-xl p-4 sm:p-5 rounded-2xl shadow-xl shadow-slate-200/50 border border-slate-200/80 mb-8 sticky top-20 z-30 transition-all">
+          <form onSubmit={handleSearch} className="flex flex-col lg:flex-row gap-3">
             <div className="flex-1 relative">
-              <Search size={18} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
-              <label className="sr-only" htmlFor="directory-search">Search by business name</label>
+              <Search
+                size={18}
+                className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none"
+              />
+              <label className="sr-only" htmlFor="directory-search">
+                Search by business name
+              </label>
               <input
                 id="directory-search"
                 type="text"
-                placeholder="Search by business name..."
+                placeholder="Search business name or keyword..."
                 value={q}
                 onChange={(e) => setQ(e.target.value)}
-                className="w-full pl-10 pr-4 py-3 bg-slate-50 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-black focus:border-transparent text-black"
+                className="w-full pl-11 pr-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-black focus:bg-white text-black font-medium text-sm transition-all placeholder:text-slate-400"
               />
             </div>
-            
-            <div className="md:w-64">
-              <label className="sr-only" htmlFor="directory-category">Filter by category</label>
-              <select
-                id="directory-category"
-                value={category}
-                onChange={(e) => {
-                  setCategory(e.target.value);
-                  updateUrl(1, q, suburb, e.target.value);
-                }}
-                className="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-black text-black appearance-none cursor-pointer"
-              >
-                <option value="">All Categories</option>
-                {categories.map((c) => (
-                  <option key={c.slug} value={c.slug}>{c.name}</option>
-                ))}
-              </select>
+
+            <div className="grid grid-cols-2 gap-3 lg:w-[480px]">
+              <div className="relative">
+                <label className="sr-only" htmlFor="directory-category">
+                  Filter by category
+                </label>
+                <select
+                  id="directory-category"
+                  value={category}
+                  onChange={(e) => {
+                    setCategory(e.target.value);
+                    updateUrl(1, q, suburb, e.target.value);
+                  }}
+                  className="w-full pl-4 pr-9 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-black text-black font-medium text-xs sm:text-sm appearance-none cursor-pointer truncate"
+                >
+                  <option value="">All Categories</option>
+                  {categories.map((c) => (
+                    <option key={c.slug} value={c.slug}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown size={16} className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+              </div>
+
+              <div className="relative">
+                <label className="sr-only" htmlFor="directory-suburb">
+                  Filter by suburb
+                </label>
+                <select
+                  id="directory-suburb"
+                  value={suburb}
+                  onChange={(e) => {
+                    setSuburb(e.target.value);
+                    updateUrl(1, q, e.target.value, category);
+                  }}
+                  className="w-full pl-4 pr-9 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-black text-black font-medium text-xs sm:text-sm appearance-none cursor-pointer truncate"
+                >
+                  <option value="">All Suburbs</option>
+                  {suburbs.map((s) => (
+                    <option key={s.slug} value={s.slug}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown size={16} className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+              </div>
             </div>
 
-            <div className="md:w-64">
-              <label className="sr-only" htmlFor="directory-suburb">Filter by suburb</label>
-              <select
-                id="directory-suburb"
-                value={suburb}
-                onChange={(e) => {
-                  setSuburb(e.target.value);
-                  updateUrl(1, q, e.target.value, category);
-                }}
-                className="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-black text-black appearance-none cursor-pointer"
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                className="btn btn-primary flex-1 lg:flex-initial rounded-xl py-3 px-6 text-xs font-bold uppercase tracking-wider bg-black text-white hover:bg-slate-800 transition-all shadow-md active:scale-95"
               >
-                <option value="">All Suburbs</option>
-                {suburbs.map((s) => (
-                  <option key={s.slug} value={s.slug}>{s.name}</option>
-                ))}
-              </select>
-            </div>
+                Filter
+              </button>
 
-            <button
-              type="submit"
-              className="bg-black text-white px-6 py-3 rounded-lg font-semibold hover:bg-slate-800 transition-colors"
-            >
-              Filter
-            </button>
+              {activeFiltersCount > 0 && (
+                <button
+                  type="button"
+                  onClick={clearAllFilters}
+                  className="btn btn-outline rounded-xl p-3 border-slate-200 text-slate-600 hover:bg-slate-100 transition-all"
+                  title="Clear all filters"
+                  aria-label="Clear all filters"
+                >
+                  <X size={18} />
+                </button>
+              )}
+            </div>
           </form>
+
+          <p className="sr-only" role="status" aria-live="polite">
+            {isPending ? "Loading matching businesses…" : "Directory results are ready."}
+          </p>
+
+          {/* Active Filter Pills */}
+          {activeFiltersCount > 0 && (
+            <div className="flex flex-wrap items-center gap-2 mt-4 pt-3 border-t border-slate-100 text-xs">
+              <span className="font-bold text-slate-500 uppercase tracking-wider text-[10px]">Active Filters:</span>
+              {q && (
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-slate-100 font-semibold text-slate-800 border border-slate-200">
+                  Search: &quot;{q}&quot;
+                  <button onClick={() => { setQ(""); updateUrl(1, "", suburb, category); }} aria-label="Remove search query filter"><X size={12} className="hover:text-black" /></button>
+                </span>
+              )}
+              {category && (
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-slate-100 font-semibold text-slate-800 border border-slate-200">
+                  Category: {categories.find((c) => c.slug === category)?.name || category}
+                  <button onClick={() => { setCategory(""); updateUrl(1, q, suburb, ""); }} aria-label="Remove category filter"><X size={12} className="hover:text-black" /></button>
+                </span>
+              )}
+              {suburb && (
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-slate-100 font-semibold text-slate-800 border border-slate-200">
+                  Suburb: {suburbs.find((s) => s.slug === suburb)?.name || suburb}
+                  <button onClick={() => { setSuburb(""); updateUrl(1, q, "", category); }} aria-label="Remove suburb filter"><X size={12} className="hover:text-black" /></button>
+                </span>
+              )}
+              <button
+                onClick={clearAllFilters}
+                className="text-xs font-bold text-slate-500 hover:text-black underline ml-2 transition-colors"
+              >
+                Clear all
+              </button>
+            </div>
+          )}
         </div>
 
+        {/* ── Business Listings ─────────────────────────────── */}
         {vendors.length === 0 ? (
-          <div className="text-center py-20 px-6 bg-white border rounded-2xl max-w-xl mx-auto shadow-sm">
-            <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-6">
-              <Filter className="text-slate-400" size={30} aria-hidden="true" />
+          <div className="text-center py-20 px-6 bg-white border border-slate-200 rounded-3xl max-w-lg mx-auto shadow-sm">
+            <div className="w-16 h-16 bg-slate-100 rounded-2xl flex items-center justify-center mx-auto mb-6 text-slate-400">
+              <Filter size={28} aria-hidden="true" />
             </div>
-            <h3 className="text-2xl font-black tracking-tight mb-3">No Businesses Found</h3>
-            <p className="text-slate-600 mb-8 max-w-sm mx-auto leading-relaxed">
-              We couldn&apos;t find any listings matching your filters. Try adjusting your search criteria.
+            <h2 className="text-2xl font-black tracking-tight mb-2">No Businesses Found</h2>
+            <p className="text-slate-600 text-sm mb-6 max-w-sm mx-auto leading-relaxed">
+              We couldn&apos;t find any local listings matching your selected search criteria.
             </p>
-            <button
-              onClick={() => {
-                setQ("");
-                setSuburb("");
-                setCategory("");
-                updateUrl(1, "", "", "");
-              }}
-              className="btn btn-primary"
-            >
-              Clear Filters
+            <button onClick={clearAllFilters} className="btn btn-primary rounded-xl px-6 py-3">
+              Clear All Filters
             </button>
           </div>
         ) : (
-          <div className="grid gap-6">
+          <div
+            className={
+              viewMode === "grid"
+                ? "grid md:grid-cols-2 lg:grid-cols-3 gap-5"
+                : "flex flex-col gap-3"
+            }
+          >
             {vendors.map((vendor) => {
-              const subName = suburbs.find(s => s.slug === vendor.suburb_slug)?.name || vendor.suburb_slug;
-              const catName = categories.find(c => c.slug === vendor.category_slug)?.name || vendor.category_slug;
+              const subName = suburbs.find((s) => s.slug === vendor.suburb_slug)?.name || vendor.suburb_slug;
+              const catName = categories.find((c) => c.slug === vendor.category_slug)?.name || vendor.category_slug;
+              const isExpanded = expandedVendorId === vendor.id;
 
               return (
                 <article
                   key={vendor.id}
-                  className="card relative overflow-hidden transition-all duration-300 bg-white p-6 rounded-xl border border-slate-200 shadow-sm hover:shadow-md hover:border-slate-300"
+                  className="group bg-white rounded-2xl border border-slate-200/90 shadow-sm hover:shadow-xl hover:border-slate-400/80 transition-all duration-300 overflow-hidden flex flex-col justify-between"
                 >
-
-                  <div className="flex flex-col md:flex-row md:items-start justify-between gap-6">
-                    <div className="flex-1">
-                      <div className="flex flex-wrap items-center gap-3 mb-3">
-                        <h3 className="text-2xl font-black tracking-tight text-black">
-                          {vendor.business_name}
-                        </h3>
-                        <span className="text-xs font-semibold px-2 py-1 bg-slate-100 rounded text-slate-600">
-                          {catName}
-                        </span>
-                      </div>
-
-                      <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-500 uppercase tracking-wider mb-4">
-                        <MapPin size={14} className="text-slate-400" aria-hidden="true" />
-                        <span>{vendor.street_address ? `${vendor.street_address} • ` : ''}Servicing {subName}</span>
-                      </div>
-
-                      <p className="text-slate-600 text-sm leading-relaxed max-w-3xl">
-                        {vendor.description || ((vendor.phone || vendor.website || vendor.contact_email) 
-                          ? `No description provided. Contact ${vendor.business_name} directly using the details below.` 
-                          : 'Contact details are not yet available.')}
-                      </p>
+                  {/* Card Header & Compact Info */}
+                  <div className="p-5 sm:p-6 flex-1">
+                    <div className="flex items-start justify-between gap-3 mb-2">
+                      <h2 className="text-lg sm:text-xl font-black tracking-tight text-slate-900 group-hover:text-black transition-colors leading-snug">
+                        {vendor.business_name}
+                      </h2>
+                      <span className="shrink-0 text-[10px] font-bold uppercase tracking-wider px-2.5 py-1 bg-slate-100 rounded-full text-slate-700 border border-slate-200">
+                        {catName}
+                      </span>
                     </div>
 
-                    <div className="flex flex-wrap md:flex-col gap-2 min-w-[200px] w-full md:w-auto pt-4 md:pt-0 border-t md:border-t-0 md:border-l border-slate-100 md:pl-6">
+                    <div className="flex items-center gap-1.5 text-xs font-semibold text-slate-500 mb-4">
+                      <MapPin size={14} className="text-slate-400 shrink-0" aria-hidden="true" />
+                      <span className="truncate">
+                        {vendor.street_address ? `${vendor.street_address} • ` : ""}Servicing {subName}
+                      </span>
+                    </div>
+
+                    {/* Expandable Details Accordion */}
+                    <AnimatePresence>
+                      {isExpanded && (
+                        <motion.div
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: "auto" }}
+                          exit={{ opacity: 0, height: 0 }}
+                          transition={{ duration: 0.25, ease: "easeInOut" }}
+                          className="overflow-hidden border-t border-slate-100 pt-4 mt-2 space-y-3 text-xs text-slate-600 leading-relaxed"
+                        >
+                          <p className="line-clamp-4">
+                            {vendor.description ||
+                              `No description provided. Contact ${vendor.business_name} directly using the details below.`}
+                          </p>
+
+                          {vendor.contact_email && (
+                            <div className="flex items-center gap-2 font-medium text-slate-800">
+                              <Mail size={13} className="text-slate-400" />
+                              <a href={`mailto:${vendor.contact_email}`} className="hover:underline truncate">
+                                {vendor.contact_email}
+                              </a>
+                            </div>
+                          )}
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
+
+                  {/* Card Footer Actions */}
+                  <div className="p-4 sm:px-6 sm:pb-5 bg-slate-50/60 border-t border-slate-100 flex flex-wrap items-center justify-between gap-2 text-xs">
+                    {/* Expand / Collapse Button */}
+                    <button
+                      type="button"
+                      onClick={() => toggleExpand(vendor.id)}
+                      className="flex items-center gap-1.5 font-bold text-slate-600 hover:text-black transition-colors py-1 px-2 rounded-lg hover:bg-slate-200/60"
+                      aria-expanded={isExpanded}
+                      aria-label={`${isExpanded ? "Hide details" : "Show quick details"} for ${vendor.business_name}`}
+                    >
+                      <span>{isExpanded ? "Hide Details" : "Quick Info"}</span>
+                      {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                    </button>
+
+                    {/* Quick Action Buttons */}
+                    <div className="flex items-center gap-2">
                       {vendor.phone && (
                         <a
                           href={`tel:${vendor.phone}`}
-                          className="btn btn-primary w-full flex items-center justify-center gap-2 bg-black text-white hover:bg-slate-800 rounded px-4 py-2 font-medium"
-                          aria-label={`Call ${vendor.business_name} at ${vendor.phone}`}
+                          className="btn btn-primary rounded-xl px-3 py-1.5 text-[11px] font-bold flex items-center gap-1.5 bg-black text-white hover:bg-slate-800 transition-all active:scale-95 shadow-sm"
+                          aria-label={`Call ${vendor.business_name}`}
                         >
-                          <Phone size={16} aria-hidden="true" />
-                          <span>Call Direct</span>
+                          <Phone size={13} />
+                          <span className="hidden sm:inline">Call</span>
                         </a>
                       )}
-                      
+
                       {vendor.website && (
                         <a
                           href={vendor.website}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="btn btn-outline w-full flex items-center justify-center gap-2 border border-slate-200 text-slate-700 hover:bg-slate-50 rounded px-4 py-2 font-medium"
+                          className="btn btn-outline rounded-xl px-3 py-1.5 text-[11px] font-bold flex items-center gap-1 border-slate-200 text-slate-700 hover:bg-slate-100 transition-all active:scale-95"
                           aria-label={`Visit ${vendor.business_name} website`}
                         >
-                          <Globe size={16} aria-hidden="true" />
-                          <span>Website</span>
-                          <ExternalLink size={12} className="opacity-60" aria-hidden="true" />
+                          <Globe size={13} />
+                          <ExternalLink size={11} className="opacity-60" />
                         </a>
                       )}
 
                       <Link
                         href={`/vendor/${vendor.slug}`}
-                        className="btn w-full flex items-center justify-center gap-2 bg-slate-50 hover:bg-slate-100 text-slate-700 border border-slate-200 rounded px-4 py-2 font-medium"
-                        aria-label={`View profile for ${vendor.business_name}`}
+                        className="btn rounded-xl px-3.5 py-1.5 text-[11px] font-bold flex items-center gap-1.5 bg-slate-100 hover:bg-black hover:text-white text-slate-800 border border-slate-200/80 transition-all active:scale-95"
+                        aria-label={`View full profile for ${vendor.business_name}`}
                       >
-                        <Star size={16} aria-hidden="true" />
-                        <span>View Profile</span>
+                        <Building2 size={13} />
+                        <span>Profile</span>
                       </Link>
-
-                      {vendor.contact_email && (
-                        <a
-                          href={`mailto:${vendor.contact_email}`}
-                          className="btn w-full flex items-center justify-center gap-2 text-slate-600 hover:text-black font-medium py-2"
-                          aria-label={`Email ${vendor.business_name}`}
-                        >
-                          <Mail size={16} aria-hidden="true" />
-                          <span>Send Email</span>
-                        </a>
-                      )}
                     </div>
                   </div>
                 </article>
@@ -253,28 +422,29 @@ export function DirectoryBrowseClient({
           </div>
         )}
 
+        {/* ── Pagination ───────────────────────────────────── */}
         {totalPages > 1 && (
-          <div className="mt-12 flex items-center justify-center gap-2">
+          <div className="mt-14 flex items-center justify-center gap-3">
             <button
               disabled={currentPage <= 1}
               onClick={() => updateUrl(currentPage - 1, q, suburb, category)}
-              className="p-2 border border-slate-200 rounded text-slate-600 hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="p-3 border border-slate-200 rounded-xl bg-white text-slate-700 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
               aria-label="Previous page"
             >
-              <ChevronLeft size={20} />
+              <ChevronLeft size={18} />
             </button>
-            
-            <span className="px-4 text-sm font-medium text-slate-600">
+
+            <span className="px-4 py-2 text-xs font-bold text-slate-700 bg-white border border-slate-200 rounded-xl shadow-sm">
               Page {currentPage} of {totalPages}
             </span>
 
             <button
               disabled={currentPage >= totalPages}
               onClick={() => updateUrl(currentPage + 1, q, suburb, category)}
-              className="p-2 border border-slate-200 rounded text-slate-600 hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="p-3 border border-slate-200 rounded-xl bg-white text-slate-700 hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm transition-all active:scale-95"
               aria-label="Next page"
             >
-              <ChevronRight size={20} />
+              <ChevronRight size={18} />
             </button>
           </div>
         )}


### PR DESCRIPTION
## Summary
- make the public directory compact and scannable, with optional Quick Info and grid/list views
- preserve search, category and suburb filters with clearer active state and accessible pending feedback
- parallelise independent public reads; keep exact count pagination and correct out-of-range handling
- fetch vendor media concurrently with its public profile

## Boundaries
- no migration, schema, policy, or public-read access change
- no data, deployment, or HANDOVER current-state claim
- listing wording remains neutral: being listed is not a verification claim

## Verification
- `npm run check`
- `web: npm run lint && npm run build && npm run cf:build`
- read-only `node scripts/production-smoke.mjs`
- local in-app-browser: grid/list toggle, Quick Info accordion, accessible status, and keyword filtering (`?q=15+lbs`)