### PR TITLE
Define controlled technical acceptance

### DIFF
--- a/docs/OPS/PUBLIC_RELEASE_ACCEPTANCE.md
+++ b/docs/OPS/PUBLIC_RELEASE_ACCEPTANCE.md
@@ -2,16 +2,22 @@
 
 The owner authorised the first public release on 23 July 2026. This register preserves the evidence still required after release and the rollback rule: a material public safety, privacy, integrity or route failure means deliberately disable the public-launch gate and record why.
 
-## How to finish the remaining authenticated proof
+## Technical completion evidence
 
-Use real activity only. Do not create fake production businesses, claims, ABNs, images or contact requests merely to satisfy this checklist. Record the time, route and plain-English result in the relevant Linear issue after each walkthrough.
+D-017 governs this register. Technical completion does not wait for ordinary production activity. Prove every required journey in controlled local or disposable non-production acceptance with clearly synthetic data, test identities/inboxes and mocked provider outcomes where needed. A permanent staging system is not required.
 
-1. **Account access:** On the Mac browser, open `/login` and sign in with the approved address and password. When the email-code fallback needs verification, request the newest eight-digit code, read it on the phone, then type it into the Mac browser. Confirm the intended private page opens. Do not click an email link or request repeated codes while rate-limited.
-2. **Owner and submitter paths:** Complete the claim, profile-change, missing-business and request-status journeys only when there is a real owner or community submission to use. Confirm that each stays private or pending until the stated operator decision.
-3. **Operator ABN and media:** In `/ops`, use only a real listing with operator-held ABN evidence and an actual owner-authorised image. Check that ABN information stays private and media remains private until the operator decision.
-4. **Status email and failure:** Use an actual permitted decision, not a fabricated request. Confirm the in-product status first. Then record one genuine delivery result and one safe, deliberate provider-failure result without enabling retries, bulk sends, marketing or a general inbox.
+For each journey, record the environment, route, action, visible status or alert, resulting private/public state, relevant audit outcome, success branch, validation/failure branch, recovery path, authorisation boundary and reset/teardown result in Linear. A test form submission alone is not acceptance.
 
-The automated checks already prove code and security boundaries. These walkthroughs prove that a person can complete the real service safely; they remain outstanding until recorded.
+Production verification is deliberately non-mutating: verify real public routes, metadata, sitemap, redirects, access control and relevant live integrations. Do not create fabricated durable production businesses, claims, ABNs, images, contacts, accounts or audit events. Genuine customer activity is useful post-release operational observation, not a release-blocking prerequisite.
+
+### Required controlled acceptance coverage
+
+1. **Account access:** password sign-in, reset, valid/expired/superseded/reused email-code handling and safe recovery.
+2. **Owner and submitter paths:** claim, profile change, owner-submitted candidate, community submission, private status, duplicate handling, moderation and withdrawal where supported.
+3. **Contact and correction:** valid request, unavailable/failed human verification, private intake, safe Ops handling and no automatic public mutation.
+4. **Operator and evidence:** authorised and unauthorised boundaries, listing/claim/profile/contact decisions, candidate exception, ABN provider outcomes and moderated media lifecycle.
+5. **Communications:** permitted in-product status, allowed delivery, controlled delivery failure and retained user fallback—without a general sender, retries or marketing.
+6. **Public routes:** desktop and narrow-mobile browser acceptance for home, directory, taxonomy, profile, contact, privacy, account and protected-route denial, plus metadata/canonical/sitemap evidence.
 
 ## 1. Operator review
 
@@ -43,7 +49,7 @@ Maintain the following release checks and record any failure:
 
 ## 5. Release evidence and rollback
 
-- The release decision is recorded in D-011 and Linear `SUB-14`.
+- The release decision is recorded in D-011; technical completion evidence is governed by D-017 and Linear `SUB-14`.
 - The public launch gate is enabled.
 - Home, browse, one taxonomy page, one vendor profile and the sitemap were verified at first release; repeat this check after material public-route changes.
 - If any acceptance item fails, disable the public launch gate and record why. Do not work around a failure by publishing more listings.

--- a/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
+++ b/docs/REFERENCE/SuburbMates — Complete User Journey Map.md
@@ -4,7 +4,7 @@
 
 This is the owner-readable map of the finished SuburbMates experience. It starts with a person arriving at the home page and follows each person or system until its intent is complete. It covers the visible journey, the private work behind it, the background processes and the evidence Ops needs to safely operate the service.
 
-It is the product-flow companion to the Target State and Operating Authority. It does not replace the detailed Operations Specification or the [Automation workflow map](../AUTOMATION/WORKFLOWS.md). The public directory was authorised and released on 23 July 2026; where this map describes a flow that has not yet been proved through a real authenticated walkthrough, it remains a completion requirement rather than a claim of acceptance.
+It is the product-flow companion to the Target State and Operating Authority. It does not replace the detailed Operations Specification or the [Automation workflow map](../AUTOMATION/WORKFLOWS.md). The public directory was authorised and released on 23 July 2026. A flow not yet observed with a real person remains a post-release operational observation, not an unfinished technical requirement, once its controlled acceptance evidence is complete under D-017.
 
 ## The people and systems served
 
@@ -150,7 +150,7 @@ This is a first-class service journey, not a background detail of claims or form
 
 ### Current release posture
 
-Password sign-in is the normal path for existing authorised accounts. A person can set or reset a 12+ character password through their email. An eight-digit email code from `auth@suburbmates.com.au` remains an accessible fallback and may be entered in the browser being used. Approved status messages are limited to the defined claim, profile-change, submission and request-outcome paths; their real delivery and failure walkthroughs remain outstanding. There is no public support inbox, marketing mail, bulk notification system or automatic retry loop.
+Password sign-in is the normal path for existing authorised accounts. A person can set or reset a 12+ character password through their email. An eight-digit email code from `auth@suburbmates.com.au` remains an accessible fallback and may be entered in the browser being used. Approved status messages are limited to the defined claim, profile-change, submission and request-outcome paths; their success and failure branches require controlled non-production acceptance under D-017. There is no public support inbox, marketing mail, bulk notification system or automatic retry loop.
 
 ### Communications controls after release
 
@@ -355,16 +355,16 @@ This section is the practical "do this, see this" companion to the journeys abov
 
 ### Acceptance evidence for every run
 
-Record the route, button pressed, exact status or alert text, resulting private/public state, and the related Ops/audit outcome. A journey is accepted only when the original user intent succeeds safely. A form submission alone is not acceptance.
+Record the environment, route, button pressed, exact status or alert text, resulting private/public state, and the related Ops/audit outcome. A journey is accepted only when the original user intent succeeds safely. A form submission alone is not acceptance. Use controlled local or disposable non-production data for technical acceptance; record genuine production use separately as later operational observation.
 
 ## Build sequencing implied by this map
 
 1. Approve this map and reconcile it with the Target State, Operations Specification and current implementation.
 2. Maintain the released public directory discovery and profile journey with route, data and SEO checks.
-3. Complete recorded real-world account-access and approved-message delivery/failure evidence.
-4. Complete recorded owner, submitter and moderated profile-change walkthroughs.
-5. Complete recorded protected missing-business, concern-report and Ops walkthroughs.
+3. Complete automated and controlled end-to-end account-access and approved-message delivery/failure evidence.
+4. Complete automated and controlled owner, submitter and moderated profile-change acceptance.
+5. Complete automated and controlled missing-business, concern-report and Ops acceptance.
 6. Prove the audited candidate-to-Ops qualification handoff under a full approved-source run in `SUB-6`.
-7. Maintain end-to-end evidence: browser behaviour, database records, authorisation, background evidence and Ops observability.
+7. Maintain end-to-end evidence: browser behaviour, database records, authorisation, background evidence and Ops observability. Treat later genuine customer activity as operational observation, not a release blocker.
 
 Monetisation is intentionally absent from this sequence until a separate paid offer is approved.

--- a/docs/REFERENCE/SuburbMates — Decision Log.md
+++ b/docs/REFERENCE/SuburbMates — Decision Log.md
@@ -150,12 +150,22 @@ No branch, pull request, automation run or lane handover changes product policy 
 - **Status rule:** Use only `local only`, `in review`, `merged`, `deployed—verification pending`, or `live verified`. A missing deployment or live proof is a stated blocker; it is never silently handed back to the owner.
 - **Guardrail:** This rule does not authorise an unapproved product, database, security or commercial change. It completes the normal delivery of an already owner-authorised deployable change.
 
+### D-017 — Technical completion uses controlled non-production evidence
+
+- **Date:** 9 August 2026
+- **Decision:** SuburbMates may be declared technically complete without waiting for ordinary businesses or community members to create production cases. Required journey acceptance is proved with automated fixtures and controlled end-to-end testing in a local or disposable non-production environment; it does not require a permanent staging system.
+- **Production rule:** Production acceptance is non-mutating: verify public routes, access control, metadata, sitemap, deployment and relevant integrations against real production data. Never create fabricated durable businesses, claims, contact requests, ABN records, media, accounts or audit events in production merely to satisfy acceptance.
+- **Controlled-test rule:** Synthetic data must be clearly identified, isolated from production, covered by reset or teardown, and use test identities, inboxes and provider stubs where needed. It must prove the intended success, validation/error, recovery, permission and private/public-data boundaries for each journey.
+- **Completion rule:** Technical completion requires automated and controlled end-to-end evidence for every required journey and failure branch, production smoke evidence, no unresolved critical or high-severity defect, and recorded results in the relevant Linear work. Genuine customer activity remains valuable post-release operational validation; it is not a release-blocking prerequisite.
+- **Guardrail:** This does not relax any product boundary. Claims, submissions, ABN evidence, media, communications, publication, audit and retention rules must behave identically in the controlled environment; Stripe, general email, AI publication, bulk ABN work and automated media processing remain disabled.
+- **Required alignment:** `SUB-14`, the Journey Map, the post-release acceptance register and execution protocol must distinguish technical completion from later real-world observation.
+
 ## Open deviations to track
 
 | Deviation | Current truth | Required resolution |
 | --- | --- | --- |
 | Publication policy | New approved-source candidates that pass deterministic qualification become unclaimed public listings with retained evidence. The existing catalogue's 982 `existing-catalogue-v2` exceptions remain a private remediation record; no retrospective visibility decision has been recorded. | Keep new-candidate controls operational and record a separate decision before changing visibility of existing listings. |
 | Public product | Public directory release is live with a populated sitemap and indexable released routes. | Maintain production route checks and correct any observed public-data or SEO defect. |
-| Owner and public input | A real owner submission and claim are approved and recorded. Profile correction, community submission and contact/correction still lack real outcome evidence. | Record those outcomes when genuine cases arise; do not fabricate durable production records. |
+| Owner and public input | A real owner submission and claim are approved and recorded. Profile correction, community submission and contact/correction still lack real outcome evidence. | Prove these flows in controlled non-production acceptance; record genuine cases later as operational observation, without fabricating durable production records. |
 | Monetisation | Stripe is disabled. | Leave disabled until separately approved commercial scope exists. |
 | Automation record | Automation safety controls exist but documentation and issue records need current-state reconciliation. | Maintain evidence, exception handling and current documentation as workflows are hardened. |

--- a/docs/REFERENCE/SuburbMates — Execution Governance and Readiness Protocol.md
+++ b/docs/REFERENCE/SuburbMates — Execution Governance and Readiness Protocol.md
@@ -113,6 +113,12 @@ Use **Verify and Repair: [user] → [intended outcome]** for any journey that a 
 
 The standard applies equally to a completed journey and a safe, honest unavailable state. A form submission alone is never acceptance.
 
+## 5b. Technical completion and post-release observation
+
+D-017 distinguishes technical completion from real-world observation. Required journey acceptance may use automated fixtures and controlled local or disposable non-production end-to-end testing; it does not require a permanent staging system or ordinary production cases. Prove success, validation/failure, recovery, authorisation and private/public-data boundaries, then record the result in Linear.
+
+Production verification remains non-mutating unless a separately authorised operational action is required. Never fabricate durable production records to close acceptance. A genuine customer case after release is valuable operational observation and may reveal a repair task, but it is not a prerequisite to declare the implemented product technically complete.
+
 ## 6. Deviation and stop rules
 
 | Finding | Required action |

--- a/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
+++ b/docs/REFERENCE/SuburbMates — Target State and Operating Authority.md
@@ -28,7 +28,7 @@ The finished public directory helps residents find useful local businesses. Busi
 
 On 23 July 2026, the owner explicitly authorised the first public release. The production public-launch gate is enabled: the directory, public profiles and eligible taxonomy routes are available; the sitemap is populated; and released pages are indexable. `www` redirects to the canonical apex domain.
 
-This release changes neither the listing lifecycle nor the operating safeguards. Only published listings appear publicly; `/ops` remains protected; candidates, claims, profile proposals, ABN evidence and owner media remain moderated workflows. The remaining authenticated walkthrough evidence is recorded as post-release acceptance work, not as permission to weaken those controls.
+This release changes neither the listing lifecycle nor the operating safeguards. Only published listings appear publicly; `/ops` remains protected; candidates, claims, profile proposals, ABN evidence and owner media remain moderated workflows. Technical acceptance uses automated and controlled non-production end-to-end evidence; genuine customer activity is later post-release operational validation, not permission to weaken those controls or a prerequisite for technical completion.
 
 ## Directory publication policy
 
@@ -120,7 +120,8 @@ The first public directory release has passed. Before any future release-affecti
 3. source, duplicate, safety and publication safeguards are tested and auditable;
 4. owner claim and proposed-edit workflows are authenticated and moderated;
 5. public pages, metadata, sitemap and no-index rules match the active release posture; and
-6. production, database and relevant integrations are verified after deployment.
+6. production, database and relevant integrations are verified after deployment; and
+7. technical journey acceptance is evidenced through automated fixtures and a controlled local or disposable non-production environment. Do not create fabricated durable production records to satisfy it.
 
 ## Operating workflow
 


### PR DESCRIPTION
## Authority change

Records D-017: technical completion is proved with automated fixtures and controlled local or disposable non-production end-to-end acceptance; real customer activity becomes post-release operational observation.

## Preserved boundaries

- no fabricated durable production records
- no permanent staging system required
- production verification remains non-mutating
- no change to payment, publication, ownership, ABN, media or communications policy

## Verification

- `git diff --check`
- `npm run resident-journey:test`